### PR TITLE
Fix s3 filename routing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  trailingSlash: true,
+};


### PR DESCRIPTION
Dette gjør at next.js genererer filene som `news/article1/index.html` istedet for `news/article1.html` da skal routing fungere