### PR TITLE
Fjerne feilmelding i logg

### DIFF
--- a/apps/skde/src/charts/barcharts/index.tsx
+++ b/apps/skde/src/charts/barcharts/index.tsx
@@ -194,7 +194,7 @@ export const Barchart = <
               fontSize: 14,
               x: -127,
               y: -15,
-              transform: "(rotateX(90deg))",
+              transform: "",
               fontWeight: "bold",
             }}
           />


### PR DESCRIPTION
Fjernet hele (rotateX(90deg)) i transform: ... Dette får feilmeldingen til å forsvinne, og figuren (stolpediagrammet) har fremdeles Opptaksområde riktig vei

Closes #406 
