### PR TITLE
fix(toc): check for if type is number given that first entry has index 0

### DIFF
--- a/apps/skde/src/components/TableOfContents/ListItem.tsx
+++ b/apps/skde/src/components/TableOfContents/ListItem.tsx
@@ -55,7 +55,7 @@ export const ListItem: React.FC<ListItemProps> = ({
       <a
         {...ATag[0]}
         onClick={() => {
-          if (i) {
+          if (typeof i === "number" || i) {
             setExpanded((state) => {
               return state === i ? "none" : i;
             });


### PR DESCRIPTION
First entry in a table of contents has index 0.
Thus should check for where i is a number or defined.

closes #615 