### PR TITLE
api: use user defined port for db if needed

### DIFF
--- a/apps/api/src/knexfile.ts
+++ b/apps/api/src/knexfile.ts
@@ -13,6 +13,7 @@ const connections: { [env: string]: Knex.Config } = {
     client: "mysql",
     connection: {
       host: "127.0.0.1",
+      port: Number(process.env.DB_PORT) ?? 3306,
       user: "imongr",
       password: "imongr",
       database: "imongr",


### PR DESCRIPTION
Will make it possible to use the app together with imongr. imongr docker-compose will expose port 3331-3333 to db