### PR TITLE
Ingress i egen komponent

### DIFF
--- a/apps/skde/_posts/helseatlas/statisk/nyfodt_bo.md
+++ b/apps/skde/_posts/helseatlas/statisk/nyfodt_bo.md
@@ -2,11 +2,8 @@
 filename: nyfodt_bo
 title: Boområder for nyfødtmedisinatlaset
 lang: nb
+ingress: Nedenfor finner du beskrivelse av hvilke kommuner som hører inn under de ulike boområdene/opptaksområdene som nyfødtmedisinatlaset tar utgangspunkt i.
 ---
-
-<div className="ingress">
-Nedenfor finner du beskrivelse av hvilke kommuner som hører inn under de ulike boområdene/opptaksområdene som nyfødtmedisinatlaset tar utgangspunkt i.
-</div>
 
 Befolkningsområder/boområder er definert kommunevis (bydeler/postnummer for OUS og Akershus) på grunnlag av mors adresse og helseforetakenes nedslagsfelt eller ansvarsområde/opptaksområde. Boområder er i denne sammenheng det samme som forstås som opptaksområder for helseforetak eller sykehus. Det vil si området hvor foretaket eller sykehuset har øyeblikkelig-hjelp ansvar for innbyggerne.
 

--- a/apps/skde/src/components/Atlas/v2/index.tsx
+++ b/apps/skde/src/components/Atlas/v2/index.tsx
@@ -7,6 +7,7 @@ import { TableOfContents } from "../../TableOfContents";
 import { OrderedList } from "../../TableOfContents/OrderedList";
 import { ListItem } from "../../TableOfContents/ListItem";
 import { DataContext } from "../../Context";
+import { Ingress } from "../../Ingress";
 
 export interface AtlasPageProps {
   content: string;
@@ -80,7 +81,7 @@ const AtlasPage: React.FC<AtlasPageProps> = ({
             </TableOfContents>
             <div className={styles.main_content}>
               <h1>{obj.mainTitle}</h1>
-              <div className="ingress">{obj.ingress}</div>
+              <Ingress>{obj.ingress}</Ingress>
               <Chapters innhold={obj.kapittel} lang={obj.lang} />
             </div>
           </div>

--- a/apps/skde/src/components/Ingress/Ingress.module.css
+++ b/apps/skde/src/components/Ingress/Ingress.module.css
@@ -1,0 +1,5 @@
+.ingress {
+  font-size: 20px;
+  line-height: 30px;
+  color: #000000;
+}

--- a/apps/skde/src/components/Ingress/index.tsx
+++ b/apps/skde/src/components/Ingress/index.tsx
@@ -1,0 +1,14 @@
+import styles from "./Ingress.module.css";
+import { Markdown } from "../Markdown";
+
+type IngressProp = {
+  children: string;
+};
+
+export const Ingress = ({ children }: IngressProp) => {
+  return (
+    <div className={styles.ingress}>
+      <Markdown>{children}</Markdown>
+    </div>
+  );
+};

--- a/apps/skde/src/components/Static/index.tsx
+++ b/apps/skde/src/components/Static/index.tsx
@@ -1,4 +1,5 @@
 import { Markdown } from "../Markdown";
+import { Ingress } from "../Ingress";
 import { AtlasLayout } from "../Layout";
 import styles from "./Static.module.css";
 
@@ -7,6 +8,7 @@ export interface PageContentProps {
   frontMatter: {
     title: string;
     lang: "nb" | "en" | "nn";
+    ingress?: string;
   };
 }
 
@@ -23,6 +25,7 @@ export const PageContent: React.FC<PageContentProps> = ({
           </div>
           <div className={styles.article}>
             <div className={styles.article__content}>
+              {frontMatter.ingress && <Ingress>{frontMatter.ingress}</Ingress>}
               <Markdown lang={frontMatter.lang}>{content}</Markdown>
             </div>
           </div>

--- a/apps/skde/src/styles/globals.css
+++ b/apps/skde/src/styles/globals.css
@@ -49,12 +49,6 @@ li.MuiBreadcrumbs-li:last-child {
   font-weight: 700;
 }
 
-.ingress {
-  font-size: 20px;
-  line-height: 30px;
-  color: #000000;
-  padding-bottom: 1rem;
-}
 @media screen and (min-width: 0) and (max-width: 942px) {
   .main-content {
     max-width: 95%;


### PR DESCRIPTION
Kan brukes på alle sidene og man får flyttet css ut av global.css. Kjører gjennom markdown.
Closes #637