### PR TITLE
Fjern mellomrom etter lenke i markdown

### DIFF
--- a/apps/skde/src/components/Markdown/index.tsx
+++ b/apps/skde/src/components/Markdown/index.tsx
@@ -92,8 +92,7 @@ export const Markdown = ({ children, lang }: MarkdownProp) => {
     a({ href, children }) {
       return (
         <a href={href} target="_blank" rel="noreferrer">
-          {" "}
-          {children}{" "}
+          {children}
         </a>
       );
     },


### PR DESCRIPTION
Litt usikker på hvorfor den havnet der...