### PR TITLE
Bruk 'level' i indikatordata, hvis den eksisterer

### DIFF
--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -68,3 +68,12 @@ test("Use level_green for level_yellow if level_yellow is null", () => {
   indicator.level_yellow = null;
   expect(level(indicator)).toBe("L");
 });
+
+test("Use level if it exists", () => {
+  indicator.level = "H";
+  expect(level(indicator)).toBe("H");
+  indicator.level = "M";
+  expect(level(indicator)).toBe("M");
+  indicator.level = "L";
+  expect(level(indicator)).toBe("L");
+});

--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -80,4 +80,8 @@ test("Use level if it exists", () => {
   expect(level(indicator)).toBe("M");
   indicator.level = "L";
   expect(level(indicator)).toBe("L");
+  indicator.level_green = undefined;
+  indicator.level_yellow = undefined;
+  indicator.level = "H";
+  expect(level(indicator)).toBe("H");
 });

--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -70,6 +70,10 @@ test("Use level_green for level_yellow if level_yellow is null", () => {
 });
 
 test("Use level if it exists", () => {
+  indicator.var = 0.01;
+  indicator.level_direction = 1;
+  indicator.level_green = 0.95;
+  indicator.level_yellow = 0.8;
   indicator.level = "H";
   expect(level(indicator)).toBe("H");
   indicator.level = "M";

--- a/packages/qmongjs/src/helpers/functions/defineLevel.ts
+++ b/packages/qmongjs/src/helpers/functions/defineLevel.ts
@@ -7,7 +7,7 @@ const numWithValidDigits = (value: number, decimals: number) => {
 export const level = (indicatorData: Indicator) => {
   const { level, level_green, level_yellow, level_direction, sformat } =
     indicatorData;
-  if (level != undefined) {
+  if (level !== undefined) {
     return level;
   }
   if (

--- a/packages/qmongjs/src/helpers/functions/defineLevel.ts
+++ b/packages/qmongjs/src/helpers/functions/defineLevel.ts
@@ -5,7 +5,11 @@ const numWithValidDigits = (value: number, decimals: number) => {
 };
 
 export const level = (indicatorData: Indicator) => {
-  const { level_green, level_yellow, level_direction, sformat } = indicatorData;
+  const { level, level_green, level_yellow, level_direction, sformat } =
+    indicatorData;
+  if (level != undefined) {
+    return level;
+  }
   if (
     level_green === undefined ||
     level_green === null ||

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,10 +29,11 @@ export interface Indicator {
   year: number;
   denominator: number;
   var: number;
-  level_direction: number | null;
-  level_green: number | null;
-  level_yellow: number | null;
-  sformat: string | null;
+  level?: null | "H" | "M" | "L" | "";
+  level_direction?: number | null;
+  level_green?: number | null;
+  level_yellow?: number | null;
+  sformat?: string | null;
   dg: number | null;
   delivery_time: Date | null;
   delivery_latest_update?: Date | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -30,7 +30,7 @@ export interface Indicator {
   denominator: number;
   var: number;
   level?: null | "H" | "M" | "L" | "";
-  level_direction?: number | null;
+  level_direction: number | null;
   level_green?: number | null;
   level_yellow?: number | null;
   sformat?: string | null;


### PR DESCRIPTION
App vil da fungere med gammelt API. Vi kan fjerne dette senere, når vi vet at app bruker siste versjon av api.