### PR TITLE
Revert "Bruk 'level' i indikatordata, hvis den eksisterer (#748)"

### DIFF
--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -68,20 +68,3 @@ test("Use level_green for level_yellow if level_yellow is null", () => {
   indicator.level_yellow = null;
   expect(level(indicator)).toBe("L");
 });
-
-test("Use level if it exists", () => {
-  indicator.var = 0.01;
-  indicator.level_direction = 1;
-  indicator.level_green = 0.95;
-  indicator.level_yellow = 0.8;
-  indicator.level = "H";
-  expect(level(indicator)).toBe("H");
-  indicator.level = "M";
-  expect(level(indicator)).toBe("M");
-  indicator.level = "L";
-  expect(level(indicator)).toBe("L");
-  indicator.level_green = undefined;
-  indicator.level_yellow = undefined;
-  indicator.level = "H";
-  expect(level(indicator)).toBe("H");
-});

--- a/packages/qmongjs/src/helpers/functions/defineLevel.ts
+++ b/packages/qmongjs/src/helpers/functions/defineLevel.ts
@@ -5,11 +5,7 @@ const numWithValidDigits = (value: number, decimals: number) => {
 };
 
 export const level = (indicatorData: Indicator) => {
-  const { level, level_green, level_yellow, level_direction, sformat } =
-    indicatorData;
-  if (level !== undefined) {
-    return level;
-  }
+  const { level_green, level_yellow, level_direction, sformat } = indicatorData;
   if (
     level_green === undefined ||
     level_green === null ||

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -29,11 +29,10 @@ export interface Indicator {
   year: number;
   denominator: number;
   var: number;
-  level?: null | "H" | "M" | "L" | "";
   level_direction: number | null;
-  level_green?: number | null;
-  level_yellow?: number | null;
-  sformat?: string | null;
+  level_green: number | null;
+  level_yellow: number | null;
+  sformat: string | null;
   dg: number | null;
   delivery_time: Date | null;
   delivery_latest_update?: Date | null;


### PR DESCRIPTION
This reverts commit 5e907031b40f7bcff5047d803354c22f584c5717.