### PR TITLE
Bruk riktig dato-variabel i teksten sist oppdatert

### DIFF
--- a/packages/qmongjs/src/components/Charts/LineChart/__tests__/index.tsx
+++ b/packages/qmongjs/src/components/Charts/LineChart/__tests__/index.tsx
@@ -90,7 +90,7 @@ test("Render without levels @250px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -111,7 +111,7 @@ test("Render without levels @250px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -132,7 +132,7 @@ test("Render without levels @250px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -153,7 +153,7 @@ test("Render without levels @250px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
       ]}
@@ -200,7 +200,7 @@ test("Render with levels @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -221,7 +221,7 @@ test("Render with levels @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -242,7 +242,7 @@ test("Render with levels @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -263,7 +263,7 @@ test("Render with levels @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
       ]}
@@ -311,7 +311,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -332,7 +332,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -353,7 +353,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -374,7 +374,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -395,7 +395,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -416,7 +416,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -437,7 +437,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
         {
@@ -458,7 +458,7 @@ test("Render with levels reversed @500px", async () => {
           dg: null,
           include: 1,
           type: "andel",
-          delivery_time: new Date("October 13, 2014 11:13:00"),
+          delivery_latest_update: new Date("October 13, 2014 11:13:00"),
           delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
         },
       ]}
@@ -506,7 +506,7 @@ function buildDataPoint(overrides: Partial<DataPoint>): DataPoint {
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
     ...overrides,
   };

--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrow.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrow.tsx
@@ -44,8 +44,11 @@ export function ChartRow(props: Props) {
   const format = description.sformat ?? undefined;
   const max_value = description.max_value ?? undefined;
 
+  // Use delivery_latest_update if it exists. If not, use delivery_time if it exists.
   const delivery_time = indicatorData[0].delivery_latest_update
     ? new Date(indicatorData[0].delivery_latest_update)
+    : indicatorData[0].delivery_time
+    ? new Date(indicatorData[0].delivery_time)
     : undefined;
 
   return (

--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrow.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrow.tsx
@@ -44,8 +44,8 @@ export function ChartRow(props: Props) {
   const format = description.sformat ?? undefined;
   const max_value = description.max_value ?? undefined;
 
-  const delivery_time = indicatorData[0].delivery_time
-    ? new Date(indicatorData[0].delivery_time)
+  const delivery_time = indicatorData[0].delivery_latest_update
+    ? new Date(indicatorData[0].delivery_latest_update)
     : undefined;
 
   return (

--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -17,7 +17,7 @@ const indicator: Indicator = {
   dg: null,
   include: 1,
   type: "a",
-  delivery_time: new Date("October 13, 2014 11:13:00"),
+  delivery_latest_update: new Date("October 13, 2014 11:13:00"),
   delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
 };
 

--- a/packages/qmongjs/src/test/test_data/national_data.ts
+++ b/packages/qmongjs/src/test/test_data/national_data.ts
@@ -17,7 +17,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
   {
@@ -36,7 +36,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
   {
@@ -55,7 +55,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
   {
@@ -74,7 +74,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
   {
@@ -93,7 +93,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
   {
@@ -112,7 +112,7 @@ const national_data: Indicator[] = [
     dg: null,
     include: 1,
     type: "andel",
-    delivery_time: new Date("October 13, 2014 11:13:00"),
+    delivery_latest_update: new Date("October 13, 2014 11:13:00"),
     delivery_latest_affirm: new Date("October 13, 2019 11:13:00"),
   },
 ];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,7 +34,7 @@ export interface Indicator {
   level_yellow: number | null;
   sformat: string | null;
   dg: number | null;
-  delivery_time: Date | null;
+  delivery_time?: Date | null;
   delivery_latest_update?: Date | null;
   delivery_latest_affirm?: Date | null;
   type?: string | null;


### PR DESCRIPTION
Ble tidligere brukt `delivery_time`, som opplaster ikke kunne definere selv. Bruker nå `delivery_latest_update`, som opplaster definerer når hen leverer data.

Closes #824