### PR TITLE
CMS: bedre tekst på publisert-knappen.

### DIFF
--- a/apps/skde/src/components/CMS/config.ts
+++ b/apps/skde/src/components/CMS/config.ts
@@ -37,10 +37,11 @@ const atlas = (lang: "no" | "en"): Collection => {
     fields: [
       filename,
       {
-        label: "Publisert",
+        label: "Publisert på forsiden",
         name: "publisert",
         widget: "boolean",
         default: false,
+        hint: "Atlaset legges på forsiden av skde.no/helseatlas hvis «Publisert på forsiden» er huket av.",
       },
       {
         label: "Publiseringsdato",


### PR DESCRIPTION
Var uklart hva denne gjorde, og den het det samme som lagre-knappen.