### PR TITLE
Farge på lenker i sykehusviser

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrowdescription.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrowdescription.tsx
@@ -34,6 +34,18 @@ const ChartRowDescription = ({
                 p({ children }) {
                   return <p style={{ margin: 0 }}>{children}</p>;
                 },
+                a({ href, children }) {
+                  return (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      style={{ color: "#006492" }}
+                    >
+                      {children}
+                    </a>
+                  );
+                },
               }}
             >
               {description_text}


### PR DESCRIPTION
Gjelder lenker lagt inn i utvidet indikatorbeskrivelse. Brukte samme farge som kvalitetsregistre.no
Brukte kode fra helseatlas, så lenker åpnes i ny fane. Closes #984