### PR TITLE
Droppe next-tanspile-modules

### DIFF
--- a/apps/skde/next.config.js
+++ b/apps/skde/next.config.js
@@ -1,9 +1,8 @@
-const withTM = require("next-transpile-modules")(["qmongjs"]);
-
-module.exports = withTM({
+module.exports = {
   images: {
     loader: "custom",
   },
   trailingSlash: true,
   reactStrictMode: true,
-});
+  transpilePackages: ["qmongjs"],
+};

--- a/apps/skde/package.json
+++ b/apps/skde/package.json
@@ -70,7 +70,6 @@
     "eslint-config-next": "13.3.4",
     "husky": "8.0.3",
     "next-router-mock": "0.9.3",
-    "next-transpile-modules": "10.0.0",
     "prettier": "2.8.8",
     "react-markdown": "8.0.7",
     "react-scripts": "5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15323,15 +15323,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-transpile-modules@npm:10.0.0":
-  version: 10.0.0
-  resolution: "next-transpile-modules@npm:10.0.0"
-  dependencies:
-    enhanced-resolve: ^5.10.0
-  checksum: 3300fc7081f63b2c9487588db7cbe718f209dfd2111adec22d9c8af0e3c8ade2d95fd45f91e045546d78d98cafc78a49431de9a623360d33831b5e694bf007c9
-  languageName: node
-  linkType: hard
-
 "next@npm:13.3.4":
   version: 13.3.4
   resolution: "next@npm:13.3.4"
@@ -19334,7 +19325,6 @@ __metadata:
     next: 13.3.4
     next-query-params: 4.1.0
     next-router-mock: 0.9.3
-    next-transpile-modules: 10.0.0
     prettier: 2.8.8
     qmongjs: "*"
     react: 18.2.0


### PR DESCRIPTION
Fra [Nextjs 13.1](https://nextjs.org/blog/next-13-1#built-in-module-transpilation-stable) er den inkludert i pakken.

```
next-transpile-modules@npm:10.0.0 is deprecated: All features of next-transpile-modules are now natively built-in Next.js 13.1. Please use Next's transpilePackages option :)
```