### PR TITLE
Definer om atlas er nylig publisert basert på dato

### DIFF
--- a/apps/skde/src/components/Atlas/FrontPage/index.tsx
+++ b/apps/skde/src/components/Atlas/FrontPage/index.tsx
@@ -2,7 +2,6 @@ import { AtlasLayout } from "../../Layout";
 import { MainBanner } from "../../MainBanner";
 import { AtlasLink } from "../../Buttons";
 import classNames from "./FrontPage.module.css";
-import { log } from "console";
 
 export interface HomeProps {
   atlasInfo: {
@@ -27,7 +26,6 @@ const FrontPage: React.FC<HomeProps> = ({ atlasInfo, lang }) => {
     .reverse();
 
   const url = lang === "no" ? "helseatlas" : "helseatlas/en";
-
   const Links = sortedAtlas.map((atlas, i) => (
     <AtlasLink
       key={atlas.article}

--- a/apps/skde/src/components/Atlas/FrontPage/index.tsx
+++ b/apps/skde/src/components/Atlas/FrontPage/index.tsx
@@ -2,6 +2,7 @@ import { AtlasLayout } from "../../Layout";
 import { MainBanner } from "../../MainBanner";
 import { AtlasLink } from "../../Buttons";
 import classNames from "./FrontPage.module.css";
+import { log } from "console";
 
 export interface HomeProps {
   atlasInfo: {
@@ -26,6 +27,7 @@ const FrontPage: React.FC<HomeProps> = ({ atlasInfo, lang }) => {
     .reverse();
 
   const url = lang === "no" ? "helseatlas" : "helseatlas/en";
+
   const Links = sortedAtlas.map((atlas, i) => (
     <AtlasLink
       key={atlas.article}
@@ -35,7 +37,6 @@ const FrontPage: React.FC<HomeProps> = ({ atlasInfo, lang }) => {
       linkText={atlas.frontMatter.frontpagetext}
       wide={i === 0}
       date={atlas.frontMatter.date}
-      newlyUpdated={i === 0}
       lang={lang}
     />
   ));

--- a/apps/skde/src/components/Buttons/AtlasLink.tsx
+++ b/apps/skde/src/components/Buttons/AtlasLink.tsx
@@ -12,7 +12,6 @@ interface Props {
   linkText: string;
   wide?: boolean;
   date: Date;
-  newlyUpdated?: boolean;
   lang: "no" | "en";
 }
 
@@ -27,9 +26,12 @@ export const AtlasLink: React.FC<Props> = ({
   wide,
   linkText,
   date,
-  newlyUpdated,
   lang,
 }) => {
+  // Newly updated if there is less than 60 says since atlas was published
+  const newlyUpdated =
+    (new Date().getTime() - new Date(date).getTime()) / (1000 * 60 * 60 * 24) <
+    60;
   return (
     <div
       className={`${classNames.linkOuterWrapper} ${

--- a/apps/skde/src/components/Buttons/__tests__/atlaslink.test.tsx
+++ b/apps/skde/src/components/Buttons/__tests__/atlaslink.test.tsx
@@ -20,7 +20,6 @@ test("Norsk render", async () => {
       wide={false}
       linkText="Lorem lipsum dolor 1"
       date={date1}
-      newlyUpdated={false}
     />
   );
   expect(container).toMatchSnapshot();
@@ -37,7 +36,6 @@ test("English render", async () => {
       wide={false}
       linkText="Lorem lipsum dolor 2"
       date={date1}
-      newlyUpdated={false}
     />
   );
   expect(container).toMatchSnapshot();
@@ -54,7 +52,6 @@ test("Wide is true", async () => {
       wide={true}
       linkText=""
       date={date1}
-      newlyUpdated={false}
     />
   );
   expect(container).toMatchSnapshot();
@@ -62,6 +59,7 @@ test("Wide is true", async () => {
 
 test("newlyUpdated is true", async () => {
   const date1 = new Date("October 13, 2014 11:13:00");
+  jest.useFakeTimers().setSystemTime(new Date("2014-10-10"));
   const { container } = render(
     <AtlasLink
       lang="no"
@@ -71,7 +69,6 @@ test("newlyUpdated is true", async () => {
       wide={false}
       linkText=""
       date={date1}
-      newlyUpdated={true}
     />
   );
   expect(container).toMatchSnapshot();


### PR DESCRIPTION
I dag settes siste atlas til nylig publisert, uavhengig av hvor lenge siden det ble publisert:

![image](https://github.com/mong/mongts/assets/136346/ee1c2c46-3d46-4613-b25b-c04ba43d5a09)

Endret slik at det, etter 60 dager, ser slik ut:

![image](https://github.com/mong/mongts/assets/136346/8476957f-1193-4514-9e57-1f66e66d1e4d)

Kan vurdere om wide også skal droppes?