### PR TITLE
Markdown: Bruk `title` som `alt` hvis `alt` mangler

### DIFF
--- a/apps/skde/src/components/Markdown/__tests__/__snapshots__/markdown.test.tsx.snap
+++ b/apps/skde/src/components/Markdown/__tests__/__snapshots__/markdown.test.tsx.snap
@@ -163,6 +163,40 @@ exports[`Text with image 1`] = `
 </div>
 `;
 
+exports[`Text with image without alt-text 1`] = `
+<div>
+  <p>
+    Dette er en test
+  </p>
+  
+
+  <h1
+    id="hovedoverskrift"
+  >
+    Hovedoverskrift
+  </h1>
+  
+
+  <figure
+    style="width: 90%; display: flex; justify-content: center; align-items: center; flex-direction: column;"
+  >
+    <img
+      alt="Menisk, utvikling i antall inngrep pr. 100 000 innbyggere i perioden 2013–2017, justert for kjønn og alder. Fordelt på opptaksområder og offentlig eller privat behandler."
+      src="https://picsum.photos/id/237/100/100.jpg"
+      style="display: block; margin: auto;"
+      title=""
+    />
+    <figcaption>
+      <strong>
+        Figur:
+      </strong>
+       
+      Menisk, utvikling i antall inngrep pr. 100 000 innbyggere i perioden 2013–2017, justert for kjønn og alder. Fordelt på opptaksområder og offentlig eller privat behandler.
+    </figcaption>
+  </figure>
+</div>
+`;
+
 exports[`Text with image, language english 1`] = `
 <div>
   <p>

--- a/apps/skde/src/components/Markdown/__tests__/markdown.test.tsx
+++ b/apps/skde/src/components/Markdown/__tests__/markdown.test.tsx
@@ -28,6 +28,13 @@ test("Text with image", async () => {
   expect(container).toMatchSnapshot();
 });
 
+test("Text with image without alt-text", async () => {
+  const markdownText =
+    'Dette er en test\n\n# Hovedoverskrift\n\n![](https://picsum.photos/id/237/100/100.jpg "Menisk, utvikling i antall inngrep pr. 100 000 innbyggere i perioden 2013–2017, justert for kjønn og alder. Fordelt på opptaksområder og offentlig eller privat behandler.")\n\n';
+  const { container } = render(<Markdown>{markdownText}</Markdown>);
+  expect(container).toMatchSnapshot();
+});
+
 test("Text with image, language english", async () => {
   const markdownText =
     'Dette er en test\n\n# Hovedoverskrift\n\n![Menisk, utvikling i antall inngrep i perioden 2013–2017](https://picsum.photos/id/237/100/100.jpg "Menisk, utvikling i antall inngrep pr. 100 000 innbyggere i perioden 2013–2017, justert for kjønn og alder. Fordelt på opptaksområder og offentlig eller privat behandler.")\n\n';

--- a/apps/skde/src/components/Markdown/index.tsx
+++ b/apps/skde/src/components/Markdown/index.tsx
@@ -47,7 +47,7 @@ export const Markdown = ({ children, lang }: MarkdownProp) => {
         >
           <img
             src={src}
-            alt={alt}
+            alt={alt ? alt : title ? title : ""}
             title={alt}
             style={{
               display: "block",


### PR DESCRIPTION
De fleste figurene i ortopedi og psyk manglet `alt`. Figur var satt inn med `![](en/eller/annen/kilde.png "En eller annen figurtekst")`, det vil si med tom `[]`.

Vil nå bruke `title`-tekst hvis `alt`-tekst mangler.

Closes #1084