### PR TITLE
Erstatt next export med output: export i config

### DIFF
--- a/apps/skde/next.config.js
+++ b/apps/skde/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  output: "export",
   images: {
     loader: "custom",
   },

--- a/apps/skde/package.json
+++ b/apps/skde/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "export": "next export",
+    "export": "next build",
     "prettier": "prettier \"**/*.+(js|jsx|ts|tsx|json|html|yml|yaml|css|md)\"",
     "format": "yarn prettier --write",
     "test": "yarn run test:base --coverage",

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
       "dependsOn": ["^build"]
     },
     "export": {
-      "dependsOn": ["build"]
+      "dependsOn": ["^build"]
     },
     "check-format": {},
     "check-types": {},


### PR DESCRIPTION
next export is deprecated and replaced with 'output': 'export' (v13.3.0)