### PR TITLE
reintroduser markering når man har valgt å vise kun en måloppnåelse

### DIFF
--- a/packages/qmongjs/src/components/TargetLevels/__test__/__snapshots__/button.test.tsx.snap
+++ b/packages/qmongjs/src/components/TargetLevels/__test__/__snapshots__/button.test.tsx.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders 1`] = `
+<div>
+  <button>
+    <i
+      style="padding-right: 0.2em;"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: rgb(59, 170, 52); font-size: 1.2rem;"
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"
+        />
+      </svg>
+    </i>
+    <div
+      class="legend-text"
+    >
+      Høy måloppnåelse
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button renders 2`] = `
+<div>
+  <button
+    class="button_checked"
+  >
+    <i
+      style="padding-right: 0.2em;"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: rgb(59, 170, 52); font-size: 1.2rem;"
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8z"
+        />
+      </svg>
+    </i>
+    <div
+      class="legend-text"
+    >
+      Høy måloppnåelse
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button renders 3`] = `
+<div>
+  <button>
+    <i
+      style="padding-right: 0.2em;"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: rgb(253, 156, 0); font-size: 1.2rem;"
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 256c0 136.966 111.033 248 248 248s248-111.034 248-248S392.966 8 256 8 8 119.033 8 256zm248 184V72c101.705 0 184 82.311 184 184 0 101.705-82.311 184-184 184z"
+        />
+      </svg>
+    </i>
+    <div
+      class="legend-text"
+    >
+      Bla bla bla
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button renders 4`] = `
+<div>
+  <button>
+    <i
+      style="padding-right: 0.2em;"
+    />
+    <div
+      class="legend-text"
+    >
+      Bla bla bla
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button renders 5`] = `
+<div>
+  <button
+    class="button_checked"
+  >
+    <i
+      style="padding-right: 0.2em;"
+    />
+    <div
+      class="legend-text"
+    >
+      Bla bla bla
+    </div>
+  </button>
+</div>
+`;
+
+exports[`Button renders 6`] = `
+<div>
+  <button
+    class="button_checked"
+  >
+    <i
+      style="padding-right: 0.2em;"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        style="color: rgb(227, 7, 19); font-size: 1.2rem;"
+        viewBox="0 0 512 512"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm0 448c-110.5 0-200-89.5-200-200S145.5 56 256 56s200 89.5 200 200-89.5 200-200 200z"
+        />
+      </svg>
+    </i>
+    <div
+      class="legend-text"
+    >
+      Bla bla og bla
+    </div>
+  </button>
+</div>
+`;

--- a/packages/qmongjs/src/components/TargetLevels/__test__/button.test.tsx
+++ b/packages/qmongjs/src/components/TargetLevels/__test__/button.test.tsx
@@ -1,0 +1,94 @@
+import LEGEND_BTN from "../button";
+import { render } from "@testing-library/react";
+
+const dummy_function = (n: string) => {
+  n;
+};
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Høy måloppnåelse"
+      legend_btn_class="high"
+      icon_class="fa fa-fas fa-circle"
+      update_show_level_filter={dummy_function}
+      show_level_filter=""
+    />
+  );
+  expect(container).toMatchSnapshot();
+  const { container: another } = render(
+    <LEGEND_BTN
+      level="Høy måloppnåelse"
+      legend_btn_class="high"
+      icon_class="fa fa-fas fa-circle"
+      update_show_level_filter={dummy_function}
+      show_level_filter="L"
+    />
+  );
+  expect(another).toEqual(container);
+});
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Høy måloppnåelse"
+      legend_btn_class="high"
+      icon_class="fa fa-fas fa-circle"
+      update_show_level_filter={dummy_function}
+      show_level_filter="H"
+    />
+  );
+  expect(container).toMatchSnapshot();
+});
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Bla bla bla"
+      legend_btn_class="mamma"
+      icon_class="fa fa-fas fa-adjust"
+      update_show_level_filter={dummy_function}
+      show_level_filter="H"
+    />
+  );
+  expect(container).toMatchSnapshot();
+});
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Bla bla bla"
+      legend_btn_class="anna"
+      icon_class=""
+      update_show_level_filter={dummy_function}
+      show_level_filter="H"
+    />
+  );
+  expect(container).toMatchSnapshot();
+});
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Bla bla bla"
+      legend_btn_class="anna"
+      icon_class=""
+      update_show_level_filter={dummy_function}
+      show_level_filter="A"
+    />
+  );
+  expect(container).toMatchSnapshot();
+});
+
+it("Button renders", async () => {
+  const { container } = render(
+    <LEGEND_BTN
+      level="Bla bla og bla"
+      legend_btn_class="likes"
+      icon_class="fa fa-circle-o"
+      update_show_level_filter={dummy_function}
+      show_level_filter="L"
+    />
+  );
+  expect(container).toMatchSnapshot();
+});

--- a/packages/qmongjs/src/components/TargetLevels/button.tsx
+++ b/packages/qmongjs/src/components/TargetLevels/button.tsx
@@ -1,11 +1,12 @@
 import { FaCircle, FaAdjust, FaRegCircle } from "react-icons/fa";
+import styles from "./index.module.css";
 
 interface Props {
   level: string;
   icon_class: string;
   legend_btn_class: string;
   update_show_level_filter(p: string | undefined): void;
-  show_level_filter: string;
+  show_level_filter: string | undefined;
 }
 
 function LEGEND_BTN(props: Props) {
@@ -19,7 +20,10 @@ function LEGEND_BTN(props: Props) {
 
   const level_filter = legend_btn_class[0].toUpperCase();
   const checked_class = level_filter === show_level_filter ? "checked" : "";
-  const handle_level_filter = (current_state: string, update_state: string) => {
+  const handle_level_filter = (
+    current_state: string | undefined,
+    update_state: string
+  ) => {
     current_state === update_state
       ? update_show_level_filter(undefined)
       : update_show_level_filter(update_state);
@@ -27,7 +31,9 @@ function LEGEND_BTN(props: Props) {
 
   return (
     <button
-      className={`${legend_btn_class} ${checked_class}`}
+      className={
+        checked_class === "checked" ? styles.button_checked : undefined
+      }
       onClick={() => handle_level_filter(show_level_filter, level_filter)}
     >
       <i style={{ paddingRight: "0.2em" }}>

--- a/packages/qmongjs/src/components/TargetLevels/index.module.css
+++ b/packages/qmongjs/src/components/TargetLevels/index.module.css
@@ -41,7 +41,7 @@
   box-shadow: none;
   top: 0px;
 }
-.table_legend button.checked {
+.table_legend .button_checked {
   border: 2px solid #00263d;
   box-shadow: 0px 4px 10px 2px rgba(196, 196, 196, 0.2);
   top: -7px;


### PR DESCRIPTION
I produksjon kan man ikke lenger se at man har valgt å kun vise gitt måloppnåelse. Det ser det slik ut:

![image](https://github.com/mong/mongts/assets/136346/3a437145-522c-4263-9e8e-041125181d6d)

Med denne PR vil det se slik ut:

![image](https://github.com/mong/mongts/assets/136346/ae31874b-c746-4f86-b80f-46ea46c49b09)
