### PR TITLE
Start med zoom 0 til 100 i linjediagram.

### DIFF
--- a/packages/qmongjs/src/components/Charts/LineChart/index.tsx
+++ b/packages/qmongjs/src/components/Charts/LineChart/index.tsx
@@ -464,5 +464,5 @@ function getYScaleDomain(
   }
 
   // yaxis max is maximum 1 (100 %) if percentage
-  return [yMin, percentage ? Math.min(yMax, 1) : yMax];
+  return [yMin, percentage ? (zoom ? Math.min(yMax, 1) : 1) : yMax];
 }


### PR DESCRIPTION
Ble endret til 0 til yMax i PR #1001. Etter det var det ikke lenger mulig å zoome ut til 100 %. Linjediagram vil nå starte med helt ut-zoomet, fra 0 til 100 %