### PR TITLE
Fjerne 'Disse dataene ble lastet opp ...'

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/__tests__/__snapshots__/chartrowdescription.tsx.snap
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/__tests__/__snapshots__/chartrowdescription.tsx.snap
@@ -61,12 +61,6 @@ exports[`ChartRowDescription where date will change with time zone 1`] = `
                 >
                   Denne kvalitetsindikatoren er definert som andel pasienter med...
                 </p>
-                <p>
-                  Disse dataene ble lastet opp
-                   
-                  1. januar 2000
-                  .
-                </p>
               </div>
             </div>
           </div>
@@ -138,12 +132,6 @@ exports[`ChartRowDescription with date equals zero and Norwegian characters 1`] 
                 >
                   Vi prøver ågså særnårske bokstaver
                 </p>
-                <p>
-                  Disse dataene ble lastet opp
-                   
-                  1. januar 1970
-                  .
-                </p>
               </div>
             </div>
           </div>
@@ -214,12 +202,6 @@ exports[`ChartRowDescription with non-default title and +02:00 time zone 1`] = `
                   style="margin: 0px;"
                 >
                   Denne kvalitetsindikatoren er definert som andel pasienter med...
-                </p>
-                <p>
-                  Disse dataene ble lastet opp
-                   
-                  10. mars 1979
-                  .
                 </p>
               </div>
             </div>
@@ -313,12 +295,6 @@ exports[`ChartRowDescription with some markdown 1`] = `
                     src="https://loremflickr.com/320/240"
                   />
                    Prøve med fotnote[^1]. [^1]: Som står her.
-                </p>
-                <p>
-                  Disse dataene ble lastet opp
-                   
-                  10. mars 1979
-                  .
                 </p>
               </div>
             </div>

--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrowdescription.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/chartrowdescription.tsx
@@ -50,18 +50,6 @@ const ChartRowDescription = ({
             >
               {description_text}
             </ReactMarkdown>
-            {delivery_time && (
-              <p>
-                Disse dataene ble lastet opp{" "}
-                {delivery_time.toLocaleString("no-NO", {
-                  day: "numeric",
-                  month: "long",
-                  year: "numeric",
-                  timeZone: "CET",
-                })}
-                .
-              </p>
-            )}
           </>
         </AccordionDetails>
       </Accordion>


### PR DESCRIPTION
En bug i imongr (https://github.com/mong/imongr/issues/284) gjør at denne datoen ikke nødvendigvis er riktig