### PR TITLE
1221 helseatlas page crashes when changing atlas via menu

### DIFF
--- a/apps/skde/src/components/TableOfContents/__tests__/__snapshots__/tableofcontents.test.tsx.snap
+++ b/apps/skde/src/components/TableOfContents/__tests__/__snapshots__/tableofcontents.test.tsx.snap
@@ -364,32 +364,6 @@ exports[`English menu 2`] = `
                         >
                           Test to
                         </a>
-                        <ol
-                          class="tocList"
-                        >
-                          <li
-                            class="tocListItem false"
-                            data-testid="tocItem"
-                          >
-                            <a
-                              data-testid="toc_a_#test-to_kirurgiske-inngrep-for-endometriose"
-                              href="#test-to_kirurgiske-inngrep-for-endometriose"
-                            >
-                              Kirurgiske inngrep for endometriose
-                            </a>
-                          </li>
-                          <li
-                            class="tocListItem false"
-                            data-testid="tocItem"
-                          >
-                            <a
-                              data-testid="toc_a_#test-to_kirurgiske-inngrep-for-noe-annet"
-                              href="#test-to_kirurgiske-inngrep-for-noe-annet"
-                            >
-                              Kirurgiske inngrep for noe annet
-                            </a>
-                          </li>
-                        </ol>
                       </li>
                       <li
                         class="tocListItem false"

--- a/apps/skde/src/components/TableOfContents/index.tsx
+++ b/apps/skde/src/components/TableOfContents/index.tsx
@@ -19,7 +19,7 @@ type TableOfContentsProps = {
   tocData: TocData;
 };
 
-const TocDataToList = (tocData: TocData, parentID?: string) => {
+const TocDataToList = ({ tocData, parentID }) => {
   const [expanded, setExpanded] = React.useState<string>("none");
 
   return (
@@ -38,7 +38,7 @@ const TocDataToList = (tocData: TocData, parentID?: string) => {
             setExpanded={setExpanded}
             linkTitle={content.elemID}
           >
-            {TocDataToList(content.children, href)}
+            <TocDataToList tocData={content.children} parentID={href} />
           </ListItem>
         ) : (
           <ListItem
@@ -61,7 +61,7 @@ export const TableOfContents: React.FC<TableOfContentsProps> = ({
   const [expanded, setExpanded] = React.useState<boolean>(false);
   const handleChange = () => setExpanded((state) => !state);
 
-  const TOCOrderedList = TocDataToList(tocData);
+  const TOCOrderedList = <TocDataToList tocData={tocData} parentID={null} />;
 
   return (
     <>


### PR DESCRIPTION
TocDataToList is now used as a tag/component instead of being called as a function.

Note that there is still another bug that must be fixed, but it is unrelated to the page-crash bug described in this issue. The other bug is that several items in the list are shown as bold (active).