### PR TITLE
Ikke rund av verdi før målnivå-beregning

### DIFF
--- a/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
+++ b/packages/qmongjs/src/helpers/functions/__test__/defineLevel.test.tsx
@@ -43,7 +43,7 @@ test("Returns correct level with direction 1", () => {
   indicator.var = 0.79;
   expect(level(indicator)).toBe("L");
   indicator.var = 0.945;
-  expect(level(indicator)).toBe("H");
+  expect(level(indicator)).toBe("M");
 });
 
 test("Returns no level if direction is null", () => {

--- a/packages/qmongjs/src/helpers/functions/defineLevel.ts
+++ b/packages/qmongjs/src/helpers/functions/defineLevel.ts
@@ -1,11 +1,7 @@
 import { Indicator } from "types";
 
-const numWithValidDigits = (value: number, decimals: number) => {
-  return Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals);
-};
-
 export const level = (indicatorData: Indicator) => {
-  const { level_green, level_yellow, level_direction, sformat } = indicatorData;
+  const { level_green, level_yellow, level_direction } = indicatorData;
   if (
     level_green === undefined ||
     level_green === null ||
@@ -13,19 +9,13 @@ export const level = (indicatorData: Indicator) => {
   ) {
     return;
   }
-  let decimalPoints = sformat ? Number(sformat.replace(/[^0-9]/g, "")) : 0;
-  decimalPoints = sformat?.includes("%") ? decimalPoints + 2 : decimalPoints;
-  const value = numWithValidDigits(indicatorData.var, decimalPoints);
-  const green = numWithValidDigits(level_green, decimalPoints);
+  const value = indicatorData.var;
   // If level_yellow is NULL: set to level_green
-  const yellow =
-    level_yellow != null
-      ? numWithValidDigits(level_yellow, decimalPoints)
-      : green;
+  const yellow = level_yellow != null ? level_yellow : level_green;
 
   if (
-    (level_direction === 0 && value <= green) ||
-    (level_direction != 0 && value >= green)
+    (level_direction === 0 && value <= level_green) ||
+    (level_direction != 0 && value >= level_green)
   ) {
     return "H";
   } else if (


### PR DESCRIPTION
Grensene er absolutte, før avrunding.

Det blir fort et avvik mellom det som vises i rapportalen og egenberegnet verdier.
Det vil også være avvik i fargen på indikator og det som vises i figurene.

Endres derfor etter diskusjon med Eva og @kevinthon