### PR TITLE
Rapportalen: Skip search option in year-selector

### DIFF
--- a/packages/qmongjs/src/components/SelectYear/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/qmongjs/src/components/SelectYear/__test__/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,75 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Button renders 1`] = `
+<div>
+  <form
+    data-testid="year_selector"
+  >
+    <div
+      class=" css-b62m3t-container"
+    >
+      <span
+        class="css-1f43avz-a11yText-A11yText"
+        id="react-select-2-live-region"
+      />
+      <span
+        aria-atomic="false"
+        aria-live="polite"
+        aria-relevant="additions text"
+        class="css-1f43avz-a11yText-A11yText"
+        role="log"
+      />
+      <div
+        class=" css-11mctf7-control"
+      >
+        <div
+          class=" css-1fdsijx-ValueContainer"
+        >
+          <div
+            class=" css-1qrxvr1-singleValue"
+          >
+            2001
+          </div>
+          <input
+            aria-activedescendant=""
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-haspopup="true"
+            aria-readonly="true"
+            class="css-mohuvp-dummyInput-DummyInput"
+            id="react-select-2-input"
+            inputmode="none"
+            role="combobox"
+            tabindex="0"
+            value=""
+          />
+        </div>
+        <div
+          class=" css-1hb7zxy-IndicatorsContainer"
+        >
+          <span
+            class=" css-1u9des2-indicatorSeparator"
+          />
+          <div
+            aria-hidden="true"
+            class=" css-1xc3v61-indicatorContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-tj5bde-Svg"
+              focusable="false"
+              height="20"
+              viewBox="0 0 20 20"
+              width="20"
+            >
+              <path
+                d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/packages/qmongjs/src/components/SelectYear/__test__/index.test.tsx
+++ b/packages/qmongjs/src/components/SelectYear/__test__/index.test.tsx
@@ -1,0 +1,31 @@
+import SelectYear from "../.";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+
+it("Button renders", async () => {
+  const mockedOnChange = vi.fn();
+  const { container, getByText, queryByTestId } = render(
+    <SelectYear
+      opts={[2000, 2001, 2002]}
+      update_year={mockedOnChange}
+      selected_year={2001}
+    />,
+  );
+  expect(container).toMatchSnapshot();
+  const selectYearComponent = queryByTestId("year_selector");
+  expect(selectYearComponent).toBeDefined();
+  expect(selectYearComponent).not.toBeNull();
+  expect(mockedOnChange).toHaveBeenCalledTimes(0);
+
+  fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowDown" });
+  await waitFor(() => getByText("2002"));
+  fireEvent.click(getByText("2002"));
+
+  expect(mockedOnChange).toHaveBeenCalledTimes(1);
+  expect(mockedOnChange).toHaveBeenCalledWith("2002");
+  fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowUp" });
+  fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowUp" });
+  await waitFor(() => getByText("2000"));
+  fireEvent.click(getByText("2000"));
+  expect(mockedOnChange).toHaveBeenCalledTimes(2);
+  expect(mockedOnChange).toHaveBeenCalledWith("2000");
+});

--- a/packages/qmongjs/src/components/SelectYear/__test__/index.test.tsx
+++ b/packages/qmongjs/src/components/SelectYear/__test__/index.test.tsx
@@ -2,12 +2,13 @@ import SelectYear from "../.";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 
 it("Button renders", async () => {
+  const YearArray = Array.from({ length: 5 }, (value, index) => 2000 + index);
   const mockedOnChange = vi.fn();
   const { container, getByText, queryByTestId } = render(
     <SelectYear
-      opts={[2000, 2001, 2002]}
+      opts={YearArray}
       update_year={mockedOnChange}
-      selected_year={2001}
+      selected_year={YearArray[1]}
     />,
   );
   expect(container).toMatchSnapshot();
@@ -17,15 +18,15 @@ it("Button renders", async () => {
   expect(mockedOnChange).toHaveBeenCalledTimes(0);
 
   fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowDown" });
-  await waitFor(() => getByText("2002"));
-  fireEvent.click(getByText("2002"));
+  await waitFor(() => getByText(YearArray[2]));
+  fireEvent.click(getByText(YearArray[2]));
 
   expect(mockedOnChange).toHaveBeenCalledTimes(1);
-  expect(mockedOnChange).toHaveBeenCalledWith("2002");
+  expect(mockedOnChange).toHaveBeenCalledWith(String(YearArray[2]));
   fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowUp" });
   fireEvent.keyDown(selectYearComponent.firstChild, { key: "ArrowUp" });
-  await waitFor(() => getByText("2000"));
-  fireEvent.click(getByText("2000"));
+  await waitFor(() => getByText(YearArray[0]));
+  fireEvent.click(getByText(YearArray[0]));
   expect(mockedOnChange).toHaveBeenCalledTimes(2);
-  expect(mockedOnChange).toHaveBeenCalledWith("2000");
+  expect(mockedOnChange).toHaveBeenCalledWith(String(YearArray[0]));
 });

--- a/packages/qmongjs/src/components/SelectYear/index.tsx
+++ b/packages/qmongjs/src/components/SelectYear/index.tsx
@@ -60,7 +60,7 @@ function SelectYear(props: Props) {
         options={selection_options}
         defaultValue={defaultValue}
         value={selected_option}
-        isSearchable
+        isSearchable={false}
         styles={customStyles}
       />
     </form>


### PR DESCRIPTION
Var unødvendig. Folk trenger ikke søkemuligheter på år:

![image](https://github.com/mong/mongts/assets/136346/fcad7e27-b4cb-4322-8643-17c2a7e4bc31)


La også inn en test.