### PR TITLE
Rapportalen: five years pickable as standard

### DIFF
--- a/packages/qmongjs/src/__test__/app_config.test.ts
+++ b/packages/qmongjs/src/__test__/app_config.test.ts
@@ -1,0 +1,6 @@
+import { minYear, maxYear } from "../app_config";
+import { test, expect } from "vitest";
+
+test("Number of selectable years are 5", () => {
+  expect(maxYear - minYear + 1).toBe(5);
+});

--- a/packages/qmongjs/src/app_config.ts
+++ b/packages/qmongjs/src/app_config.ts
@@ -42,8 +42,8 @@ export const app_text: appTextTypes = {
   },
 };
 
-export const minYear = 2017;
 export const maxYear = 2023;
+export const minYear = maxYear - 4;
 export const defaultYear = 2022;
 export const mainQueryParamsConfig = {
   selected_row: withDefault(StringParam, undefined),


### PR DESCRIPTION
Forgot earlier to increase minYear when increasing maxYear, so number of pickable years increased. This is only relevant for alle-register page.