### PR TITLE
Hent indikatorbeskrivelse i API-kall

### DIFF
--- a/apps/api/src/models/data/indicators.ts
+++ b/apps/api/src/models/data/indicators.ts
@@ -31,6 +31,10 @@ export const indicatorsModel = (filter?: Filter): Promise<Indicator[]> =>
       "medfield.id as medfield_id",
       "medfield.name as medfield_name",
       "medfield.full_name as medfield_full_name",
+      "ind.short_description",
+      "ind.long_description",
+      "ind.title",
+      "ind.name",
     )
     .from("agg_data")
     .leftJoin("ind", "agg_data.ind_id", "ind.id")

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,6 +46,8 @@ export interface Indicator {
   medfield_id: number;
   medfield_name: string;
   medfield_full_name: string;
+  short_description: string | null;
+  long_description: string | null;
 }
 
 export interface TuName {


### PR DESCRIPTION
Hent alle data som trengs for å lage indikatortabellen i samme API-kall: 

![image](https://github.com/mong/mongts/assets/64078729/50be5ec9-8943-4a16-8b10-f7edcad39d1d)
