### PR TITLE
Deaktiver strapi-bygging

### DIFF
--- a/apps/strapi/package.json
+++ b/apps/strapi/package.json
@@ -4,10 +4,6 @@
   "version": "0.1.0",
   "description": "A Strapi application",
   "scripts": {
-    "dev": "strapi develop",
-    "develop": "strapi develop",
-    "start": "strapi start",
-    "build": "strapi build",
     "strapi": "strapi"
   },
   "dependencies": {


### PR DESCRIPTION
Kan aktivere det igjen når strapi er med klar for produksjon. Slet med å få bygd mongts lokalt.

Closes #2077