### PR TITLE
Lik hover-effekt når ResultBox er lukket og åpen

### DIFF
--- a/apps/skde/src/components/ResultBox/index.tsx
+++ b/apps/skde/src/components/ResultBox/index.tsx
@@ -205,7 +205,7 @@ export const ResultBox: React.FC<ResultBoxProps> = ({
           sx={{
             backgroundColor: "#FAFAFA",
             ":hover": {
-              backgroundColor: expandedResultBox ? "" : "rgb(241, 241, 241)",
+              backgroundColor: "rgb(241, 241, 241)",
               transition: "200ms ease-in",
             },
           }}


### PR DESCRIPTION
Som vi diskuterte i stand-up er det sannsynligvis mer intuitivt at man kan lukke ResultBox hvis den også har en hover-effect når den er åpnet. Dette vil også gjøre at ResultBox ligner mer på hvordan FactBox fungerer.