### PR TITLE
Kun permanent åpen sidemeny når bredden på siden er over 1300px

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -1,7 +1,6 @@
 import AppBar from "@mui/material/AppBar";
 import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
-import IconButton from "@mui/material/IconButton";
 import TuneIcon from "@mui/icons-material/Tune";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
@@ -10,13 +9,16 @@ import { imgLoader } from "qmongjs/src/helpers/functions";
 import { useState, useEffect } from "react";
 import { TreatmentQualityFilterMenu } from "qmongjs";
 import {
+  FilterIconButton,
   FilterDrawer,
   FilterDrawerBox,
   MainBox,
   appBarElevation,
   filterMenuTopMargin,
-  smSizeWidth,
+  desktopBreakpoint,
+  treatmentQualityTheme,
 } from "../../src/components/TreatmentQuality";
+import { ThemeProvider } from "@mui/material/styles";
 
 /**
  * Treatment quality page (Behandlingskvalitet)
@@ -24,12 +26,12 @@ import {
  * @returns The page component
  */
 export default function TreatmentQuality() {
-  const [width, setWidth] = useState(smSizeWidth);
+  const [width, setWidth] = useState(desktopBreakpoint);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
-  const isSmallScreen = width <= smSizeWidth;
-  const drawerOpen = isSmallScreen ? mobileOpen : true;
-  const drawerType = isSmallScreen ? "temporary" : "permanent";
+  const isPhoneSizedScreen = width < desktopBreakpoint;
+  const drawerOpen = isPhoneSizedScreen ? mobileOpen : true;
+  const drawerType = isPhoneSizedScreen ? "temporary" : "permanent";
 
   // Used to change drawer style between small screens and larger screens
   useEffect(() => {
@@ -64,82 +66,83 @@ export default function TreatmentQuality() {
   };
 
   return (
-    <Box sx={{ display: "flex" }}>
-      <CssBaseline />
-      <AppBar
-        position="fixed"
-        elevation={appBarElevation}
-        sx={{
-          zIndex: (theme) => theme.zIndex.drawer + 1,
-          backgroundColor: "rgba(222, 231, 238, 1)",
-          color: "black",
-        }}
-      >
-        <Toolbar>
-          <IconButton
-            color="inherit"
-            aria-label="åpne sidemeny"
-            edge="start"
-            onClick={handleDrawerToggle}
-            sx={{ mr: 2, display: { sm: "none" } }}
-          >
-            <TuneIcon />
-            <Typography>Filter</Typography>
-          </IconButton>
-          <Box sx={{ marginLeft: 2 }}>
-            <Typography variant="h6">Behandlingskvalitet</Typography>
-          </Box>
-          <Box sx={{ marginLeft: "auto", marginTop: 1.15 }}>
-            <Image
-              loader={imgLoader}
-              src="/img/logos/SKDE_sort.png"
-              height="40"
-              width="99"
-              alt="SKDE logo"
-            />
-          </Box>
-        </Toolbar>
-      </AppBar>
-      <FilterDrawerBox
-        component="nav"
-        sx={{ flexShrink: { sm: 0 } }}
-        aria-label="filtermenyboks"
-      >
-        <Toolbar />
-        <FilterDrawer
-          variant={drawerType}
-          open={drawerOpen}
-          onTransitionEnd={handleDrawerTransitionEnd}
-          onClose={handleDrawerClose}
-          ModalProps={{
-            keepMounted: true,
-          }}
+    <ThemeProvider theme={treatmentQualityTheme}>
+      <Box sx={{ display: "flex" }}>
+        <CssBaseline />
+        <AppBar
+          position="fixed"
+          elevation={appBarElevation}
           sx={{
-            display: "block",
-            "& .MuiDrawer-paper": {
-              boxSizing: "border-box",
-            },
+            zIndex: (theme) => theme.zIndex.drawer + 1,
+            backgroundColor: "rgba(222, 231, 238, 1)",
+            color: "black",
+          }}
+        >
+          <Toolbar>
+            <FilterIconButton
+              color="inherit"
+              aria-label="åpne sidemeny"
+              edge="start"
+              onClick={handleDrawerToggle}
+            >
+              <TuneIcon />
+              <Typography>Filter</Typography>
+            </FilterIconButton>
+            <Box sx={{ marginLeft: 2 }}>
+              <Typography variant="h6">Behandlingskvalitet</Typography>
+            </Box>
+            <Box sx={{ marginLeft: "auto", marginTop: 1.15 }}>
+              <Image
+                loader={imgLoader}
+                src="/img/logos/SKDE_sort.png"
+                height="40"
+                width="99"
+                alt="SKDE logo"
+              />
+            </Box>
+          </Toolbar>
+        </AppBar>
+        <FilterDrawerBox
+          component="nav"
+          sx={{ flexShrink: { sm: 0 } }}
+          aria-label="filtermenyboks"
+        >
+          <Toolbar />
+          <FilterDrawer
+            variant={drawerType}
+            open={drawerOpen}
+            onTransitionEnd={handleDrawerTransitionEnd}
+            onClose={handleDrawerClose}
+            ModalProps={{
+              keepMounted: true,
+            }}
+            sx={{
+              display: "block",
+              "& .MuiDrawer-paper": {
+                boxSizing: "border-box",
+              },
+            }}
+          >
+            <Toolbar />
+            <Box sx={{ marginTop: filterMenuTopMargin }}>
+              <TreatmentQualityFilterMenu />
+            </Box>
+          </FilterDrawer>
+        </FilterDrawerBox>
+        <MainBox
+          component="main"
+          sx={{
+            paddingLeft: "0px",
+            flexGrow: 1,
+            p: 3,
           }}
         >
           <Toolbar />
-          <Box sx={{ marginTop: filterMenuTopMargin }}>
-            <TreatmentQualityFilterMenu />
-          </Box>
-        </FilterDrawer>
-      </FilterDrawerBox>
-      <MainBox
-        component="main"
-        sx={{
-          paddingLeft: "0px",
-          flexGrow: 1,
-          p: 3,
-        }}
-      >
-        <Toolbar />
-        <Typography paragraph>
-          Resultater fra medisinske kvalitetsregistre
-        </Typography>
-      </MainBox>
-    </Box>
+          <Typography paragraph>
+            Resultater fra medisinske kvalitetsregistre
+          </Typography>
+        </MainBox>
+      </Box>
+    </ThemeProvider>
   );
 }

--- a/apps/skde/src/components/TreatmentQuality/index.ts
+++ b/apps/skde/src/components/TreatmentQuality/index.ts
@@ -1,16 +1,51 @@
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
-import { styled } from "@mui/material/styles";
+import IconButton from "@mui/material/IconButton";
+import { createTheme, styled } from "@mui/material/styles";
 
 export const appBarElevation = 2;
 export const filterMenuTopMargin = 2;
 
 export const smDrawerWidth = 320;
-export const mdDrawerWidth = 400;
-export const lgDrawerWidth = 450;
-export const xlDrawerWidth = 500;
+export const mdDrawerWidth = 500;
+export const lgDrawerWidth = 700;
+export const xlDrawerWidth = 450;
 
-export const smSizeWidth = 600;
+/** The width at which the drawer type changes.
+ * Most modern desktops have a resolution greater than this, whereas
+ * many smart phones have landscape mode width of 1280 px.
+ * */
+export const desktopBreakpoint = 1300;
+
+declare module "@mui/material/styles" {
+  interface BreakpointOverrides {
+    xs: false;
+    sm: true;
+    md: true;
+    lg: true;
+    xl: true;
+    desktop: true;
+  }
+}
+
+/** The theme for the treatment quality page */
+export const treatmentQualityTheme = createTheme({
+  breakpoints: {
+    values: {
+      sm: 600,
+      md: 900,
+      lg: 1200,
+      xl: 1536,
+      desktop: desktopBreakpoint,
+    },
+  },
+});
+
+export const FilterIconButton = styled(IconButton)(({ theme }) => ({
+  [theme.breakpoints.up("desktop")]: {
+    display: "none",
+  },
+}));
 
 export const FilterDrawer = styled(Drawer)(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {
@@ -28,7 +63,7 @@ export const FilterDrawer = styled(Drawer)(({ theme }) => ({
       width: lgDrawerWidth,
     },
   },
-  [theme.breakpoints.up("lg")]: {
+  [theme.breakpoints.up("desktop")]: {
     "& .MuiDrawer-paper": {
       width: xlDrawerWidth,
     },
@@ -51,7 +86,7 @@ export const FilterDrawerBox = styled(Box)(({ theme }) => ({
       width: lgDrawerWidth,
     },
   },
-  [theme.breakpoints.up("lg")]: {
+  [theme.breakpoints.up("desktop")]: {
     "& .MuiDrawer-paper": {
       width: xlDrawerWidth,
     },
@@ -65,18 +100,16 @@ export const MainBox = styled(Box)(({ theme }) => ({
     },
   },
   [theme.breakpoints.up("sm")]: {
-    marginLeft: mdDrawerWidth,
     "& .MuiDrawer-paper": {
-      width: `calc(100% - ${mdDrawerWidth}px)`,
+      width: "100%",
     },
   },
   [theme.breakpoints.up("md")]: {
-    marginLeft: lgDrawerWidth,
     "& .MuiDrawer-paper": {
       width: `calc(100% - ${lgDrawerWidth}px)`,
     },
   },
-  [theme.breakpoints.up("lg")]: {
+  [theme.breakpoints.up("desktop")]: {
     marginLeft: xlDrawerWidth,
     "& .MuiDrawer-paper": {
       width: `calc(100% - ${xlDrawerWidth}px)`,


### PR DESCRIPTION
De fleste moderne desktop-skjermer er over 1300px, mens landskapsvisning på mobil godt kan være så store som 1280px (for eksempel Samsung S23). For disse blir det for lite igjen av skjermen til tabell hvis meny vises permanent. Setter derfor skillet ved 1300px.
