### PR TITLE
2145 tastatursnarvei for ekspandering av behandlingsenheter i filtermeny

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -1,5 +1,5 @@
 import type {} from "@mui/x-tree-view/themeAugmentation";
-import React, { use, useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Box from "@mui/material/Box";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
@@ -10,7 +10,6 @@ import {
   FilterSettingsValue,
 } from "./FilterSettingsContext";
 import { FilterSettingsDispatchContext } from "./FilterSettingsReducer";
-import { FilterSettingsAction } from "./FilterSettingsReducer";
 import { FilterSettingsActionType } from "./FilterSettingsReducer";
 import { TreeViewFilterSectionItem } from "./TreeViewFilterSectionItem";
 import Alert from "@mui/material/Alert";
@@ -60,6 +59,7 @@ const buildTreeLevel = (
   selectedIds: string[],
   filterKey: string,
   handleCheckboxChange: (checked: boolean, value: string) => void,
+  toggleExpand: (value: string) => void,
 ) => {
   return treeData.map((node) => {
     return (
@@ -69,6 +69,7 @@ const buildTreeLevel = (
         labeledValue={node.nodeValue}
         selectedIds={selectedIds}
         handleCheckboxChange={handleCheckboxChange}
+        toggleExpand={toggleExpand}
       >
         {node.children &&
           buildTreeLevel(
@@ -76,6 +77,7 @@ const buildTreeLevel = (
             selectedIds,
             filterKey,
             handleCheckboxChange,
+            toggleExpand,
           )}
       </TreeViewFilterSectionItem>
     );
@@ -94,6 +96,7 @@ export const buildTreeView = (
   props: TreeViewSectionProps,
   selectedIds: string[],
   handleCheckboxChange: (checked: boolean, value: string) => void,
+  toggleExpand: (value: string) => void,
 ) => {
   return (
     <>
@@ -102,6 +105,7 @@ export const buildTreeView = (
         selectedIds,
         props.filterkey,
         handleCheckboxChange,
+        toggleExpand,
       )}
     </>
   );
@@ -217,6 +221,7 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
   const [initiallyExpanded, setInitiallyExpanded] = useState(
     initDefaultExpanded(selectedIds, filterSettingsValuesMap),
   );
+  const [expanded, setExpanded] = useState<string[]>(initiallyExpanded);
   const [treeViewKey, setTreeViewKey] = useState(0);
 
   useEffect(() => {
@@ -276,6 +281,15 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
     }
   };
 
+  /** Toggle expanded state for a node */
+  const toggleExpanded = (value: string) => {
+    if (expanded.includes(value)) {
+      setExpanded(expanded.filter((id) => id !== value));
+    } else {
+      setExpanded([...expanded, value]);
+    }
+  };
+
   return (
     <Box>
       {showMaxSelectionAlert && (
@@ -288,8 +302,20 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
         defaultExpanded={initiallyExpanded}
+        expanded={expanded}
+        onNodeFocus={(event, nodeId) => {
+          const checkbox = document.getElementById(
+            `checkbox-${filterKey}-${nodeId}`,
+          );
+          if (checkbox) {
+            checkbox.focus();
+          }
+        }}
+        onNodeSelect={(event, nodeId) => {
+          toggleExpanded(nodeId);
+        }}
       >
-        {buildTreeView(props, selectedIds, handleCheckboxClick)}
+        {buildTreeView(props, selectedIds, handleCheckboxClick, toggleExpanded)}
       </TreeView>
     </Box>
   );

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -218,16 +218,13 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
   const selectedIds = getSelectedNodeIds(filterSettings.map.get(filterKey));
   const filterSettingsValuesMap = initFilterSettingsValuesMap(treeData);
   const [showMaxSelectionAlert, setMaxSelectionAlert] = useState(false);
-  const [initiallyExpanded, setInitiallyExpanded] = useState(
+  const [expanded, setExpanded] = useState(
     initDefaultExpanded(selectedIds, filterSettingsValuesMap),
   );
-  const [expanded, setExpanded] = useState<string[]>(initiallyExpanded);
   const [treeViewKey, setTreeViewKey] = useState(0);
 
   useEffect(() => {
-    setInitiallyExpanded(
-      initDefaultExpanded(selectedIds, filterSettingsValuesMap),
-    );
+    setExpanded(initDefaultExpanded(selectedIds, filterSettingsValuesMap));
     setTreeViewKey(treeViewKey + 1);
   }, [props.refreshState]);
 
@@ -301,7 +298,7 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
         data-testid={`tree-view-section-${props.sectionid}`}
         defaultCollapseIcon={<ExpandMoreIcon />}
         defaultExpandIcon={<ChevronRightIcon />}
-        defaultExpanded={initiallyExpanded}
+        defaultExpanded={expanded}
         expanded={expanded}
         onNodeFocus={(event, nodeId) => {
           const checkbox = document.getElementById(
@@ -312,7 +309,9 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
           }
         }}
         onNodeSelect={(event, nodeId) => {
-          toggleExpanded(nodeId);
+          if (typeof nodeId == "string") {
+            toggleExpanded(nodeId);
+          }
         }}
       >
         {buildTreeView(props, selectedIds, handleCheckboxClick, toggleExpanded)}

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -37,11 +37,9 @@ export const TreeViewFilterSectionItem = (
     toggleExpand,
   } = props;
   const isSelected = selectedIds.includes(labeledValue.value);
-  const treeItemRef = React.useRef<HTMLLIElement>(null);
 
   return (
     <TreeItem
-      ref={treeItemRef}
       key={`tree-view-item-${filterKey}-${labeledValue.value}`}
       data-testid={`tree-view-item-${labeledValue.value}`}
       nodeId={labeledValue.value}

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -14,6 +14,7 @@ type TreeViewFilterSectionItemProps = PropsWithChildren<{
   labeledValue: FilterSettingsValue;
   selectedIds: string[];
   handleCheckboxChange: (checked: boolean, value: string) => void;
+  toggleExpand: (value: string) => void;
 }>;
 
 /**
@@ -28,23 +29,37 @@ type TreeViewFilterSectionItemProps = PropsWithChildren<{
 export const TreeViewFilterSectionItem = (
   props: TreeViewFilterSectionItemProps,
 ) => {
-  const { filterKey, labeledValue, selectedIds, handleCheckboxChange } = props;
+  const {
+    filterKey,
+    labeledValue,
+    selectedIds,
+    handleCheckboxChange,
+    toggleExpand,
+  } = props;
   const isSelected = selectedIds.includes(labeledValue.value);
+  const treeItemRef = React.useRef<HTMLLIElement>(null);
 
   return (
     <TreeItem
+      ref={treeItemRef}
       key={`tree-view-item-${filterKey}-${labeledValue.value}`}
       data-testid={`tree-view-item-${labeledValue.value}`}
       nodeId={labeledValue.value}
       label={
         <>
           <Checkbox
+            id={`checkbox-${filterKey}-${labeledValue.value}`}
             key={`checkbox-${filterKey}-${labeledValue.value}`}
             data-testid={`checkbox-${filterKey}-${labeledValue.value}`}
             checked={isSelected}
             onClick={(event) => {
               handleCheckboxChange(!isSelected, labeledValue.value);
               event.stopPropagation();
+            }}
+            onKeyUp={(event) => {
+              if (event.key === "Enter") {
+                toggleExpand(labeledValue.value);
+              }
             }}
           />
           {labeledValue.valueLabel}


### PR DESCRIPTION
Tastatursnarveiene for behandlingsenheter er nå som følgende:

Tab og shift-tab for å navigere opp og ned i treet.
Enter for å ekspandere/kollapse noder i treet.
Space for å velge/avvelge enheten.

Kommentar: Å bruke den innebyggede funksjonaliteten med piltaster hadde en issue med at man ikke scrollet nedover hvis listen ble for lang. Man kunne navigere seg nedover med pilene, men dette ble utenfor skjermen. Det var også et problem med at tab-posisjon for neste node og noden som var valgt med piltaster ikke samsvarte. Endte derfor med løsningen som er beskrevet over. 