### PR TITLE
sticky indicator table header

### DIFF
--- a/apps/skde/src/components/TreatmentQuality/TreatmentQualityFooter.tsx
+++ b/apps/skde/src/components/TreatmentQuality/TreatmentQualityFooter.tsx
@@ -23,7 +23,7 @@ export function TreatmentQualityFooter() {
         columns={{ xs: 4, sm: 8, md: 12, lg: 12 }}
         padding={{ xs: 1, sm: 1, md: 2, lg: 2 }}
       >
-        <FooterItem item xs={4} sm={8} md={3} lg={3}>
+        <FooterItem item xs={4} sm={8} md={2} lg={2}>
           <Link title="Link til SKDEs forside" href="/">
             <Image
               className="footer-logo"
@@ -70,7 +70,7 @@ export function TreatmentQualityFooter() {
             </ListItem>
           </List>
         </FooterItem>
-        <FooterItem item xs={4} sm={8} md={3} lg={3}>
+        <FooterItem item xs={4} sm={8} md={4} lg={4}>
           <nav aria-label="Linker til nettstedsinformasjon">
             <List>
               <ListItem disablePadding>

--- a/apps/skde/src/components/TreatmentQuality/index.ts
+++ b/apps/skde/src/components/TreatmentQuality/index.ts
@@ -170,27 +170,34 @@ export const FooterDivider = styled(Divider)(({ theme }) => ({
 }));
 
 export const MainBox = styled(Box)(({ theme }) => ({
-  marginTop: "64px",
-  height: `calc(100vh - 64px)`,
   padding: 0,
   flexGrow: 1,
   overflowX: "auto",
   display: "grid",
-  "& .gradient-box": {
-    mask: "linear-gradient(90deg,#0000,#000 0% 95%, #0005)",
+  "& table": {
+    borderSpacing: "0px",
   },
   "& th": {
-    whiteSpace: "nowrap",
+    top: "0px !important",
+    minWidth: "128px",
+    verticalAlign: "top",
     paddingTop: 10,
     paddingBottom: 10,
     paddingRight: 15,
+    position: "sticky",
+    backgroundColor: "#00263d",
+    color: "white",
   },
   [theme.breakpoints.down("sm")]: {
+    marginTop: "56px",
+    height: "calc(100vh - 56px)",
     "& .MuiDrawer-paper": {
       width: "100%",
     },
   },
   [theme.breakpoints.up("sm")]: {
+    marginTop: "64px",
+    height: "calc(100vh - 64px)",
     "& .MuiDrawer-paper": {
       width: "100%",
     },


### PR DESCRIPTION
Overskriftene til indikatortabellen er nå festet slik at de vises selv om man scroller nedover siden.

(Også en ørliten endring i footeren som gjaldt bredde på to grid-kolonner.)