### PR TITLE
2199 lage trevisning for valg av register

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -161,15 +161,29 @@ export default function TreatmentQuality() {
         break;
       }
       case medicalFieldKey: {
-        let medicalFieldFilter =
-          newFilterSettings.map.get(medicalFieldKey)[0].value;
-        if (!medicalFieldFilter || medicalFieldFilter === "all") {
+        let medicalFieldFilter = newFilterSettings.map
+          .get(medicalFieldKey)
+          .map((value) => value.value);
+
+        if (!medicalFieldFilter || medicalFieldFilter[0] === "all") {
           setSelectedMedicalFields(registers.map((register) => register.rname));
         } else {
-          const selectedMedicalFields = medicalFields
-            .filter((field) => field.shortName === medicalFieldFilter)
-            .flatMap((field) => field.registers);
-          setSelectedMedicalFields(selectedMedicalFields);
+          const selectedMedicalFields = medicalFields.filter((field) =>
+            medicalFieldFilter.includes(field.shortName),
+          );
+          const selectedMedicalFieldNames = selectedMedicalFields.map(
+            (field) => field.shortName,
+          );
+          let selectedRegisters = medicalFieldFilter.filter(
+            (name) => !selectedMedicalFieldNames.includes(name),
+          );
+          selectedRegisters = Array.from(
+            new Set<string>([
+              ...selectedMedicalFields.flatMap((field) => field.registers),
+              ...selectedRegisters,
+            ]),
+          );
+          setSelectedMedicalFields(selectedRegisters);
         }
         break;
       }
@@ -236,6 +250,8 @@ export default function TreatmentQuality() {
                 <TreatmentQualityFilterMenu
                   onSelectionChanged={handleFilterChanged}
                   onFilterInitialized={handleFilterInitialized}
+                  registryNameData={registers}
+                  medicalFieldData={medicalFields}
                 />
               )}
             </Box>

--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -108,6 +108,38 @@ export default function TreatmentQuality() {
   const medicalFields = medicalFieldsQuery?.data;
 
   /**
+   * Get the register names for the selected medical fields and registers
+   *
+   * @param medicalFieldFilter Array of medical field and register names
+   * @returns Array of register names
+   */
+  const getMedicalFieldFilterRegisters = (medicalFieldFilter: string[]) => {
+    let registerFilter: string[];
+
+    if (!medicalFieldFilter || medicalFieldFilter[0] === "all") {
+      registerFilter = registers.map((register) => register.rname);
+    } else {
+      const selectedMedicalFields = medicalFields.filter((field) =>
+        medicalFieldFilter.includes(field.shortName),
+      );
+      const selectedMedicalFieldNames = selectedMedicalFields.map(
+        (field) => field.shortName,
+      );
+      let selectedRegisters = medicalFieldFilter.filter(
+        (name) => !selectedMedicalFieldNames.includes(name),
+      );
+      registerFilter = Array.from(
+        new Set<string>([
+          ...selectedMedicalFields.flatMap((field) => field.registers),
+          ...selectedRegisters,
+        ]),
+      );
+    }
+
+    return registerFilter;
+  };
+
+  /**
    * Handle that the initial filter settings are loaded, which can happen
    * more than once due to Next's pre-rendering and hydration behaviour combined
    * with reading of query params.
@@ -122,15 +154,12 @@ export default function TreatmentQuality() {
     );
     setSelectedLevel(filterSettings.get(levelKey)[0].value ?? undefined);
 
-    let medicalFieldFilter = filterSettings.get(medicalFieldKey)[0].value;
-    if (!medicalFieldFilter || medicalFieldFilter === "all") {
-      setSelectedMedicalFields(registers.map((register) => register.rname));
-    } else {
-      const selectedMedicalFields = medicalFields
-        .filter((field) => field.shortName === medicalFieldFilter)
-        .flatMap((field) => field.registers);
-      setSelectedMedicalFields(selectedMedicalFields);
-    }
+    const medicalFieldFilter = filterSettings
+      .get(medicalFieldKey)
+      .map((value) => value.value);
+    const registerFilter = getMedicalFieldFilterRegisters(medicalFieldFilter);
+    setSelectedMedicalFields(registerFilter);
+
     setSelectedTreatmentUnits(
       filterSettings.get(treatmentUnitsKey).map((value) => value.value),
     );
@@ -161,30 +190,12 @@ export default function TreatmentQuality() {
         break;
       }
       case medicalFieldKey: {
-        let medicalFieldFilter = newFilterSettings.map
+        const medicalFieldFilter = newFilterSettings.map
           .get(medicalFieldKey)
           .map((value) => value.value);
-
-        if (!medicalFieldFilter || medicalFieldFilter[0] === "all") {
-          setSelectedMedicalFields(registers.map((register) => register.rname));
-        } else {
-          const selectedMedicalFields = medicalFields.filter((field) =>
-            medicalFieldFilter.includes(field.shortName),
-          );
-          const selectedMedicalFieldNames = selectedMedicalFields.map(
-            (field) => field.shortName,
-          );
-          let selectedRegisters = medicalFieldFilter.filter(
-            (name) => !selectedMedicalFieldNames.includes(name),
-          );
-          selectedRegisters = Array.from(
-            new Set<string>([
-              ...selectedMedicalFields.flatMap((field) => field.registers),
-              ...selectedRegisters,
-            ]),
-          );
-          setSelectedMedicalFields(selectedRegisters);
-        }
+        const registerFilter =
+          getMedicalFieldFilterRegisters(medicalFieldFilter);
+        setSelectedMedicalFields(registerFilter);
         break;
       }
       case treatmentUnitsKey: {

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/filterMenuOptions.ts
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/filterMenuOptions.ts
@@ -1,6 +1,7 @@
 import { FilterSettingsValue } from "../FilterSettingsContext";
 import { maxYear, minYear, defaultYear, app_text } from "../../../app_config";
 import { UseQueryResult } from "@tanstack/react-query";
+import { TreeViewFilterSectionNode } from "../TreeViewFilterSection";
 
 /** Maximum allowed number of selected treatment units */
 export const maxSelectedTreatmentUnits = () => {
@@ -60,6 +61,7 @@ export const getAchievementLevelOptions = (): {
  * @returns
  */
 export const getTreatmentUnitsTree = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   unitNamesQuery: UseQueryResult<any, unknown>,
 ) => {
   const unitnames = unitNamesQuery.data?.nestedUnitNames;
@@ -75,18 +77,21 @@ export const getTreatmentUnitsTree = (
     defaults: [{ value: "Nasjonalt", valueLabel: "Nasjonalt" }],
     treedata: [
       { nodeValue: { value: "Nasjonalt", valueLabel: "Nasjonalt" } },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       ...unitnames.map((unit: any) => {
         return {
           nodeValue: {
             value: unit.rhf,
             valueLabel: unit.rhf,
           },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           children: unit.hf.map((hf: any) => {
             return {
               nodeValue: {
                 value: hf.hf,
                 valueLabel: hf.hf_full,
               },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               children: hf.hospital.map((hospital: any) => {
                 return {
                   nodeValue: {
@@ -99,6 +104,48 @@ export const getTreatmentUnitsTree = (
           }),
         };
       }),
-    ],
+    ] as TreeViewFilterSectionNode[],
   };
+};
+
+/**
+ * Gets the medical field options available for selection
+ *
+ * @returns The tree structure with medical field options and the default value
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getMedicalFields = (medicalFieldData: any, registryData: any) => {
+  let medicalFields: TreeViewFilterSectionNode[];
+  if (medicalFieldData && registryData) {
+    medicalFields = medicalFieldData.map(
+      (field: { shortName?: string; name?: string; registers?: string[] }) => ({
+        nodeValue: {
+          value: field.shortName,
+          valueLabel: field.name,
+        },
+        children: field.registers?.map((register: string) => ({
+          nodeValue: {
+            value: register,
+            valueLabel:
+              registryData.find(
+                (reg: { rname: string }) => reg.rname === register,
+              )?.full_name ?? register,
+          },
+        })),
+      }),
+    );
+  } else {
+    medicalFields = [];
+  }
+
+  medicalFields.unshift({
+    nodeValue: { value: "all", valueLabel: "Alle fagområder" },
+  });
+
+  const medicalFieldOptions = {
+    treedata: medicalFields,
+    defaults: [medicalFields[0].nodeValue],
+  };
+
+  return medicalFieldOptions;
 };

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -297,6 +297,7 @@ export function TreatmentQualityFilterMenu({
           refreshState={shouldRefreshInititalState}
           treedata={medicalFields.treedata}
           defaultvalues={medicalFields.defaults}
+          autoUncheckId={medicalFields.defaults[0].value}
           initialselections={
             selectedMedicalFields.map((value) => ({
               value: value,

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -297,7 +297,7 @@ export function TreatmentQualityFilterMenu({
           refreshState={shouldRefreshInititalState}
           treedata={medicalFields.treedata}
           defaultvalues={medicalFields.defaults}
-          autoUncheckId={medicalFields.defaults[0].value}
+          autouncheckid={medicalFields.defaults[0].value}
           initialselections={
             selectedMedicalFields.map((value) => ({
               value: value,

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import {
+  ArrayParam,
   DelimitedArrayParam,
   StringParam,
   UrlUpdateType,
@@ -140,7 +141,7 @@ export function TreatmentQualityFilterMenu({
 
   const [selectedMedicalFields, setSelectedMedicalFields] = useQueryParam(
     medicalFieldKey,
-    withDefault(DelimitedArrayParam, [medicalFields.defaults[0].value]),
+    withDefault(ArrayParam, [medicalFields.defaults[0].value]),
   );
 
   optionsMap.set(medicalFieldKey, {

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -45,7 +45,7 @@ export type TreeViewSectionProps = FilterMenuSectionProps & {
   multiselect?: boolean;
   maxselections?: number;
   treedata: TreeViewFilterSectionNode[];
-  autoUncheckId?: string;
+  autouncheckid?: string;
 };
 
 /**
@@ -112,7 +112,7 @@ export const buildTreeView = (
         props.filterkey,
         handleCheckboxChange,
         toggleExpand,
-        props.autoUncheckId,
+        props.autouncheckid,
       )}
     </>
   );

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -37,12 +37,15 @@ export type TreeViewFilterSettingsValue = FilterSettingsValue & {
  * treeData prop, which is an array of TreeViewFilterSectionNode objects
  * representing the tree structure of the filter options. Also accepts the
  * multiselect prop, which is a boolean that determines whether the filter
- * is single or multi-select.
+ * is single or multi-select. If an autoUncheckedId is provided, e.g., "all",
+ * the component will automatically uncheck this node when another node is
+ * checked.
  */
 export type TreeViewSectionProps = FilterMenuSectionProps & {
   multiselect?: boolean;
   maxselections?: number;
   treedata: TreeViewFilterSectionNode[];
+  autoUncheckId?: string;
 };
 
 /**
@@ -60,6 +63,7 @@ const buildTreeLevel = (
   filterKey: string,
   handleCheckboxChange: (checked: boolean, value: string) => void,
   toggleExpand: (value: string) => void,
+  autoUncheckId?: string,
 ) => {
   return treeData.map((node) => {
     return (
@@ -68,6 +72,7 @@ const buildTreeLevel = (
         filterKey={filterKey}
         labeledValue={node.nodeValue}
         selectedIds={selectedIds}
+        autoUncheckId={autoUncheckId}
         handleCheckboxChange={handleCheckboxChange}
         toggleExpand={toggleExpand}
       >
@@ -78,6 +83,7 @@ const buildTreeLevel = (
             filterKey,
             handleCheckboxChange,
             toggleExpand,
+            autoUncheckId,
           )}
       </TreeViewFilterSectionItem>
     );
@@ -106,6 +112,7 @@ export const buildTreeView = (
         props.filterkey,
         handleCheckboxChange,
         toggleExpand,
+        props.autoUncheckId,
       )}
     </>
   );
@@ -231,7 +238,11 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
   /**
    * A for updating the selected nodes in the filter settings state
    */
-  const handleCheckboxClick = (checked: boolean, nodeId: string) => {
+  const handleCheckboxClick = (
+    checked: boolean,
+    nodeId: string,
+    autoUncheckId?: string,
+  ) => {
     let updatedSelectedIds = selectedIds;
 
     if (checked) {
@@ -240,7 +251,13 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
           setMaxSelectionAlert(true);
           return;
         } else {
-          updatedSelectedIds = [...selectedIds, nodeId];
+          let selectedIdsFiltered = selectedIds;
+          if (autoUncheckId) {
+            selectedIdsFiltered = selectedIds.filter(
+              (id) => id !== autoUncheckId,
+            );
+          }
+          updatedSelectedIds = [...selectedIdsFiltered, nodeId];
         }
       } else {
         updatedSelectedIds = [nodeId];

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -13,8 +13,13 @@ type TreeViewFilterSectionItemProps = PropsWithChildren<{
   filterKey: string;
   labeledValue: FilterSettingsValue;
   selectedIds: string[];
-  handleCheckboxChange: (checked: boolean, value: string) => void;
+  handleCheckboxChange: (
+    checked: boolean,
+    value: string,
+    autoUncheckId?: string,
+  ) => void;
   toggleExpand: (value: string) => void;
+  autoUncheckId?: string;
 }>;
 
 /**
@@ -35,6 +40,7 @@ export const TreeViewFilterSectionItem = (
     selectedIds,
     handleCheckboxChange,
     toggleExpand,
+    autoUncheckId,
   } = props;
   const isSelected = selectedIds.includes(labeledValue.value);
 
@@ -51,7 +57,11 @@ export const TreeViewFilterSectionItem = (
             data-testid={`checkbox-${filterKey}-${labeledValue.value}`}
             checked={isSelected}
             onClick={(event) => {
-              handleCheckboxChange(!isSelected, labeledValue.value);
+              handleCheckboxChange(
+                !isSelected,
+                labeledValue.value,
+                autoUncheckId,
+              );
               event.stopPropagation();
             }}
             onKeyUp={(event) => {


### PR DESCRIPTION
Har lagt til en trevisning der registernavn vises som barn-noder av fagområde. Man kan velge en eller flere register og fagområder. En ekstra feature er at valget for "Alle" automatisk fjernes når man velger huker av et annet fagområde eller register. Det er en generell feature som gjelder trevisninger som aktiveres når "autouncheckid" er satt