### PR TITLE
Bruk kortnavn på register i stedet for langt navn

### DIFF
--- a/apps/api/src/models/info/names.ts
+++ b/apps/api/src/models/info/names.ts
@@ -3,7 +3,13 @@ import { RegisterName } from "types";
 
 export const registerNamesModel = (): Promise<RegisterName[]> =>
   db
-    .select("id", "name as rname", "full_name", "vw_registry_contexts.*")
+    .select(
+      "id",
+      "name as rname",
+      "full_name",
+      "short_name",
+      "vw_registry_contexts.*",
+    )
     .from("registry")
     .leftJoin(
       "vw_registry_contexts",

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/filterMenuOptions.ts
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/filterMenuOptions.ts
@@ -129,7 +129,7 @@ export const getMedicalFields = (medicalFieldData: any, registryData: any) => {
             valueLabel:
               registryData.find(
                 (reg: { rname: string }) => reg.rname === register,
-              )?.full_name ?? register,
+              )?.short_name ?? register,
           },
         })),
       }),

--- a/packages/qmongjs/src/components/SelectRegister/index.tsx
+++ b/packages/qmongjs/src/components/SelectRegister/index.tsx
@@ -47,7 +47,7 @@ const SelectRegister = (props: selectedRegisterProps) => {
             .filter(
               (reg) =>
                 reg.rname?.toLowerCase().includes(value.toLocaleLowerCase()) ||
-                reg.full_name
+                reg.short_name
                   ?.toLowerCase()
                   .includes(value.toLocaleLowerCase()),
             )
@@ -64,7 +64,7 @@ const SelectRegister = (props: selectedRegisterProps) => {
         );
 
   filteredReg.sort((a, b) =>
-    a.full_name > b.full_name ? 1 : b.full_name > a.full_name ? -1 : 0,
+    a.short_name > b.short_name ? 1 : b.short_name > a.short_name ? -1 : 0,
   );
 
   return (
@@ -119,7 +119,7 @@ const SelectRegister = (props: selectedRegisterProps) => {
                   passHref
                   onClick={() => updateBtnToggle(!btnToggle)}
                 >
-                  {reg.full_name}
+                  {reg.short_name}
                 </Link>
               </li>
             );

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -80,6 +80,7 @@ export interface RegisterName {
   id: number;
   rname: string;
   full_name: string;
+  short_name: string;
   caregiver_data: 0 | 1 | null;
   resident_data: 0 | 1 | null;
   dg_data: 0 | 1 | null;


### PR DESCRIPTION
Dropper ordene norsk/nasjonalt/register, som gikk igjen hos alle. Ekstra kolonne i db må inn for at det skal fungere

Menyene vil se ut som følger:

![image](https://github.com/mong/mongts/assets/136346/b9a161b1-3344-412b-9773-883a0abc1815)

![image](https://github.com/mong/mongts/assets/136346/4f62a0d6-56eb-494a-bdac-6ca030b96d82)

Ser slik ut i dag:

![image](https://github.com/mong/mongts/assets/136346/410e4c04-98ef-47c2-834e-5b2193923135)


![image](https://github.com/mong/mongts/assets/136346/2618319f-ed51-4d71-9367-4078b84ca914)
