### PR TITLE
2304 search box in tree views

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -323,6 +323,7 @@ export function TreatmentQualityFilterMenu({
           sectionid={medicalFieldKey}
           sectiontitle="Fagområder"
           filterkey={medicalFieldKey}
+          searchbox={true}
         />
         <TreeViewFilterSection
           refreshState={shouldRefreshInititalState}
@@ -337,6 +338,7 @@ export function TreatmentQualityFilterMenu({
           sectionid={treatmentUnitsKey}
           sectiontitle="Behandlingsenheter"
           filterkey={treatmentUnitsKey}
+          searchbox={true}
         />
       </FilterMenu>
     </>

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -183,13 +183,14 @@ export const initFilterSettingsValuesMap = (
 };
 
 /**
- * Initializes the default expanded nodes for the TreeView
+ * Gets a list of the nodes to expand, including their anchestor ids, given the
+ * selectedIds, which can be at various levels.
  *
  * @param selectedIds The selected node ids
  * @param filterSettingsValuesMap The map used for looking up FilterSettingValues by node ids
- * @returns A list of node ids that should be expanded by default
+ * @returns A list of node ids that should be expanded
  */
-export const initDefaultExpanded = (
+export const buildExpandedNodeList = (
   selectedIds: string[],
   filterSettingsValuesMap: Map<string, TreeViewFilterSettingsValue>,
 ) => {
@@ -224,30 +225,35 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
   const isMultiSelect = props.multiselect ?? true;
   const searchBox = props.searchbox ?? false;
   const maxSelections = props.maxselections;
+  const autoUncheckId = props.autouncheckid;
   const filterKey = props.filterkey;
   const treeData = props.treedata;
   const selectedIds = getSelectedNodeIds(filterSettings.map.get(filterKey));
   const filterSettingsValuesMap = initFilterSettingsValuesMap(treeData);
   const [showMaxSelectionAlert, setMaxSelectionAlert] = useState(false);
   const [expanded, setExpanded] = useState(
-    initDefaultExpanded(selectedIds, filterSettingsValuesMap),
+    buildExpandedNodeList(selectedIds, filterSettingsValuesMap),
   );
   const [treeViewKey, setTreeViewKey] = useState(0);
 
   useEffect(() => {
-    setExpanded(initDefaultExpanded(selectedIds, filterSettingsValuesMap));
+    setExpanded(buildExpandedNodeList(selectedIds, filterSettingsValuesMap));
     setTreeViewKey(treeViewKey + 1);
   }, [props.refreshState]);
 
   /**
-   * A for updating the selected nodes in the filter settings state
+   * Handler for updating the selected nodes in the filter settings state
    */
   const handleCheckboxClick = (
     checked: boolean,
-    nodeId: string,
+    nodeIds: string | string[],
     autoUncheckId?: string,
   ) => {
     let updatedSelectedIds = selectedIds;
+
+    if (!Array.isArray(nodeIds)) {
+      nodeIds = [nodeIds];
+    }
 
     if (checked) {
       if (isMultiSelect) {
@@ -256,19 +262,23 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
           return;
         } else {
           let selectedIdsFiltered = selectedIds;
-          if (autoUncheckId && nodeId !== autoUncheckId) {
+          if (autoUncheckId && !nodeIds.includes(autoUncheckId)) {
             selectedIdsFiltered = selectedIds.filter(
               (id) => id !== autoUncheckId,
             );
-            updatedSelectedIds = [...selectedIdsFiltered, nodeId];
-          } else if (nodeId === autoUncheckId) {
-            updatedSelectedIds = [nodeId];
+            updatedSelectedIds = Array.from(
+              new Set(selectedIdsFiltered.concat(nodeIds)),
+            );
+          } else if (autoUncheckId && nodeIds.includes(autoUncheckId)) {
+            updatedSelectedIds = [autoUncheckId];
           } else {
-            updatedSelectedIds = [...selectedIds, nodeId];
+            updatedSelectedIds = Array.from(
+              new Set(selectedIdsFiltered.concat(nodeIds)),
+            );
           }
         }
       } else {
-        updatedSelectedIds = [nodeId];
+        updatedSelectedIds = nodeIds;
       }
 
       const selectedFilterSettingValues = updatedSelectedIds
@@ -293,7 +303,9 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
         type: FilterSettingsActionType.DEL_SECTION_SELECTIONS,
         sectionSetting: {
           key: filterKey,
-          values: [{ value: nodeId, valueLabel: "" }],
+          values: nodeIds.map((nodeId) => {
+            return { value: nodeId, valueLabel: "" };
+          }),
         },
       });
     }
@@ -301,6 +313,23 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
     if (maxSelections !== undefined) {
       setMaxSelectionAlert(false);
     }
+  };
+
+  /**
+   * Search handler for the search box. Selects and expands matching nodes
+   *
+   * @param searchText The text entered in the search box
+   */
+  const handleSearch = (nodeIds: string[]) => {
+    handleCheckboxClick(true, nodeIds, autoUncheckId);
+    const nodeAndAnchestorIds = buildExpandedNodeList(
+      nodeIds,
+      filterSettingsValuesMap,
+    );
+    const newExpanded = Array.from(
+      new Set<string>(expanded.concat(nodeAndAnchestorIds)),
+    );
+    setExpanded(newExpanded);
   };
 
   /** Toggle expanded state for a node */
@@ -320,6 +349,7 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
       {searchBox && (
         <TreeViewSearchBox
           options={Array.from(filterSettingsValuesMap.values())}
+          onSearch={handleSearch}
         />
       )}
       <TreeView

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -13,6 +13,7 @@ import { FilterSettingsDispatchContext } from "./FilterSettingsReducer";
 import { FilterSettingsActionType } from "./FilterSettingsReducer";
 import { TreeViewFilterSectionItem } from "./TreeViewFilterSectionItem";
 import Alert from "@mui/material/Alert";
+import TreeViewSearchBox from "./TreeViewSearchBox";
 
 /**
  * The structure of a node in the tree data used with the TreeViewFilterSection
@@ -46,6 +47,7 @@ export type TreeViewSectionProps = FilterMenuSectionProps & {
   maxselections?: number;
   treedata: TreeViewFilterSectionNode[];
   autouncheckid?: string;
+  searchbox?: boolean;
 };
 
 /**
@@ -220,6 +222,7 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
   const filterSettingsDispatch = useContext(FilterSettingsDispatchContext);
 
   const isMultiSelect = props.multiselect ?? true;
+  const searchBox = props.searchbox ?? false;
   const maxSelections = props.maxselections;
   const filterKey = props.filterkey;
   const treeData = props.treedata;
@@ -313,6 +316,11 @@ export function TreeViewFilterSection(props: TreeViewSectionProps) {
     <Box>
       {showMaxSelectionAlert && (
         <Alert severity="warning">{`Du kan maksimalt huke av ${maxSelections} valg.`}</Alert>
+      )}
+      {searchBox && (
+        <TreeViewSearchBox
+          options={Array.from(filterSettingsValuesMap.values())}
+        />
       )}
       <TreeView
         key={treeViewKey}

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
@@ -8,21 +8,21 @@ export type TreeViewSearchBoxProps = {
 
 interface AutocompleteOption {
   label: string;
-  displayText: string;
 }
 
 export function TreeViewSearchBox(props: TreeViewSearchBoxProps) {
   const hintText = props.hintText || "Søk...";
   const options: AutocompleteOption[] = props.options.map((option) => ({
-    displayText: option.valueLabel,
-    label: option.value,
+    label: option.valueLabel,
   }));
 
   return (
     <>
       <Autocomplete
         autoHighlight
-        options={options}
+        options={Array.from(
+          new Set<string>(options.map((option) => option.label)),
+        )}
         renderInput={(params) => <TextField {...params} label={hintText} />}
       />
     </>

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
@@ -4,16 +4,19 @@ import { TreeViewFilterSettingsValue } from "./TreeViewFilterSection";
 export type TreeViewSearchBoxProps = {
   hintText?: string;
   options: TreeViewFilterSettingsValue[];
+  onSearch: (nodeValues: string[]) => void;
 };
 
 interface AutocompleteOption {
   label: string;
+  value: string;
 }
 
 export function TreeViewSearchBox(props: TreeViewSearchBoxProps) {
   const hintText = props.hintText || "Søk...";
   const options: AutocompleteOption[] = props.options.map((option) => ({
     label: option.valueLabel,
+    value: option.value,
   }));
 
   return (
@@ -24,6 +27,15 @@ export function TreeViewSearchBox(props: TreeViewSearchBoxProps) {
           new Set<string>(options.map((option) => option.label)),
         )}
         renderInput={(params) => <TextField {...params} label={hintText} />}
+        onChange={(_, newValue) => {
+          if (newValue) {
+            props.onSearch(
+              options
+                .filter((option) => option.label === newValue)
+                .map((option) => option.value),
+            );
+          }
+        }}
       />
     </>
   );

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewSearchBox.tsx
@@ -1,0 +1,32 @@
+import { Autocomplete, TextField } from "@mui/material";
+import { TreeViewFilterSettingsValue } from "./TreeViewFilterSection";
+
+export type TreeViewSearchBoxProps = {
+  hintText?: string;
+  options: TreeViewFilterSettingsValue[];
+};
+
+interface AutocompleteOption {
+  label: string;
+  displayText: string;
+}
+
+export function TreeViewSearchBox(props: TreeViewSearchBoxProps) {
+  const hintText = props.hintText || "Søk...";
+  const options: AutocompleteOption[] = props.options.map((option) => ({
+    displayText: option.valueLabel,
+    label: option.value,
+  }));
+
+  return (
+    <>
+      <Autocomplete
+        autoHighlight
+        options={options}
+        renderInput={(params) => <TextField {...params} label={hintText} />}
+      />
+    </>
+  );
+}
+
+export default TreeViewSearchBox;


### PR DESCRIPTION
For å kunne søke i trevisningene i filtermenyen, er det lagt til en søkeboks over treet.

Det søkes i visningsnavnet til nodene. Treffene er case-insensitive. 

Treff vises i en nedtrekksmeny.

Når brukeren trykker Enter etter å ha valgt, velges noden. Allerede valgte noder blir ikke endret. 

Valget ekspanderes i treet, slik at brukeren ser posisjonen i treet til det som ble valgt. 

Fremtidige forbedringer som ikke er med i denne pull-requesten:
* Noder med ulike id-er, men samme _visningsnavn_ blir valgt samtidig. Bør kunne skille disse på et vis.
* Søkeboksen nullstilles ikke etter et valg, slik at siste valg fortsatt vises i tekstboksen.


![image](https://github.com/mong/mongts/assets/9477329/6d4b878e-3b35-4272-ae12-591d10fde948)
