### PR TITLE
Bug-fiks i ny tabell

### DIFF
--- a/apps/skde/src/components/TreatmentQuality/index.ts
+++ b/apps/skde/src/components/TreatmentQuality/index.ts
@@ -211,7 +211,7 @@ export const IndicatorTableWrapper = styled(Box)(({ theme }) => ({
 }));
 
 export const IndicatorTableV2Wrapper = styled(Box)(({ theme }) => ({
-  "& table": {
+  "& .MuiTable-root": {
     tableLayout: "fixed",
     width: "100vw",
     paddingLeft: theme.spacing(6),


### PR DESCRIPTION
Styling var satt på `table` istedenfor `MuiTable`

![image](https://github.com/mong/mongts/assets/64078729/4683c8cf-fd83-4ab9-866b-fa04130457a8)
