### PR TITLE
Dropp redefinering av lastCompleteYear før linechart

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/Chart.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/Chart.tsx
@@ -154,14 +154,5 @@ const GetLineChart = (props: ChartProps) => {
     )
     .sort((a: Indicator, b: Indicator) => b.year - a.year);
 
-  // get the last year with complete data
-  const lastCompleteYear: number | undefined = data
-    ? data[0].delivery_latest_affirm
-      ? new Date(data[0].delivery_latest_affirm).getFullYear() - 1
-      : undefined
-    : undefined;
-
-  return (
-    <LineChart {...props} data={data} lastCompleteYear={lastCompleteYear} />
-  );
+  return <LineChart {...props} data={data} />;
 };

--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/__tests__/chart.test.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/__tests__/chart.test.tsx
@@ -166,6 +166,7 @@ test("Line", async () => {
       showLevel={true}
       selectedTreatmentUnits={[]}
       indicatorData={[]}
+      lastCompleteYear={2018}
     />,
   );
 


### PR DESCRIPTION
Var allerede definert, og lå i props. Ble definert forskjellig i de to tilfellene. Må legge på ett par dager slik at 31.12 blir 01.01.

Closes #2469