### PR TITLE
Kollaps filtermeny når man klikker utenfor eller velger enhet

### DIFF
--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -234,7 +234,7 @@ export const Skde = (): JSX.Element => {
                         filterkey={treatmentUnitsKey}
                         searchbox={true}
                         multiselect={false}
-                        accordion={"false"}
+                        accordion={false}
                         noShadow={true}
                       />
                     </FilterMenu>

--- a/packages/qmongjs/src/components/FilterMenu/RadioGroupFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/RadioGroupFilterSection.tsx
@@ -46,7 +46,7 @@ export const RadioGroupFilterSection = (
 
   return (
     <FormControl>
-      {accordion === "false" && (
+      {accordion === false && (
         <FormLabel id={`filter-section-radio-group-label-${props.sectionid}`}>
           {props.sectiontitle}
         </FormLabel>

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -355,7 +355,7 @@ export function TreatmentQualityFilterMenu({
         onFilterInitialized={onFilterInitialized}
       >
         <SelectedFiltersSection
-          accordion="false"
+          accordion={false}
           filterkey="selectedfilters"
           sectionid="selectedfilters"
           sectiontitle="Valgte filtre"

--- a/packages/qmongjs/src/components/FilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/index.tsx
@@ -68,7 +68,7 @@ export type FilterMenuSectionProps = PropsWithChildren<{
   sectionid: string;
   sectiontitle: string;
   filterkey: string;
-  accordion?: string;
+  accordion?: boolean;
   noShadow?: boolean;
   defaultvalues?: FilterSettingsValue[];
   initialselections?: FilterSettingsValue[];
@@ -86,7 +86,7 @@ const FilterMenuSection = ({
   noShadow,
   children,
 }: FilterMenuSectionProps) => {
-  if (accordion === "false") {
+  if (accordion === false) {
     if (noShadow === true) {
       return (
         <Box key={`fms-box-${sectionid}`}>


### PR DESCRIPTION
- Har satt filtermenyen inn i en `accordion` og lagt til en click-tracker som lukker menyen nårt man velger en enhet eller klikker utenfor menyen. 
- Lagt til parameter `noShadow` i `TreeViewFilterSection` som gjør at filtermenyen bruker `Box` istedenfor `Card`. Kanten på filtermenyen inne i accordion-modulen blir da ikke synlig.
- Endret accordion-parameteren fra `string` til `boolean` ettersom man sjekker etter "true" eller "false". 
- Endret plassering av fagområdetabeller slik at de kommer oppå hverandre istedenfor ved siden av. 

![image](https://github.com/mong/mongts/assets/64078729/694a1f1f-5587-4fe9-8f3c-8166f8040a88)
