### PR TITLE
Inkluder sorteringsvariabel på hf/rhf i api

### DIFF
--- a/apps/api/src/helpers/functions/nestUnitNames.ts
+++ b/apps/api/src/helpers/functions/nestUnitNames.ts
@@ -14,20 +14,22 @@ export const nestTuNames = (
     return a.hospital > b.hospital ? 1 : a.hospital < b.hospital ? -1 : 0;
   });
   tu_names.sort((a, b) => {
-    return a.hf_full > b.hf_full ? 1 : a.hf_full < b.hf_full ? -1 : 0;
+    return a.hf_sort > b.hf_sort ? 1 : a.hf_sort < b.hf_sort ? -1 : 0;
   });
   tu_names.sort((a, b) => {
-    return a.rhf > b.rhf ? 1 : a.rhf < b.rhf ? -1 : 0;
+    return a.rhf_sort > b.rhf_sort ? 1 : a.rhf_sort < b.rhf_sort ? -1 : 0;
   });
 
   const nested_tu_names = tu_names.reduce((acc, cur) => {
     if (acc.length === 0 || acc.every((tu_entry) => tu_entry.rhf !== cur.rhf)) {
       const entry = {
         rhf: cur.rhf,
+        rhf_sort: cur.rhf_sort,
         hf: [
           {
             hf: cur.hf,
             hf_full: cur.hf_full,
+            hf_sort: cur.hf_sort,
             hospital: [cur.hospital],
           },
         ],
@@ -44,6 +46,7 @@ export const nestTuNames = (
         const hf_entry = {
           hf: cur.hf,
           hf_full: cur.hf_full,
+          hf_sort: cur.hf_sort,
           hospital: [cur.hospital],
         };
         acc.filter((acc_data) => acc_data.rhf === cur.rhf)[0].hf.push(hf_entry);

--- a/apps/api/src/models/data/unitNames.ts
+++ b/apps/api/src/models/data/unitNames.ts
@@ -65,7 +65,9 @@ export const unitNamesAllLevels = (): Promise<TuName[]> =>
       "hospital.short_name as hospital",
       "hf.short_name as hf",
       "hf.full_name as hf_full",
+      "hf.sorting as hf_sort",
       "rhf.short_name as rhf",
+      "rhf.sorting as rhf_sort",
     )
     .from("hospital")
     .leftJoin("hf", "hospital.hf_orgnr", "hf.orgnr")

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -57,14 +57,18 @@ export interface TuName {
   hospital: string;
   hf: string;
   hf_full: string;
+  hf_sort: number;
   rhf: string;
+  rhf_sort: number;
 }
 
 export interface NestedTreatmentUnitName {
   rhf: string;
+  rhf_sort: number;
   hf: {
     hf: string;
     hf_full: string;
+    hf_sort: number;
     hospital: string[];
   }[];
 }


### PR DESCRIPTION
Gjelder den nestede strukturen av RHF/HF/sykehus.

Relatert til og som en del av løsningen på #2450 og #2468