### PR TITLE
nedgrader react til 18.2.0

### DIFF
--- a/apps/skde/package.json
+++ b/apps/skde/package.json
@@ -48,7 +48,7 @@
     "next": "14.2.3",
     "next-query-params": "5.0.0",
     "qmongjs": "*",
-    "react": "18.3.1",
+    "react": "18.2.0",
     "react-icons": "5.2.1",
     "react-spring": "9.7.3",
     "rehype-raw": "7.0.0",

--- a/packages/qmongjs/package.json
+++ b/packages/qmongjs/package.json
@@ -47,7 +47,7 @@
     "d3": "7.9.0",
     "d3-format": "3.1.0",
     "next": "14.2.3",
-    "react": "18.3.1",
+    "react": "18.2.0",
     "react-dom": "18.3.1",
     "react-icons": "5.2.1",
     "react-select": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19711,7 +19711,7 @@ __metadata:
     next-query-params: "npm:5.0.0"
     next-router-mock: "npm:0.9.13"
     prettier: "npm:3.2.5"
-    react: "npm:18.3.1"
+    react: "npm:18.2.0"
     react-dom: "npm:18.3.1"
     react-icons: "npm:5.2.1"
     react-markdown: "npm:9.0.1"
@@ -20487,16 +20487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
-  languageName: node
-  linkType: hard
-
-"react@npm:^18.2.0":
+"react@npm:18.2.0, react@npm:^18.2.0":
   version: 18.2.0
   resolution: "react@npm:18.2.0"
   dependencies:
@@ -22022,7 +22013,7 @@ __metadata:
     next-router-mock: "npm:0.9.13"
     prettier: "npm:3.2.5"
     qmongjs: "npm:*"
-    react: "npm:18.3.1"
+    react: "npm:18.2.0"
     react-icons: "npm:5.2.1"
     react-markdown: "npm:9.0.1"
     react-scripts: "npm:5.0.1"


### PR DESCRIPTION
Løser enn så lenge #2460. Kommer en permanent fiks i en senere versjon av React. Se f.eks. https://www.github.com/facebook/react/pull/25927