### PR TITLE
Egen funksjon for å definere siste komplette år.

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/chartrow/Chart.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/chartrow/Chart.tsx
@@ -4,6 +4,7 @@ import BarChart, { Bar, BarStyle } from "../../Charts/BarChart";
 import LineChart from "../../Charts/LineChart";
 import { Level } from "../../Charts/types";
 import { useIndicatorQuery } from "../../../helpers/hooks";
+import { getLastCompleteYear } from "../../../helpers/functions";
 
 export interface ChartProps {
   context: { context: string; type: string };
@@ -155,11 +156,7 @@ const GetLineChart = (props: ChartProps) => {
     .sort((a: Indicator, b: Indicator) => b.year - a.year);
 
   // get the last year with complete data
-  const lastCompleteYear: number | undefined = data
-    ? data[0].delivery_latest_affirm
-      ? new Date(data[0].delivery_latest_affirm).getFullYear() - 1
-      : undefined
-    : undefined;
+  const lastCompleteYear = getLastCompleteYear(data, 0, true);
 
   return (
     <LineChart {...props} data={data} lastCompleteYear={lastCompleteYear} />

--- a/packages/qmongjs/src/components/IndicatorTable/indicatorrow/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/indicatorrow/index.tsx
@@ -11,6 +11,7 @@ import Zoom from "@mui/material/Zoom";
 import { Description, Indicator } from "types";
 import { mainQueryParamsConfig } from "../../../app_config";
 import { level } from "../../../helpers/functions";
+import { getLastCompleteYear } from "../../../helpers/functions";
 
 const formatIndicatorValues = (
   description: Description,
@@ -183,22 +184,7 @@ export const IndicatorRow = (props: IndicatorRowProps) => {
           );
         });
 
-  // Add two day to the delivery_latest_affirm date, in case the date is set to late December.
-  // Thus, if delivery_latest_affirm date is set to December 31 2020 then new date will be January 2 2021.
-  // Then delivery_latest_affirm_year will be defined as 2021 - 1 = 2020.
-  const delivery_latest_affirm_year = indicatorData[0].delivery_latest_affirm
-    ? new Date(
-        new Date(indicatorData[0].delivery_latest_affirm).setDate(
-          new Date(indicatorData[0].delivery_latest_affirm).getDate() + 2,
-        ),
-      ).getFullYear() - 1
-    : undefined;
-
-  // Only define lastCompleteYear if it is before the year of the data.
-  const lastCompleteYear =
-    delivery_latest_affirm_year && treatmentYear > delivery_latest_affirm_year
-      ? delivery_latest_affirm_year
-      : undefined;
+  const lastCompleteYear = getLastCompleteYear(indicatorData, treatmentYear);
 
   const lastCompleteDate = indicatorData[0].delivery_latest_affirm;
 

--- a/packages/qmongjs/src/helpers/functions/getLastCompleteYear.ts
+++ b/packages/qmongjs/src/helpers/functions/getLastCompleteYear.ts
@@ -1,0 +1,28 @@
+import { Indicator } from "types";
+
+export function getLastCompleteYear(
+  indicatorData: Indicator[],
+  treatmentYear: number,
+  alwaysReturnYear: boolean = false,
+): number | undefined {
+  // Add two day to the delivery_latest_affirm date, in case the date is set to late December.
+  // Thus, if delivery_latest_affirm date is set to December 31 2020 then new date will be January 2 2021.
+  // Then delivery_latest_affirm_year will be defined as 2021 - 1 = 2020.
+  const delivery_latest_affirm_year = indicatorData[0].delivery_latest_affirm
+    ? new Date(
+        new Date(indicatorData[0].delivery_latest_affirm).setDate(
+          new Date(indicatorData[0].delivery_latest_affirm).getDate() + 2,
+        ),
+      ).getFullYear() - 1
+    : undefined;
+
+  // Only define lastCompleteYear if it is before the year of the data.
+  const lastCompleteYear =
+    (delivery_latest_affirm_year &&
+      treatmentYear > delivery_latest_affirm_year) ||
+    alwaysReturnYear
+      ? delivery_latest_affirm_year
+      : undefined;
+
+  return lastCompleteYear;
+}

--- a/packages/qmongjs/src/helpers/functions/index.ts
+++ b/packages/qmongjs/src/helpers/functions/index.ts
@@ -5,3 +5,4 @@ export { imgLoader } from "./imgLoader";
 export { level, level2 } from "./defineLevel";
 export { customFormat } from "./localFormater";
 export { levelSymbols, newLevelSymbols } from "./levelSymbols";
+export { getLastCompleteYear } from "./getLastCompleteYear";


### PR DESCRIPTION
Stiplet linje la ikke til ett par dager på valideringsdatoen, slik at data definert som OK etter 31. des. ble stiplet det året. Closes #1871

Funksjonen returnerer undefined hvis år er ok som default.