### PR TITLE
Fiks bryter for datakvalitet i filtermeny

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -313,7 +313,8 @@ export default function TreatmentQualityPage() {
                 <IndicatorTableWrapper className="table-wrapper">
                   <IndicatorTable
                     key="indicator-table"
-                    context={dataQualitySelected ? "coverage" : tableContext}
+                    context={tableContext}
+                    dataQuality={dataQualitySelected}
                     tableType="allRegistries"
                     registerNames={registers}
                     unitNames={selectedTreatmentUnits}

--- a/packages/qmongjs/src/components/FilterMenu/SwitchFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/SwitchFilterSection.tsx
@@ -1,5 +1,11 @@
 import React, { useContext } from "react";
-import { FormControlLabel, FormGroup, Switch } from "@mui/material";
+import {
+  FormControlLabel,
+  FormGroup,
+  Switch,
+  FormHelperText,
+  FormControl,
+} from "@mui/material";
 import { FilterMenuSectionProps } from ".";
 import {
   FilterSettingsContext,
@@ -41,20 +47,26 @@ export function SwitchFilterSection(props: SwitchFilterSectionProps) {
   };
 
   return (
-    <FormGroup aria-label={props.label} row>
-      <FormControlLabel
-        labelPlacement="start"
-        label={labelText}
-        control={
-          <Switch
-            checked={!disabled && isChecked}
-            onChange={handleChange}
-            color="primary"
-            disabled={disabled}
-          />
-        }
-      />
-    </FormGroup>
+    <FormControl>
+      <FormHelperText sx={{ fontSize: 16 }}>
+        Bytter visning av kvalitetsindikatorer til indikatorer for dekningsgrad.
+        Dekningsgrad sier noe om datakvalitet for kvalitetsindikatoren.
+      </FormHelperText>
+      <FormGroup aria-label={props.label} row>
+        <FormControlLabel
+          labelPlacement="start"
+          label={labelText}
+          control={
+            <Switch
+              checked={!disabled && isChecked}
+              onChange={handleChange}
+              color="primary"
+              disabled={disabled}
+            />
+          }
+        />
+      </FormGroup>
+    </FormControl>
   );
 }
 

--- a/packages/qmongjs/src/components/FilterMenu/SwitchFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/SwitchFilterSection.tsx
@@ -18,11 +18,9 @@ import { getSelectedValue } from "./utils";
 export type SwitchFilterSectionProps = FilterMenuSectionProps & {
   label: string;
   activatedswitchvalue: FilterSettingsValue;
-  disabled?: boolean;
 };
 
 export function SwitchFilterSection(props: SwitchFilterSectionProps) {
-  const disabled = props.disabled ?? false;
   const labelText = props.label;
   const filterKey = props.filterkey;
   const activatedSwitchValue = props.activatedswitchvalue;
@@ -58,10 +56,9 @@ export function SwitchFilterSection(props: SwitchFilterSectionProps) {
           label={labelText}
           control={
             <Switch
-              checked={!disabled && isChecked}
+              checked={isChecked}
               onChange={handleChange}
               color="primary"
-              disabled={disabled}
             />
           }
         />

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -426,7 +426,6 @@ export function TreatmentQualityFilterMenu({
               : undefined
           }
           activatedswitchvalue={dataQualitySelectedValue}
-          disabled={context === "resident"}
         />
       </FilterMenu>
     </>

--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -4,6 +4,7 @@ import { RegisterName } from "types";
 
 export interface IndicatorTableProps {
   context: string;
+  dataQuality: boolean;
   tableType: "allRegistries" | "singleRegister";
   colspan: number;
   descriptionHeader?: string;
@@ -21,6 +22,7 @@ export interface IndicatorTableProps {
 export const IndicatorTable = (props: IndicatorTableProps) => {
   const {
     context,
+    dataQuality,
     tableType,
     unitNames = ["Nasjonalt"],
     treatmentYear = 2019,
@@ -45,6 +47,7 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
       />
       <IndicatorTableBody
         context={context}
+        dataQuality={dataQuality}
         tableType={tableType}
         colspan={colspan}
         registerNames={registerNames}

--- a/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
@@ -4,6 +4,7 @@ import { NoDataAvailible } from "../ContenForEmptyTable";
 
 export interface IndicatorTableBodyProps {
   context: string;
+  dataQuality: boolean;
   tableType: "allRegistries" | "singleRegister";
   colspan: number;
   registerNames: RegisterName[];
@@ -17,6 +18,7 @@ export interface IndicatorTableBodyProps {
 export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
   const {
     context,
+    dataQuality,
     tableType,
     colspan,
     registerNames,
@@ -35,6 +37,7 @@ export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
       return (
         <TableBlock
           context={context}
+          dataQuality={dataQuality}
           tableType={tableType}
           key={`${register.rname}`}
           registerName={register}

--- a/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
@@ -10,6 +10,7 @@ import { Description, Indicator, RegisterName } from "types";
 
 export interface TableBlockProps {
   context: string;
+  dataQuality: boolean;
   tableType: "allRegistries" | "singleRegister";
   registerName: RegisterName;
   blockTitle?: string;
@@ -24,6 +25,7 @@ export interface TableBlockProps {
 export const TableBlock = (props: TableBlockProps) => {
   const {
     context,
+    dataQuality,
     tableType,
     registerName,
     colspan,
@@ -34,10 +36,11 @@ export const TableBlock = (props: TableBlockProps) => {
     blockTitle,
     unitNames,
   } = props;
-  const queryContext =
-    context === "coverage"
-      ? { context: "caregiver", type: "dg" }
-      : { context, type: "ind" };
+  const queryContext = dataQuality
+    ? { context, type: "dg" }
+    : { context, type: "ind" };
+
+  console.log(queryContext);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const indicatorDataQuery: UseQueryResult<any, unknown> = useIndicatorQuery({

--- a/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
@@ -40,8 +40,6 @@ export const TableBlock = (props: TableBlockProps) => {
     ? { context, type: "dg" }
     : { context, type: "ind" };
 
-  console.log(queryContext);
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const indicatorDataQuery: UseQueryResult<any, unknown> = useIndicatorQuery({
     registerShortName: registerName.rname,

--- a/packages/qmongjs/src/components/RegisterPage/SelectedRegister.tsx
+++ b/packages/qmongjs/src/components/RegisterPage/SelectedRegister.tsx
@@ -236,7 +236,8 @@ export const SelectedRegister = ({ registerNames }: SelectedRegisterProps) => {
         <div className={styles.contentContainer}>
           <div className={styles.mainTableContainer}>
             <IndicatorTable
-              context={context}
+              context={context === "coverage" ? "caregiver" : context}
+              dataQuality={context === "coverage"}
               tableType={"singleRegister"}
               registerNames={registerInfo}
               unitNames={[...validated_treatment_units, "Nasjonalt"]}

--- a/packages/qmongjs/src/components/RegisterPage/main_component.tsx
+++ b/packages/qmongjs/src/components/RegisterPage/main_component.tsx
@@ -120,7 +120,8 @@ const Main = (props: Props) => {
         </div>
         <div className={styles.mainTableContainer}>
           <IndicatorTable
-            context={context}
+            context={context === "coverage" ? "caregiver" : context}
+            dataQuality={context === "coverage"}
             tableType="allRegistries"
             registerNames={orderedRegisterList}
             unitNames={[...treatment_units, "Nasjonalt"]}


### PR DESCRIPTION
Man kan nå velge å vise datakvalitet for opptaksområde. 

![image](https://github.com/mong/mongts/assets/64078729/c79060f0-9b37-4509-befb-b7ad0b4df83b)
