### PR TITLE
Fiks i lenke i tabell i datakvalitetsfane

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
@@ -116,12 +116,12 @@ export const TableBlock = (props: TableBlockProps) => {
   });
 
   const tabName =
-    context === "caregiver" && registerName.caregiver_data
-      ? "sykehus"
-      : context === "resident" && registerName.resident_data
-        ? "opptaksomraade"
-        : context === "coverage" && registerName.dg_data
-          ? "datakvalitet"
+    dataQuality && registerName.dg_data
+      ? "datakvalitet"
+      : context === "caregiver" && registerName.caregiver_data
+        ? "sykehus"
+        : context === "resident" && registerName.resident_data
+          ? "opptaksomraade"
           : "sykehus";
 
   return (


### PR DESCRIPTION
Context ble endret i PR #2620, så context lik coverage ikke lenger finnes. Lenker til register ble derfor feil i tabell hvis man var på datakvalitetsfanen, siden den var avhengig av dette.