### PR TITLE
Egen Header-komponent

### DIFF
--- a/apps/skde/src/components/Header/HeaderMiddle.tsx
+++ b/apps/skde/src/components/Header/HeaderMiddle.tsx
@@ -8,7 +8,13 @@ const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   paddingBottom: theme.spacing(8),
 }));
 
-export const HeaderMiddleToolbar = () => {
+type HeaderMiddleProps = {
+  page: "behandlingskvalitet" | "pasientstrømmer";
+};
+
+export const HeaderMiddle = (props: HeaderMiddleProps) => {
+  const { page } = props;
+
   return (
     <StyledToolbar className="header-middle">
       <Grid container spacing={2} rowSpacing={6}>
@@ -20,12 +26,14 @@ export const HeaderMiddleToolbar = () => {
             Resultater fra nasjonale medisinske kvalitetsregistre
           </Typography>
         </Grid>
-        <ArrowLink
-          href={"https://www.kvalitetsregistre.no/"}
-          text={"Om kvalitetsregistre"}
-          externalLink={true}
-          button={true}
-        />
+        {page === "behandlingskvalitet" ? (
+          <ArrowLink
+            href={"https://www.kvalitetsregistre.no/"}
+            text={"Om kvalitetsregistre"}
+            externalLink={true}
+            button={true}
+          />
+        ) : null}
       </Grid>
     </StyledToolbar>
   );

--- a/apps/skde/src/components/Header/HeaderMiddle.tsx
+++ b/apps/skde/src/components/Header/HeaderMiddle.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Toolbar, Typography, styled } from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2";
 import { ArrowLink } from "../ArrowLink";
@@ -15,25 +16,38 @@ type HeaderMiddleProps = {
 export const HeaderMiddle = (props: HeaderMiddleProps) => {
   const { page } = props;
 
+  let linkButton;
+  let headerTitle: string;
+  let headerSubtitle: string;
+
+  if (page === "behandlingskvalitet") {
+    linkButton = (
+      <ArrowLink
+        href={"https://www.kvalitetsregistre.no/"}
+        text={"Om kvalitetsregistre"}
+        externalLink={true}
+        button={true}
+      />
+    );
+
+    headerTitle = "Behandlingskvalitet";
+    headerSubtitle = "Resultater fra nasjonale medisinske kvalitetsregistre";
+  } else if (page === "pasientstrømmer") {
+    linkButton = null;
+
+    headerTitle = "Pasientstrømmer";
+    headerSubtitle = "Resultater fra pasientstrømmer";
+  }
   return (
     <StyledToolbar className="header-middle">
       <Grid container spacing={2} rowSpacing={6}>
         <Grid xs={12}>
-          <Typography variant="h1">Behandlingskvalitet</Typography>
+          <Typography variant="h1">{headerTitle}</Typography>
         </Grid>
         <Grid xs={12}>
-          <Typography variant="h6">
-            Resultater fra nasjonale medisinske kvalitetsregistre
-          </Typography>
+          <Typography variant="h6">{headerSubtitle}</Typography>
         </Grid>
-        {page === "behandlingskvalitet" ? (
-          <ArrowLink
-            href={"https://www.kvalitetsregistre.no/"}
-            text={"Om kvalitetsregistre"}
-            externalLink={true}
-            button={true}
-          />
-        ) : null}
+        {linkButton}
       </Grid>
     </StyledToolbar>
   );

--- a/apps/skde/src/components/Header/HeaderTop.tsx
+++ b/apps/skde/src/components/Header/HeaderTop.tsx
@@ -23,7 +23,7 @@ const StyledBreadcrumbSeparator = styled(NavigateNextRounded)(({ theme }) => ({
   color: theme.palette.primary.light,
 }));
 
-const SkdeBreadcrumbs = () => {
+const TreatmentQualityBreadcrumbs = () => {
   return (
     <Breadcrumbs
       separator={<StyledBreadcrumbSeparator fontSize="large" />}
@@ -52,7 +52,42 @@ const SkdeBreadcrumbs = () => {
   );
 };
 
-export const TreatmentQualityHeaderTop = () => {
+const PasientstrommerBreadcrumbs = () => {
+  return (
+    <Breadcrumbs
+      separator={<StyledBreadcrumbSeparator fontSize="large" />}
+      aria-label="breadcrumb"
+    >
+      <Link
+        underline="hover"
+        key="1"
+        color="inherit"
+        href="https://www.skde.no"
+      >
+        Forside
+      </Link>
+      <Link
+        underline="hover"
+        key="2"
+        color="inherit"
+        href="https://www.skde.no/om-skde/analyseseksjonen/"
+      >
+        Analyseseksjonen
+      </Link>
+      <Typography key="3" color="text.primary">
+        Pasientstrømmer
+      </Typography>
+    </Breadcrumbs>
+  );
+};
+
+type HeaderTopProps = {
+  page: "behandlingskvalitet" | "pasientstrømmer";
+};
+
+export const HeaderTop = (props: HeaderTopProps) => {
+  const { page } = props;
+
   return (
     <StyledToolbar className="header-top">
       <Grid container spacing={2}>
@@ -60,11 +95,15 @@ export const TreatmentQualityHeaderTop = () => {
           <LogoImage src="/img/logos/skde-blue.png" alt="SKDE logo" />
         </Grid>
         <Grid xs={12}>
-          <SkdeBreadcrumbs />
+          {page === "behandlingskvalitet" ? (
+            <TreatmentQualityBreadcrumbs />
+          ) : page === "pasientstrømmer" ? (
+            <PasientstrommerBreadcrumbs />
+          ) : null}
         </Grid>
       </Grid>
     </StyledToolbar>
   );
 };
 
-export default TreatmentQualityHeaderTop;
+export default HeaderTop;

--- a/apps/skde/src/components/Header/index.tsx
+++ b/apps/skde/src/components/Header/index.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import HeaderTop from "./HeaderTop";
+import { HeaderMiddle } from "./HeaderMiddle";
+
+type HeaderProps = {
+  page: "behandlingskvalitet" | "pasientstrømmer";
+};
+
+export const Header = (props: HeaderProps) => {
+  const { page } = props;
+
+  return (
+    <React.Fragment>
+      <HeaderTop page={page} />
+      <HeaderMiddle page={page} />
+    </React.Fragment>
+  );
+};

--- a/apps/skde/src/components/TreatmentQuality/TreatmentQualityAppBar.tsx
+++ b/apps/skde/src/components/TreatmentQuality/TreatmentQualityAppBar.tsx
@@ -1,7 +1,6 @@
 import { AppBar, styled } from "@mui/material";
-import { TreatmentQualityHeaderTop } from "./TreatmentQualityHeaderTop";
-import { HeaderMiddleToolbar } from "./TreatmentQualityHeaderMiddle";
 import { TreatmentQualityToolbar } from "./TreatmentQualityToolbar";
+import { Header } from "../Header";
 
 const StyledAppBar = styled(AppBar)(() => ({
   elevation: 0,
@@ -20,8 +19,7 @@ export const TreatmentQualityAppBar = ({
 }: AppBarProps) => {
   return (
     <>
-      <TreatmentQualityHeaderTop />
-      <HeaderMiddleToolbar />
+      <Header page="behandlingskvalitet" />
       <StyledAppBar position="sticky" elevation={0}>
         <TreatmentQualityToolbar
           openDrawer={openDrawer}


### PR DESCRIPTION
- Flyttet topp- og mellom-header til en egen mappe under `components`
- Ny komponent som heter `Header` som kan brukes på behandlingskvalitet og pasientstrømmer