### PR TITLE
Ta med foreldre-navn på ID i tresktruktur

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSection.tsx
@@ -66,6 +66,7 @@ const buildTreeLevel = (
   toggleExpand: (value: string) => void,
   autoUncheckId?: string,
   multiselect?: boolean,
+  parent?: string,
 ) => {
   return treeData.map((node) => {
     return (
@@ -78,6 +79,7 @@ const buildTreeLevel = (
         handleCheckboxChange={handleCheckboxChange}
         toggleExpand={toggleExpand}
         multiselect={multiselect}
+        parentKey={parent}
       >
         {node.children &&
           buildTreeLevel(
@@ -88,6 +90,7 @@ const buildTreeLevel = (
             toggleExpand,
             autoUncheckId,
             multiselect,
+            (parent = node.nodeValue.value),
           )}
       </TreeViewFilterSectionItem>
     );

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -27,6 +27,7 @@ type TreeViewFilterSectionItemProps = PropsWithChildren<{
   toggleExpand: (value: string) => void;
   autoUncheckId?: string;
   multiselect?: boolean;
+  parentKey?: string;
 }>;
 
 /**
@@ -43,6 +44,7 @@ export const TreeViewFilterSectionItem = (
 ) => {
   const {
     filterKey,
+    parentKey,
     labeledValue,
     selectedIds,
     handleCheckboxChange,
@@ -57,7 +59,7 @@ export const TreeViewFilterSectionItem = (
     <TreeItem
       key={`tree-view-item-${filterKey}-${labeledValue.value}`}
       data-testid={`tree-view-item-${labeledValue.value}`}
-      itemId={labeledValue.value}
+      itemId={`${parentKey}-${labeledValue.value}`}
       label={
         <>
           <Checkbox


### PR DESCRIPTION
Var problemer med ikke-unike ID for registre som lå under flere fagområder. Nå blir ID da fagområde-register.

Closes #2752