### PR TITLE
Forbedret flex til Helseatlas-forsiden

### DIFF
--- a/apps/skde/src/components/Atlas/FrontPage/FrontPage.module.css
+++ b/apps/skde/src/components/Atlas/FrontPage/FrontPage.module.css
@@ -6,4 +6,5 @@
   padding-left: 16px;
   padding-right: 16px;
   max-width: min(1216px, 95%);
+  gap: 40px;
 }

--- a/apps/skde/src/components/Atlas/FrontPage/index.tsx
+++ b/apps/skde/src/components/Atlas/FrontPage/index.tsx
@@ -2,6 +2,7 @@ import { AtlasLayout } from "../../Layout";
 import { MainBanner } from "../../MainBanner";
 import { AtlasLink } from "../../Buttons";
 import classNames from "./FrontPage.module.css";
+import linkClassNames from "../../Buttons/AtlasLink.module.css";
 
 export interface HomeProps {
   atlasInfo: {
@@ -43,7 +44,13 @@ const FrontPage = ({ atlasInfo, lang }: HomeProps) => {
     <AtlasLayout lang={lang}>
       <main>
         <MainBanner lang={lang} />
-        <div className={classNames.atlasLinksWrapper}>{Links}</div>
+        <div className={classNames.atlasLinksWrapper}>
+          {Links}
+          <div /* Dummy link to make the last link align correctly with CSS flex */
+            className={`${linkClassNames.linkOuterWrapper}`}
+            style={{ height: "0px" }}
+          ></div>
+        </div>
       </main>
     </AtlasLayout>
   );

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -26,17 +26,6 @@
   text-decoration: underline;
 }
 
-.linkImageWrapper::before,
-.linkImageWrapper::before {
-  content: "";
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background-color: none;
-  transition: 100ms ease-in;
-  z-index: 2;
-}
-
 .linkInnerWrapper {
   display: flex;
   justify-content: space-between;

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -47,8 +47,7 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
-  padding: 20px 25px 0 25px;
-  height: 380px;
+  padding: 20px 25px 20px 25px;
 }
 
 .linkDateContainer {

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -1,17 +1,17 @@
 .linkOuterWrapper {
-  max-width: 47%;
-  min-width: 350px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  max-width: min(100%, 610px);
+  min-width: 300px;
   background: #e3f3ef;
   transition: 100ms ease-in;
-  flex: 1 1 45%;
+  flex: 1 1 250px;
   overflow: hidden;
+  border-radius: 24px;
 }
 
 .linkOuterWrapper:hover,
 .linkOuterWrapper:focus {
-  background-color: #c6e6df;
+  box-shadow:2px 2px 16px rgba(0,0,0,.24);
+  transition:box-shadow .1s ease-out
 }
 
 .linkOuterWrapper:hover .linkTitle,
@@ -30,11 +30,6 @@
   z-index: 2;
 }
 
-.linkOuterWrapper:hover .linkImageWrapper::before,
-.linkOuterWrapper:focus .linkImageWrapper::before {
-  background-color: #c6e6df;
-  opacity: 0.3;
-}
 
 .linkInnerWrapper {
   display: flex;
@@ -100,7 +95,7 @@
 .linkTitle {
   font-style: normal;
   font-weight: 700;
-  font-size: 36px;
+  font-size: 26px;
   line-height: 49px;
   letter-spacing: 0.01em;
   padding-top: 20px;
@@ -114,6 +109,14 @@
 }
 
 @media screen and (min-width: 943px) {
+  .linkOuterWrapper {
+    flex-basis: 400px;
+  }
+
+  .linkTitle {
+    font-size: 36px;
+  }
+
   .linkOuterWrapper.wide {
     max-width: 100%;
     margin-top: 20px;
@@ -137,16 +140,5 @@
   .linkOuterWrapper.wide .linkText {
     flex: 1;
     height: 350px;
-  }
-
-  .wide.linkOuterWrapper:hover,
-  .wide.linkOuterWrapper:focus {
-    background-color: rgba(0, 48, 135, 0.2);
-  }
-
-  .wide.linkOuterWrapper:hover .linkImageWrapper::before,
-  .wide.linkOuterWrapper:focus .linkImageWrapper::before {
-    background-color: rgba(0, 48, 135, 0.5);
-    opacity: 0.3;
   }
 }

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -14,6 +14,13 @@
   transition: box-shadow 0.1s ease-out;
 }
 
+.linkOuterWrapper:hover .linkImageWrapper img,
+.linkOuterWrapper:focus .linkImageWrapper img {
+  background-color: #c6e6df;
+  transition: opacity 0.1s ease-in;
+  opacity: 0.8;
+}
+
 .linkOuterWrapper:hover .linkTitle,
 .linkOuterWrapper:focus .linkTitle {
   text-decoration: underline;

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -8,16 +8,19 @@
   border-radius: 24px;
 }
 
+.linkOuterWrapper,
+.linkOuterWrapper img {
+  transition: 0.1s ease-out;
+}
+
 .linkOuterWrapper:hover,
 .linkOuterWrapper:focus {
   box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.24);
-  transition: box-shadow 0.1s ease-out;
 }
 
 .linkOuterWrapper:hover .linkImageWrapper img,
 .linkOuterWrapper:focus .linkImageWrapper img {
   background-color: #c6e6df;
-  transition: opacity 0.1s ease-in;
   opacity: 0.8;
 }
 
@@ -116,7 +119,6 @@
     margin-top: 20px;
     margin-bottom: 20px;
     background: #e6eef8;
-    transition: 100ms ease-in;
     flex: 1 1 100%;
   }
 

--- a/apps/skde/src/components/Buttons/AtlasLink.module.css
+++ b/apps/skde/src/components/Buttons/AtlasLink.module.css
@@ -10,8 +10,8 @@
 
 .linkOuterWrapper:hover,
 .linkOuterWrapper:focus {
-  box-shadow:2px 2px 16px rgba(0,0,0,.24);
-  transition:box-shadow .1s ease-out
+  box-shadow: 2px 2px 16px rgba(0, 0, 0, 0.24);
+  transition: box-shadow 0.1s ease-out;
 }
 
 .linkOuterWrapper:hover .linkTitle,
@@ -29,7 +29,6 @@
   transition: 100ms ease-in;
   z-index: 2;
 }
-
 
 .linkInnerWrapper {
   display: flex;

--- a/apps/skde/src/components/Buttons/AtlasLink.tsx
+++ b/apps/skde/src/components/Buttons/AtlasLink.tsx
@@ -50,7 +50,7 @@ export const AtlasLink = ({
               style={{
                 maxWidth: "100%",
                 height: "auto",
-                objectFit: "cover"
+                objectFit: "cover",
               }}
             />
           </div>

--- a/apps/skde/src/components/Buttons/AtlasLink.tsx
+++ b/apps/skde/src/components/Buttons/AtlasLink.tsx
@@ -50,6 +50,7 @@ export const AtlasLink = ({
               style={{
                 maxWidth: "100%",
                 height: "auto",
+                objectFit: "cover"
               }}
             />
           </div>

--- a/apps/skde/src/components/Buttons/__tests__/__snapshots__/atlaslink.test.tsx.snap
+++ b/apps/skde/src/components/Buttons/__tests__/__snapshots__/atlaslink.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`English render 1`] = `
             loading="lazy"
             src="https://picsum.photos/id/237/100/100.jpg?w=1920&q=75"
             srcset="https://picsum.photos/id/237/100/100.jpg?w=640&q=75 1x, https://picsum.photos/id/237/100/100.jpg?w=1920&q=75 2x"
-            style="color: transparent; max-width: 100%; height: auto;"
+            style="color: transparent; max-width: 100%; height: auto; object-fit: cover;"
             width="610"
           />
         </div>
@@ -89,7 +89,7 @@ exports[`Norsk render 1`] = `
             loading="lazy"
             src="https://picsum.photos/id/237/100/100.jpg?w=1920&q=75"
             srcset="https://picsum.photos/id/237/100/100.jpg?w=640&q=75 1x, https://picsum.photos/id/237/100/100.jpg?w=1920&q=75 2x"
-            style="color: transparent; max-width: 100%; height: auto;"
+            style="color: transparent; max-width: 100%; height: auto; object-fit: cover;"
             width="610"
           />
         </div>
@@ -155,7 +155,7 @@ exports[`Wide is true 1`] = `
             loading="lazy"
             src="https://picsum.photos/id/237/100/100.jpg?w=1920&q=75"
             srcset="https://picsum.photos/id/237/100/100.jpg?w=640&q=75 1x, https://picsum.photos/id/237/100/100.jpg?w=1920&q=75 2x"
-            style="color: transparent; max-width: 100%; height: auto;"
+            style="color: transparent; max-width: 100%; height: auto; object-fit: cover;"
             width="610"
           />
         </div>
@@ -217,7 +217,7 @@ exports[`newlyUpdated is true 1`] = `
             loading="lazy"
             src="https://picsum.photos/id/237/100/100.jpg?w=1920&q=75"
             srcset="https://picsum.photos/id/237/100/100.jpg?w=640&q=75 1x, https://picsum.photos/id/237/100/100.jpg?w=1920&q=75 2x"
-            style="color: transparent; max-width: 100%; height: auto;"
+            style="color: transparent; max-width: 100%; height: auto; object-fit: cover;"
             width="610"
           />
         </div>

--- a/apps/skde/src/components/MainBanner/MainBanner.module.css
+++ b/apps/skde/src/components/MainBanner/MainBanner.module.css
@@ -51,14 +51,14 @@
   font-size: 24px;
   margin: auto;
   text-align: center;
-  line-height: 35px;
+  line-height: 1.4em;
 }
 
 .pageIngress {
   background: none;
   margin: auto;
   width: min(1216px, 95%);
-  padding: 50px 100px 50px 100px;
+  padding: min(5%, 50px);
 }
 
 @media screen and (max-width: 700px) {


### PR DESCRIPTION
Forbedret flex til Helseatlas-forsiden, sånn at det også ser bra ut på mindre skjermer. Jeg endret også stilen på knappene sånn at de ser lik ut knappene på FNSB.

Før: 
![Screenshot from 2024-07-05 14-09-47](https://github.com/mong/mongts/assets/593262/73ba745e-a0be-48c9-9c47-610137aab550)

Etter:
![Screenshot from 2024-07-05 14-09-39](https://github.com/mong/mongts/assets/593262/865a52f7-cd53-45dd-9b99-22551b2090b7)

Den siste linken kan se litt rar ut når den er alene på en linje, fordi den blir litt bredere enn de andre linkene. Men det er et ganske lite problem som sannsynlighvis har en litt for komplisert løsning.

Litt usikker på om vi skal ha denne siden i de nye nettsidene, men det var relativt lett å endre på.
