### PR TITLE
Redirect from frontpage to skde.no

### DIFF
--- a/apps/skde/pages/_document.tsx
+++ b/apps/skde/pages/_document.tsx
@@ -1,27 +1,39 @@
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
-class MyDocument extends Document<{ lang: string }> {
+class MyDocument extends Document<{ lang: string; pathname: string }> {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
     const { pathname } = ctx;
     const lang =
       pathname.includes("/en/") || pathname.endsWith("/en") ? "en" : "no";
-    return { ...initialProps, lang };
+    return { ...initialProps, lang, pathname };
   }
 
   render() {
-    const { lang } = this.props;
+    const { lang, pathname } = this.props;
+
     return (
       <Html lang={lang}>
         <Head>
-          <meta
-            name="google-site-verification"
-            content="XnhRhaBwfeuAccfCFysPPpe1f49t46JAfInHBDfK6HE"
-          />
+          {pathname === "/" ? (
+            <meta
+              http-equiv="refresh"
+              content="0; url=https://www.skde.no/"
+            ></meta>
+          ) : (
+            <meta
+              name="google-site-verification"
+              content="XnhRhaBwfeuAccfCFysPPpe1f49t46JAfInHBDfK6HE"
+            />
+          )}
         </Head>
         <body>
-          <Main />
-          <NextScript />
+          {pathname !== "/" && (
+            <>
+              <Main />
+              <NextScript />
+            </>
+          )}
         </body>
       </Html>
     );


### PR DESCRIPTION
Brukte meta-tag fordi man ikke kan returnere statuskoder direkte fra server når man bruker statisk genererte sider (dvs. ingen server). Er i alle fall bedre enn å gjøre en redirect med javascript.