### PR TITLE
2842 fikse skrolling nr man har valgt indikator i url en til behandlingskvalitet

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Box,
   CssBaseline,
@@ -43,11 +43,32 @@ import {
 import { Footer } from "../../src/components/Footer";
 import { mainQueryParamsConfig } from "qmongjs";
 import { PageWrapper } from "../../src/components/StyledComponents/PageWrapper";
+import useOnElementAdded from "../../src/helpers/hooks/useOnElementAdded";
 
 const dataQualityKey = "dg";
 
 // Set to true to display the switch for activating the new table
 const showNewTableSwitch = false;
+
+const scrollToSelectedRow = (selectedRow: string): boolean => {
+  const element = document.getElementById(selectedRow);
+  const headerOffset = 140;
+
+  if (element) {
+    console.log("Found element, attempting to scroll");
+    const elementPosition = element.getBoundingClientRect().top;
+    const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+    window.scrollTo({
+      top: offsetPosition,
+      behavior: "smooth",
+    });
+
+    return true;
+  } else {
+    console.log("Didn't find element");
+    return false;
+  }
+};
 
 export default function TreatmentQualityPage() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -270,20 +291,9 @@ export default function TreatmentQualityPage() {
     }
   };
 
-  useEffect(() => {
-    const element = document.getElementById(selectedRow);
-    const headerOffset = 140;
-
-    if (element) {
-      const elementPosition = element.getBoundingClientRect().top;
-      const offsetPosition =
-        elementPosition + window.pageYOffset - headerOffset;
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: "smooth",
-      });
-    }
-  });
+  // Use the custom hook to observe the addition of the selected row element, if
+  // not already available.
+  useOnElementAdded(selectedRow, queriesReady, scrollToSelectedRow);
 
   return (
     <ThemeProvider theme={skdeTheme}>

--- a/apps/skde/src/helpers/hooks/useOnElementAdded.ts
+++ b/apps/skde/src/helpers/hooks/useOnElementAdded.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+
+function useOnElementAdded(
+  targetId: string,
+  queriesReady: boolean,
+  callback: (targetId: string) => void,
+) {
+  useEffect(() => {
+    // Define the callback function for the MutationObserver
+    const observerCallback: MutationCallback = (mutationsList) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === "childList") {
+          // Check if the added nodes contain the element with the target ID
+          mutation.addedNodes.forEach((node) => {
+            if (
+              node instanceof HTMLElement && // Ensure the node is an HTMLElement
+              node.id === targetId // Check if the element has the target ID
+            ) {
+              callback(targetId);
+            }
+          });
+        }
+      }
+    };
+
+    if (queriesReady) {
+      // Set up the MutationObserver
+      const observer = new MutationObserver(observerCallback);
+
+      // Start observing the document body for changes in the DOM
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      // Cleanup the observer on component unmount
+      return () => observer.disconnect();
+    }
+  }, [targetId, queriesReady, callback]);
+}
+
+export default useOnElementAdded;

--- a/apps/skde/src/helpers/hooks/useOnElementAdded.ts
+++ b/apps/skde/src/helpers/hooks/useOnElementAdded.ts
@@ -3,37 +3,50 @@ import { useEffect } from "react";
 function useOnElementAdded(
   targetId: string,
   queriesReady: boolean,
-  callback: (targetId: string) => void,
+  callback: (targetId: string) => boolean,
 ) {
   useEffect(() => {
-    // Define the callback function for the MutationObserver
-    const observerCallback: MutationCallback = (mutationsList) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList") {
-          // Check if the added nodes contain the element with the target ID
-          mutation.addedNodes.forEach((node) => {
-            if (
-              node instanceof HTMLElement && // Ensure the node is an HTMLElement
-              node.id === targetId // Check if the element has the target ID
-            ) {
-              callback(targetId);
+    if (queriesReady && targetId) {
+      // If the target element is already available, then let the callback
+      // handle it directly.
+      const foundTarget = callback(targetId);
+
+      if (!foundTarget) {
+        // The element didn't exist, observe if it shows up and trigger callback
+        console.log(
+          `Didn't find the element with id "${targetId}" in the DOM, setting up observer`,
+        );
+
+        const observerCallback: MutationCallback = (mutationsList) => {
+          for (const mutation of mutationsList) {
+            if (mutation.type === "childList") {
+              // Check if the added nodes contain the element with the target ID
+              mutation.addedNodes.forEach((node) => {
+                if (
+                  node instanceof HTMLElement && // Ensure the node is an HTMLElement
+                  node.id === targetId // Check if the element has the target ID
+                ) {
+                  callback(targetId);
+                }
+              });
+            } else {
+              console.log(
+                `The element with id "${targetId}" was already present in the DOM, no need for observer`,
+              );
             }
-          });
-        }
+          }
+        };
+
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(document.body, { childList: true, subtree: true });
+        return () => observer.disconnect();
       }
-    };
-
-    if (queriesReady) {
-      // Set up the MutationObserver
-      const observer = new MutationObserver(observerCallback);
-
-      // Start observing the document body for changes in the DOM
-      observer.observe(document.body, { childList: true, subtree: true });
-
-      // Cleanup the observer on component unmount
-      return () => observer.disconnect();
+    } else {
+      console.log(
+        `Not scrolling. Target ID was ${targetId}. Queries ${queriesReady ? "" : "not "}ready.`,
+      );
     }
-  }, [targetId, queriesReady, callback]);
+  });
 }
 
 export default useOnElementAdded;


### PR DESCRIPTION
Har lagt inn en custom hook for å håndtere scrollingen. Hooken tar inn en callback som utfører selve scrollingen når elementet er klart.

Den dekker tre caser:
1) Elementet finnes allerede. Da scrolles det direkte til den.
2) Elementet finnes ikke ennå. Da observeres DOM-en for endringer, og callback blir kalt når/hvis den dukker opp.
3) Flere elementer kan dukke opp i treet etter elementet er klart og forskyve posisjonen. Derfor må hooken trigges og scrolle til det ønskede elementet potensielt flere ganger.

