### PR TITLE
split aldersfig to spes and lege for some

### DIFF
--- a/apps/skde/public/helseatlas/data/lab/alat_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/alat_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 32966,
           "tot_pas": 21340,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.54479850047,
-          "borhf": null
+          "prove_pr_pas": 1.54479850047
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 86632.6666667,
           "tot_pas": 57074.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.517891872,
-          "borhf": null
+          "prove_pr_pas": 1.517891872
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 58428.3333333,
           "tot_pas": 39592.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.47573624745,
-          "borhf": null
+          "prove_pr_pas": 1.47573624745
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 36954.6666667,
           "tot_pas": 24084,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.53440735205,
-          "borhf": null
+          "prove_pr_pas": 1.53440735205
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 62978,
           "tot_pas": 42314,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.48834900978,
-          "borhf": null
+          "prove_pr_pas": 1.48834900978
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 149370.666667,
           "tot_pas": 101150,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.47672433679,
-          "borhf": null
+          "prove_pr_pas": 1.47672433679
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 135679.333333,
           "tot_pas": 88017.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.54150113803,
-          "borhf": null
+          "prove_pr_pas": 1.54150113803
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 49775.6666667,
           "tot_pas": 32608,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.52648634282,
-          "borhf": null
+          "prove_pr_pas": 1.52648634282
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 245364.333333,
           "tot_pas": 150300.666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.63248998674,
-          "borhf": null
+          "prove_pr_pas": 1.63248998674
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 105023,
           "tot_pas": 62301.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.6857263622,
-          "borhf": null
+          "prove_pr_pas": 1.6857263622
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 169921.666667,
           "tot_pas": 110870,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.53262078711,
-          "borhf": null
+          "prove_pr_pas": 1.53262078711
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 203891.666667,
           "tot_pas": 127893.666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.59422801755,
-          "borhf": null
+          "prove_pr_pas": 1.59422801755
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 329816.333333,
           "tot_pas": 213926.333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.54172853895,
-          "borhf": null
+          "prove_pr_pas": 1.54172853895
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 137673.666667,
           "tot_pas": 92434.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.48941594784,
-          "borhf": null
+          "prove_pr_pas": 1.48941594784
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 65546,
           "tot_pas": 46538.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.40843032625,
-          "borhf": null
+          "prove_pr_pas": 1.40843032625
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 70314,
           "tot_pas": 47418,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.48285461217,
-          "borhf": null
+          "prove_pr_pas": 1.48285461217
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 207397,
           "tot_pas": 125808,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.64851996693,
-          "borhf": null
+          "prove_pr_pas": 1.64851996693
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 276484,
           "tot_pas": 177881,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.55432002294,
-          "borhf": null
+          "prove_pr_pas": 1.55432002294
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 155250.666667,
           "tot_pas": 95250.3333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.62992255495,
-          "borhf": null
+          "prove_pr_pas": 1.62992255495
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 91507,
           "tot_pas": 56397.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.62254125491,
-          "borhf": null
+          "prove_pr_pas": 1.62254125491
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 175051,
           "tot_pas": 108353.666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.6155521579,
-          "borhf": null
+          "prove_pr_pas": 1.6155521579
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 2846032.66667,
           "tot_pas": 1821559.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.56241528551,
-          "borhf": null
+          "prove_pr_pas": 1.56241528551
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 214981.666667,
           "tot_pas": 142006,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.51389143182,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.51389143182
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 348028,
           "tot_pas": 231360.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.50426823382,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.50426823382
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 570084.666667,
           "tot_pas": 355863.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.60197641417,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.60197641417
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1712938.33333,
           "tot_pas": 1088071.33333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.57428863426,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57428863426
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 2846032.66667,
           "tot_pas": 1815636,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.56751279809,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.56751279809
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00639392836721,
-          "menn": 0.00810605420924,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00810605420924
         },
         {
           "alder": 1,
           "kvinner": 0.0172809632442,
-          "menn": 0.0205745742302,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0205745742302
         },
         {
           "alder": 2,
           "kvinner": 0.0229168146622,
-          "menn": 0.0258033041061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0258033041061
         },
         {
           "alder": 3,
           "kvinner": 0.030633401052,
-          "menn": 0.0336838516809,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0336838516809
         },
         {
           "alder": 4,
           "kvinner": 0.03510244182,
-          "menn": 0.0385193693897,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0385193693897
         },
         {
           "alder": 5,
           "kvinner": 0.0399790993984,
-          "menn": 0.0411111040597,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0411111040597
         },
         {
           "alder": 6,
           "kvinner": 0.0462375279916,
-          "menn": 0.0452428895042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0452428895042
         },
         {
           "alder": 7,
           "kvinner": 0.0515992443489,
-          "menn": 0.0499188060146,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0499188060146
         },
         {
           "alder": 8,
           "kvinner": 0.0576754540279,
-          "menn": 0.0578987730061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0578987730061
         },
         {
           "alder": 9,
           "kvinner": 0.0643131750006,
-          "menn": 0.0647752664274,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0647752664274
         },
         {
           "alder": 10,
           "kvinner": 0.0717490202009,
-          "menn": 0.0707941873869,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0707941873869
         },
         {
           "alder": 11,
           "kvinner": 0.0775599429623,
-          "menn": 0.0737656547112,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0737656547112
         },
         {
           "alder": 12,
           "kvinner": 0.0916184148078,
-          "menn": 0.0755978848696,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0755978848696
         },
         {
           "alder": 13,
           "kvinner": 0.122033183622,
-          "menn": 0.089022627622,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.089022627622
         },
         {
           "alder": 14,
           "kvinner": 0.160042286024,
-          "menn": 0.109052083845,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.109052083845
         },
         {
           "alder": 15,
           "kvinner": 0.189666249181,
-          "menn": 0.123061410075,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123061410075
         },
         {
           "alder": 16,
           "kvinner": 0.214763133208,
-          "menn": 0.130943372821,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.130943372821
         },
         {
           "alder": 17,
           "kvinner": 0.231751695074,
-          "menn": 0.138360318936,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.138360318936
         },
         {
           "alder": 18,
           "kvinner": 0.234209262875,
-          "menn": 0.134868203142,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.134868203142
         },
         {
           "alder": 19,
           "kvinner": 0.222934840011,
-          "menn": 0.126812587129,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126812587129
         },
         {
           "alder": 20,
           "kvinner": 0.227371197137,
-          "menn": 0.124019719644,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124019719644
         },
         {
           "alder": 21,
           "kvinner": 0.231618850055,
-          "menn": 0.125122054887,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125122054887
         },
         {
           "alder": 22,
           "kvinner": 0.232200622512,
-          "menn": 0.128085804445,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128085804445
         },
         {
           "alder": 23,
           "kvinner": 0.235262532353,
-          "menn": 0.131259762156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131259762156
         },
         {
           "alder": 24,
           "kvinner": 0.235555397836,
-          "menn": 0.13537769884,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13537769884
         },
         {
           "alder": 25,
           "kvinner": 0.24200979314,
-          "menn": 0.13912038047,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13912038047
         },
         {
           "alder": 26,
           "kvinner": 0.242809436605,
-          "menn": 0.141021924456,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141021924456
         },
         {
           "alder": 27,
           "kvinner": 0.240767857834,
-          "menn": 0.145089486108,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145089486108
         },
         {
           "alder": 28,
           "kvinner": 0.243619137439,
-          "menn": 0.146969208531,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146969208531
         },
         {
           "alder": 29,
           "kvinner": 0.246539292668,
-          "menn": 0.150362477297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.150362477297
         },
         {
           "alder": 30,
           "kvinner": 0.2560273278,
-          "menn": 0.157247282076,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157247282076
         },
         {
           "alder": 31,
           "kvinner": 0.263472216244,
-          "menn": 0.159926785131,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.159926785131
         },
         {
           "alder": 32,
           "kvinner": 0.270586818744,
-          "menn": 0.162112989907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162112989907
         },
         {
           "alder": 33,
           "kvinner": 0.274095481576,
-          "menn": 0.165010879372,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.165010879372
         },
         {
           "alder": 34,
           "kvinner": 0.275851335367,
-          "menn": 0.16633302026,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16633302026
         },
         {
           "alder": 35,
           "kvinner": 0.274100049688,
-          "menn": 0.164943791187,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.164943791187
         },
         {
           "alder": 36,
           "kvinner": 0.274078430016,
-          "menn": 0.169331055272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.169331055272
         },
         {
           "alder": 37,
           "kvinner": 0.270735832445,
-          "menn": 0.173250120229,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173250120229
         },
         {
           "alder": 38,
           "kvinner": 0.274341078045,
-          "menn": 0.173604979572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173604979572
         },
         {
           "alder": 39,
           "kvinner": 0.274854485361,
-          "menn": 0.178988241004,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.178988241004
         },
         {
           "alder": 40,
           "kvinner": 0.281218586279,
-          "menn": 0.187505584346,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.187505584346
         },
         {
           "alder": 41,
           "kvinner": 0.283176115573,
-          "menn": 0.18856561296,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.18856561296
         },
         {
           "alder": 42,
           "kvinner": 0.283630498847,
-          "menn": 0.191346849094,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.191346849094
         },
         {
           "alder": 43,
           "kvinner": 0.283022840932,
-          "menn": 0.191491133128,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.191491133128
         },
         {
           "alder": 44,
           "kvinner": 0.28140532365,
-          "menn": 0.19644707056,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.19644707056
         },
         {
           "alder": 45,
           "kvinner": 0.283076402784,
-          "menn": 0.196242037195,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.196242037195
         },
         {
           "alder": 46,
           "kvinner": 0.285890078358,
-          "menn": 0.203589576684,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.203589576684
         },
         {
           "alder": 47,
           "kvinner": 0.295876738478,
-          "menn": 0.214317213757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.214317213757
         },
         {
           "alder": 48,
           "kvinner": 0.305282655084,
-          "menn": 0.223452990045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.223452990045
         },
         {
           "alder": 49,
           "kvinner": 0.317923710796,
-          "menn": 0.235668332693,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.235668332693
         },
         {
           "alder": 50,
           "kvinner": 0.328080794967,
-          "menn": 0.252935251427,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.252935251427
         },
         {
           "alder": 51,
           "kvinner": 0.341500322309,
-          "menn": 0.264172718719,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.264172718719
         },
         {
           "alder": 52,
           "kvinner": 0.348483009039,
-          "menn": 0.272436082263,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.272436082263
         },
         {
           "alder": 53,
           "kvinner": 0.356012915906,
-          "menn": 0.282480398841,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.282480398841
         },
         {
           "alder": 54,
           "kvinner": 0.364482976402,
-          "menn": 0.29847977213,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.29847977213
         },
         {
           "alder": 55,
           "kvinner": 0.372437913299,
-          "menn": 0.313005225314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.313005225314
         },
         {
           "alder": 56,
           "kvinner": 0.376192251717,
-          "menn": 0.322182289992,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.322182289992
         },
         {
           "alder": 57,
           "kvinner": 0.382210325518,
-          "menn": 0.335766380287,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.335766380287
         },
         {
           "alder": 58,
           "kvinner": 0.384635675078,
-          "menn": 0.342628447156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.342628447156
         },
         {
           "alder": 59,
           "kvinner": 0.386876055172,
-          "menn": 0.34948558091,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.34948558091
         },
         {
           "alder": 60,
           "kvinner": 0.39225885462,
-          "menn": 0.361108851413,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.361108851413
         },
         {
           "alder": 61,
           "kvinner": 0.396156391524,
-          "menn": 0.370111005392,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.370111005392
         },
         {
           "alder": 62,
           "kvinner": 0.398851433741,
-          "menn": 0.377446838701,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.377446838701
         },
         {
           "alder": 63,
           "kvinner": 0.40408923169,
-          "menn": 0.39140483643,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.39140483643
         },
         {
           "alder": 64,
           "kvinner": 0.418133416215,
-          "menn": 0.404944598057,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.404944598057
         },
         {
           "alder": 65,
           "kvinner": 0.428720576417,
-          "menn": 0.41782741341,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.41782741341
         },
         {
           "alder": 66,
           "kvinner": 0.443203137721,
-          "menn": 0.428410765256,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.428410765256
         },
         {
           "alder": 67,
           "kvinner": 0.451130756876,
-          "menn": 0.438652948044,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.438652948044
         },
         {
           "alder": 68,
           "kvinner": 0.458880259138,
-          "menn": 0.444192343743,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.444192343743
         },
         {
           "alder": 69,
           "kvinner": 0.464016977142,
-          "menn": 0.44787298235,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.44787298235
         },
         {
           "alder": 70,
           "kvinner": 0.466297620478,
-          "menn": 0.460761425193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.460761425193
         },
         {
           "alder": 71,
           "kvinner": 0.463041441763,
-          "menn": 0.451863649873,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.451863649873
         },
         {
           "alder": 72,
           "kvinner": 0.474221657439,
-          "menn": 0.468881488737,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.468881488737
         },
         {
           "alder": 73,
           "kvinner": 0.501793397496,
-          "menn": 0.492929917143,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.492929917143
         },
         {
           "alder": 74,
           "kvinner": 0.53737934877,
-          "menn": 0.536322168643,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.536322168643
         },
         {
           "alder": 75,
           "kvinner": 0.569947500772,
-          "menn": 0.571720648928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.571720648928
         },
         {
           "alder": 76,
           "kvinner": 0.619140028567,
-          "menn": 0.622686489532,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.622686489532
         },
         {
           "alder": 77,
           "kvinner": 0.630408615094,
-          "menn": 0.639172901581,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.639172901581
         },
         {
           "alder": 78,
           "kvinner": 0.617499677279,
-          "menn": 0.626175675676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.626175675676
         },
         {
           "alder": 79,
           "kvinner": 0.607608366172,
-          "menn": 0.63538544539,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.63538544539
         },
         {
           "alder": 80,
           "kvinner": 0.579896451915,
-          "menn": 0.587557221522,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.587557221522
         },
         {
           "alder": 81,
           "kvinner": 0.58168477088,
-          "menn": 0.586612964401,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.586612964401
         },
         {
           "alder": 82,
           "kvinner": 0.588455504295,
-          "menn": 0.60356919097,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.60356919097
         },
         {
           "alder": 83,
           "kvinner": 0.608372641509,
-          "menn": 0.616128812482,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.616128812482
         },
         {
           "alder": 84,
           "kvinner": 0.601940501082,
-          "menn": 0.618562506399,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.618562506399
         },
         {
           "alder": 85,
           "kvinner": 0.586213641609,
-          "menn": 0.598316295851,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.598316295851
         },
         {
           "alder": 86,
           "kvinner": 0.566470244066,
-          "menn": 0.589649156813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.589649156813
         },
         {
           "alder": 87,
           "kvinner": 0.55338153977,
-          "menn": 0.57801431322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.57801431322
         },
         {
           "alder": 88,
           "kvinner": 0.555805646621,
-          "menn": 0.580098918602,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.580098918602
         },
         {
           "alder": 89,
           "kvinner": 0.557332683825,
-          "menn": 0.587983044164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.587983044164
         },
         {
           "alder": 90,
           "kvinner": 0.566710126032,
-          "menn": 0.595561184488,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.595561184488
         },
         {
           "alder": 91,
           "kvinner": 0.567368760989,
-          "menn": 0.597701149425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.597701149425
         },
         {
           "alder": 92,
           "kvinner": 0.564475428767,
-          "menn": 0.595824361015,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.595824361015
         },
         {
           "alder": 93,
           "kvinner": 0.546126597875,
-          "menn": 0.595749848209,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.595749848209
         },
         {
           "alder": 94,
           "kvinner": 0.547991570343,
-          "menn": 0.606785772824,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.606785772824
         },
         {
           "alder": 95,
           "kvinner": 0.532689811811,
-          "menn": 0.585252435784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.585252435784
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/albumin_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/albumin_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 9969.66666667,
           "tot_pas": 7243,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.37645542823,
-          "borhf": null
+          "prove_pr_pas": 1.37645542823
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 23201.3333333,
           "tot_pas": 15763.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.4718545147,
-          "borhf": null
+          "prove_pr_pas": 1.4718545147
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 15117.3333333,
           "tot_pas": 11295,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.33840932566,
-          "borhf": null
+          "prove_pr_pas": 1.33840932566
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 9529.66666667,
           "tot_pas": 6525.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.4603361087,
-          "borhf": null
+          "prove_pr_pas": 1.4603361087
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 13780.6666667,
           "tot_pas": 10528,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.30895390071,
-          "borhf": null
+          "prove_pr_pas": 1.30895390071
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 30369.6666667,
           "tot_pas": 23233.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.30714050014,
-          "borhf": null
+          "prove_pr_pas": 1.30714050014
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 29416.6666667,
           "tot_pas": 22281.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.32021841574,
-          "borhf": null
+          "prove_pr_pas": 1.32021841574
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 21238.6666667,
           "tot_pas": 15012.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.41471646165,
-          "borhf": null
+          "prove_pr_pas": 1.41471646165
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 128641.333333,
           "tot_pas": 85412.6666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.50611540833,
-          "borhf": null
+          "prove_pr_pas": 1.50611540833
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 37873.3333333,
           "tot_pas": 26153.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.44812643385,
-          "borhf": null
+          "prove_pr_pas": 1.44812643385
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 73942.6666667,
           "tot_pas": 52670.6666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.40386806065,
-          "borhf": null
+          "prove_pr_pas": 1.40386806065
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 55516,
           "tot_pas": 37656.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.47426750465,
-          "borhf": null
+          "prove_pr_pas": 1.47426750465
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 88263,
           "tot_pas": 62548,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.41112425657,
-          "borhf": null
+          "prove_pr_pas": 1.41112425657
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 37311.3333333,
           "tot_pas": 26538.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.4059410915,
-          "borhf": null
+          "prove_pr_pas": 1.4059410915
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 16326.3333333,
           "tot_pas": 12369.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.31986849551,
-          "borhf": null
+          "prove_pr_pas": 1.31986849551
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 18459.6666667,
           "tot_pas": 13486.3333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.36876838281,
-          "borhf": null
+          "prove_pr_pas": 1.36876838281
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 48938.3333333,
           "tot_pas": 34655.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.41214435489,
-          "borhf": null
+          "prove_pr_pas": 1.41214435489
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 80679.6666667,
           "tot_pas": 56119.3333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.43764478076,
-          "borhf": null
+          "prove_pr_pas": 1.43764478076
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 93251.3333333,
           "tot_pas": 61017.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.52826776944,
-          "borhf": null
+          "prove_pr_pas": 1.52826776944
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 44789.3333333,
           "tot_pas": 30674.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.46014083283,
-          "borhf": null
+          "prove_pr_pas": 1.46014083283
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 126913,
           "tot_pas": 80588.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.57483093086,
-          "borhf": null
+          "prove_pr_pas": 1.57483093086
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 1003532.33333,
           "tot_pas": 691776.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.4506601122,
-          "borhf": null
+          "prove_pr_pas": 1.4506601122
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 57818,
           "tot_pas": 40811.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.41671431138,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41671431138
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 73567,
           "tot_pas": 56028,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.31303990862,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.31303990862
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 261696,
           "tot_pas": 179190,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.46043864055,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.46043864055
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 610451.333333,
           "tot_pas": 414891,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.47135352016,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.47135352016
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 1003532.33333,
           "tot_pas": 690586.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.45315985112,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.45315985112
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00266599336101,
-          "menn": 0.00307495285541,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00307495285541
         },
         {
           "alder": 1,
           "kvinner": 0.00660335415406,
-          "menn": 0.00803027696542,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00803027696542
         },
         {
           "alder": 2,
           "kvinner": 0.00853164736805,
-          "menn": 0.00952336398631,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00952336398631
         },
         {
           "alder": 3,
           "kvinner": 0.0103108563159,
-          "menn": 0.0121676194472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0121676194472
         },
         {
           "alder": 4,
           "kvinner": 0.0117622176283,
-          "menn": 0.0132355883093,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0132355883093
         },
         {
           "alder": 5,
           "kvinner": 0.0132437465668,
-          "menn": 0.0144631377203,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0144631377203
         },
         {
           "alder": 6,
           "kvinner": 0.0151850428653,
-          "menn": 0.0152277875661,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0152277875661
         },
         {
           "alder": 7,
           "kvinner": 0.0170868347339,
-          "menn": 0.0167284402078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0167284402078
         },
         {
           "alder": 8,
           "kvinner": 0.0189735355642,
-          "menn": 0.019098743792,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.019098743792
         },
         {
           "alder": 9,
           "kvinner": 0.0205440473481,
-          "menn": 0.0208409462592,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0208409462592
         },
         {
           "alder": 10,
           "kvinner": 0.0236853049034,
-          "menn": 0.0237234887624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0237234887624
         },
         {
           "alder": 11,
           "kvinner": 0.0261506473275,
-          "menn": 0.0244037648798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0244037648798
         },
         {
           "alder": 12,
           "kvinner": 0.032380952381,
-          "menn": 0.025501742579,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.025501742579
         },
         {
           "alder": 13,
           "kvinner": 0.042913820972,
-          "menn": 0.0301944542286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0301944542286
         },
         {
           "alder": 14,
           "kvinner": 0.0563770675674,
-          "menn": 0.0369888567081,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0369888567081
         },
         {
           "alder": 15,
           "kvinner": 0.0666787802488,
-          "menn": 0.0389171734168,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0389171734168
         },
         {
           "alder": 16,
           "kvinner": 0.0731055868251,
-          "menn": 0.0404019103145,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0404019103145
         },
         {
           "alder": 17,
           "kvinner": 0.0798704698377,
-          "menn": 0.0425206672211,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0425206672211
         },
         {
           "alder": 18,
           "kvinner": 0.0828025477707,
-          "menn": 0.0423604796117,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0423604796117
         },
         {
           "alder": 19,
           "kvinner": 0.0804049196078,
-          "menn": 0.0420186590728,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0420186590728
         },
         {
           "alder": 20,
           "kvinner": 0.0817870710496,
-          "menn": 0.0409422387527,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0409422387527
         },
         {
           "alder": 21,
           "kvinner": 0.0816555845727,
-          "menn": 0.04202134381,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.04202134381
         },
         {
           "alder": 22,
           "kvinner": 0.0829384031162,
-          "menn": 0.0441325571593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0441325571593
         },
         {
           "alder": 23,
           "kvinner": 0.0849044651314,
-          "menn": 0.0445971930102,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0445971930102
         },
         {
           "alder": 24,
           "kvinner": 0.0850440923366,
-          "menn": 0.0467724926458,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0467724926458
         },
         {
           "alder": 25,
           "kvinner": 0.0866912845683,
-          "menn": 0.0474169902701,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0474169902701
         },
         {
           "alder": 26,
           "kvinner": 0.0888267744661,
-          "menn": 0.0476121454186,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0476121454186
         },
         {
           "alder": 27,
           "kvinner": 0.0872460228434,
-          "menn": 0.0490919364804,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0490919364804
         },
         {
           "alder": 28,
           "kvinner": 0.0886843688515,
-          "menn": 0.0493537015276,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0493537015276
         },
         {
           "alder": 29,
           "kvinner": 0.0901442050536,
-          "menn": 0.0510246608046,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0510246608046
         },
         {
           "alder": 30,
           "kvinner": 0.0952950281551,
-          "menn": 0.0527530276593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0527530276593
         },
         {
           "alder": 31,
           "kvinner": 0.0983945250291,
-          "menn": 0.0542474475907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0542474475907
         },
         {
           "alder": 32,
           "kvinner": 0.100435653535,
-          "menn": 0.0552942718574,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0552942718574
         },
         {
           "alder": 33,
           "kvinner": 0.10323459123,
-          "menn": 0.055421111288,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.055421111288
         },
         {
           "alder": 34,
           "kvinner": 0.105889876792,
-          "menn": 0.0562887427881,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0562887427881
         },
         {
           "alder": 35,
           "kvinner": 0.104378815829,
-          "menn": 0.0557673256665,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0557673256665
         },
         {
           "alder": 36,
           "kvinner": 0.103906511236,
-          "menn": 0.0568662872316,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0568662872316
         },
         {
           "alder": 37,
           "kvinner": 0.103522774663,
-          "menn": 0.0585570323088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0585570323088
         },
         {
           "alder": 38,
           "kvinner": 0.105660553238,
-          "menn": 0.0584660944912,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0584660944912
         },
         {
           "alder": 39,
           "kvinner": 0.106794583053,
-          "menn": 0.0611721490502,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0611721490502
         },
         {
           "alder": 40,
           "kvinner": 0.109571058576,
-          "menn": 0.0633432362402,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0633432362402
         },
         {
           "alder": 41,
           "kvinner": 0.109674238464,
-          "menn": 0.0636697627342,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0636697627342
         },
         {
           "alder": 42,
           "kvinner": 0.108989676784,
-          "menn": 0.0648397782623,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0648397782623
         },
         {
           "alder": 43,
           "kvinner": 0.109484397391,
-          "menn": 0.0654289123859,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0654289123859
         },
         {
           "alder": 44,
           "kvinner": 0.109116939045,
-          "menn": 0.0668654523928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0668654523928
         },
         {
           "alder": 45,
           "kvinner": 0.110092156807,
-          "menn": 0.066553275247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.066553275247
         },
         {
           "alder": 46,
           "kvinner": 0.111146672553,
-          "menn": 0.0681326642029,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0681326642029
         },
         {
           "alder": 47,
           "kvinner": 0.116067630215,
-          "menn": 0.0725251236076,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0725251236076
         },
         {
           "alder": 48,
           "kvinner": 0.118987012706,
-          "menn": 0.0767456943143,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0767456943143
         },
         {
           "alder": 49,
           "kvinner": 0.123599920341,
-          "menn": 0.080092272203,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.080092272203
         },
         {
           "alder": 50,
           "kvinner": 0.127364588912,
-          "menn": 0.0851416617165,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0851416617165
         },
         {
           "alder": 51,
           "kvinner": 0.132540124772,
-          "menn": 0.0883660239448,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0883660239448
         },
         {
           "alder": 52,
           "kvinner": 0.135431037337,
-          "menn": 0.0909762887084,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0909762887084
         },
         {
           "alder": 53,
           "kvinner": 0.138441667837,
-          "menn": 0.0940536049088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0940536049088
         },
         {
           "alder": 54,
           "kvinner": 0.14127002354,
-          "menn": 0.0998570352828,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0998570352828
         },
         {
           "alder": 55,
           "kvinner": 0.141942689199,
-          "menn": 0.104629092046,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104629092046
         },
         {
           "alder": 56,
           "kvinner": 0.146004979493,
-          "menn": 0.108287787627,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.108287787627
         },
         {
           "alder": 57,
           "kvinner": 0.145634114824,
-          "menn": 0.114325670317,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114325670317
         },
         {
           "alder": 58,
           "kvinner": 0.147884139525,
-          "menn": 0.114592080225,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114592080225
         },
         {
           "alder": 59,
           "kvinner": 0.14813493454,
-          "menn": 0.117699087866,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.117699087866
         },
         {
           "alder": 60,
           "kvinner": 0.1504592478,
-          "menn": 0.121009980914,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.121009980914
         },
         {
           "alder": 61,
           "kvinner": 0.15114905986,
-          "menn": 0.124275293371,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124275293371
         },
         {
           "alder": 62,
           "kvinner": 0.153273282723,
-          "menn": 0.126651918451,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126651918451
         },
         {
           "alder": 63,
           "kvinner": 0.154852222481,
-          "menn": 0.132440535151,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132440535151
         },
         {
           "alder": 64,
           "kvinner": 0.159712978791,
-          "menn": 0.13721699038,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13721699038
         },
         {
           "alder": 65,
           "kvinner": 0.165197920173,
-          "menn": 0.141677825481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141677825481
         },
         {
           "alder": 66,
           "kvinner": 0.170648995745,
-          "menn": 0.1468655909,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.1468655909
         },
         {
           "alder": 67,
           "kvinner": 0.175017724596,
-          "menn": 0.151152948044,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151152948044
         },
         {
           "alder": 68,
           "kvinner": 0.178547502485,
-          "menn": 0.154523678455,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.154523678455
         },
         {
           "alder": 69,
           "kvinner": 0.18233988657,
-          "menn": 0.157746266405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157746266405
         },
         {
           "alder": 70,
           "kvinner": 0.183316308136,
-          "menn": 0.162691691463,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162691691463
         },
         {
           "alder": 71,
           "kvinner": 0.185224011539,
-          "menn": 0.16192530159,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16192530159
         },
         {
           "alder": 72,
           "kvinner": 0.192732443799,
-          "menn": 0.169872673849,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.169872673849
         },
         {
           "alder": 73,
           "kvinner": 0.206431333494,
-          "menn": 0.181309611898,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181309611898
         },
         {
           "alder": 74,
           "kvinner": 0.221662324042,
-          "menn": 0.200217211868,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.200217211868
         },
         {
           "alder": 75,
           "kvinner": 0.23896413288,
-          "menn": 0.217767549782,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.217767549782
         },
         {
           "alder": 76,
           "kvinner": 0.261774122051,
-          "menn": 0.241396125005,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.241396125005
         },
         {
           "alder": 77,
           "kvinner": 0.272080476324,
-          "menn": 0.251305121851,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.251305121851
         },
         {
           "alder": 78,
           "kvinner": 0.269630220741,
-          "menn": 0.249986486486,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.249986486486
         },
         {
           "alder": 79,
           "kvinner": 0.271193290896,
-          "menn": 0.259426327778,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.259426327778
         },
         {
           "alder": 80,
           "kvinner": 0.266711057359,
-          "menn": 0.247246732568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.247246732568
         },
         {
           "alder": 81,
           "kvinner": 0.27176462125,
-          "menn": 0.25181064533,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25181064533
         },
         {
           "alder": 82,
           "kvinner": 0.285055221585,
-          "menn": 0.264799207745,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.264799207745
         },
         {
           "alder": 83,
           "kvinner": 0.300774932615,
-          "menn": 0.281220902505,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.281220902505
         },
         {
           "alder": 84,
           "kvinner": 0.300447525769,
-          "menn": 0.291312583188,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.291312583188
         },
         {
           "alder": 85,
           "kvinner": 0.299962834732,
-          "menn": 0.285427941471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.285427941471
         },
         {
           "alder": 86,
           "kvinner": 0.298792209963,
-          "menn": 0.293500032306,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.293500032306
         },
         {
           "alder": 87,
           "kvinner": 0.299648525823,
-          "menn": 0.293711628583,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.293711628583
         },
         {
           "alder": 88,
           "kvinner": 0.309732348192,
-          "menn": 0.300947271356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.300947271356
         },
         {
           "alder": 89,
           "kvinner": 0.313956320533,
-          "menn": 0.319597791798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.319597791798
         },
         {
           "alder": 90,
           "kvinner": 0.327497361396,
-          "menn": 0.326880164043,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.326880164043
         },
         {
           "alder": 91,
           "kvinner": 0.345006997022,
-          "menn": 0.342175066313,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.342175066313
         },
         {
           "alder": 92,
           "kvinner": 0.350968735298,
-          "menn": 0.353899447617,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.353899447617
         },
         {
           "alder": 93,
           "kvinner": 0.346578366446,
-          "menn": 0.360534304797,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.360534304797
         },
         {
           "alder": 94,
           "kvinner": 0.358324286353,
-          "menn": 0.370758891985,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.370758891985
         },
         {
           "alder": 95,
           "kvinner": 0.35642439974,
-          "menn": 0.367360496014,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.367360496014
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/asat_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/asat_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 22965.3333333,
           "tot_pas": 15257.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.50516680139,
-          "borhf": null
+          "prove_pr_pas": 1.50516680139
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 45378,
           "tot_pas": 31572.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.43725585422,
-          "borhf": null
+          "prove_pr_pas": 1.43725585422
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 33034.6666667,
           "tot_pas": 23435,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.40962947159,
-          "borhf": null
+          "prove_pr_pas": 1.40962947159
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 24236.6666667,
           "tot_pas": 16624,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.45793230671,
-          "borhf": null
+          "prove_pr_pas": 1.45793230671
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 26821.6666667,
           "tot_pas": 19319,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.38835688528,
-          "borhf": null
+          "prove_pr_pas": 1.38835688528
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 25225.6666667,
           "tot_pas": 19462.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.29610536412,
-          "borhf": null
+          "prove_pr_pas": 1.29610536412
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 65636,
           "tot_pas": 45848.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.43158966157,
-          "borhf": null
+          "prove_pr_pas": 1.43158966157
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 7443.66666667,
           "tot_pas": 5273,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.41165686832,
-          "borhf": null
+          "prove_pr_pas": 1.41165686832
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 29018.6666667,
           "tot_pas": 19326,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.50153506502,
-          "borhf": null
+          "prove_pr_pas": 1.50153506502
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 24683.6666667,
           "tot_pas": 16548.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.49161043408,
-          "borhf": null
+          "prove_pr_pas": 1.49161043408
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 48181.3333333,
           "tot_pas": 34736.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.38705869934,
-          "borhf": null
+          "prove_pr_pas": 1.38705869934
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 170655.333333,
           "tot_pas": 108229.333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.57679372197,
-          "borhf": null
+          "prove_pr_pas": 1.57679372197
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 158889.666667,
           "tot_pas": 108213.333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.46830027107,
-          "borhf": null
+          "prove_pr_pas": 1.46830027107
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 91313.6666667,
           "tot_pas": 63161.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.44572101074,
-          "borhf": null
+          "prove_pr_pas": 1.44572101074
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 43984,
           "tot_pas": 31987.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.37502995946,
-          "borhf": null
+          "prove_pr_pas": 1.37502995946
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 43615,
           "tot_pas": 30380,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.43564845293,
-          "borhf": null
+          "prove_pr_pas": 1.43564845293
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 88945.3333333,
           "tot_pas": 59304.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.49981170572,
-          "borhf": null
+          "prove_pr_pas": 1.49981170572
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 83699,
           "tot_pas": 57659.3333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.45161234377,
-          "borhf": null
+          "prove_pr_pas": 1.45161234377
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 89316,
           "tot_pas": 56863.3333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.57071340641,
-          "borhf": null
+          "prove_pr_pas": 1.57071340641
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 66853.6666667,
           "tot_pas": 44342.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.50767137498,
-          "borhf": null
+          "prove_pr_pas": 1.50767137498
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 29590.6666667,
           "tot_pas": 20214.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.46384578599,
-          "borhf": null
+          "prove_pr_pas": 1.46384578599
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 1219491.33333,
           "tot_pas": 827762,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.47323908724,
-          "borhf": null
+          "prove_pr_pas": 1.47323908724
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 125614.666667,
           "tot_pas": 86846,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.44640705003,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44640705003
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 117683.333333,
           "tot_pas": 84608.6666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.3909134604,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.3909134604
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 109327.333333,
           "tot_pas": 75859.6666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.44117866763,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44117866763
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 866866,
           "tot_pas": 578419.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.4986808878,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.4986808878
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 1219491.33333,
           "tot_pas": 825230.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.47775873483,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.47775873483
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00328236508514,
-          "menn": 0.00401784457767,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00401784457767
         },
         {
           "alder": 1,
           "kvinner": 0.0081557983426,
-          "menn": 0.00942714605195,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00942714605195
         },
         {
           "alder": 2,
           "kvinner": 0.0101228955033,
-          "menn": 0.0107998289136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107998289136
         },
         {
           "alder": 3,
           "kvinner": 0.0128085603763,
-          "menn": 0.0141278124508,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0141278124508
         },
         {
           "alder": 4,
           "kvinner": 0.0149893225809,
-          "menn": 0.0160427462394,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160427462394
         },
         {
           "alder": 5,
           "kvinner": 0.0162046651215,
-          "menn": 0.0169826048879,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0169826048879
         },
         {
           "alder": 6,
           "kvinner": 0.0190409307133,
-          "menn": 0.0185565064183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185565064183
         },
         {
           "alder": 7,
           "kvinner": 0.0207869194189,
-          "menn": 0.0199204174982,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0199204174982
         },
         {
           "alder": 8,
           "kvinner": 0.0239759984135,
-          "menn": 0.023773006135,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.023773006135
         },
         {
           "alder": 9,
           "kvinner": 0.0263360902446,
-          "menn": 0.0263222529069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0263222529069
         },
         {
           "alder": 10,
           "kvinner": 0.0292994593777,
-          "menn": 0.0285852510616,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0285852510616
         },
         {
           "alder": 11,
           "kvinner": 0.0313204726338,
-          "menn": 0.0300844654002,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0300844654002
         },
         {
           "alder": 12,
           "kvinner": 0.0374054738174,
-          "menn": 0.0312582622281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0312582622281
         },
         {
           "alder": 13,
           "kvinner": 0.0488234955885,
-          "menn": 0.0365345608687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0365345608687
         },
         {
           "alder": 14,
           "kvinner": 0.0661363724264,
-          "menn": 0.0467760541947,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0467760541947
         },
         {
           "alder": 15,
           "kvinner": 0.0821495551503,
-          "menn": 0.0542093769912,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0542093769912
         },
         {
           "alder": 16,
           "kvinner": 0.095248332291,
-          "menn": 0.0600694659803,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0600694659803
         },
         {
           "alder": 17,
           "kvinner": 0.105336978793,
-          "menn": 0.0642823949518,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0642823949518
         },
         {
           "alder": 18,
           "kvinner": 0.106398233204,
-          "menn": 0.0640465880964,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0640465880964
         },
         {
           "alder": 19,
           "kvinner": 0.102025234305,
-          "menn": 0.0591347242246,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0591347242246
         },
         {
           "alder": 20,
           "kvinner": 0.103751844526,
-          "menn": 0.057615045878,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.057615045878
         },
         {
           "alder": 21,
           "kvinner": 0.104363072858,
-          "menn": 0.0565645426244,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0565645426244
         },
         {
           "alder": 22,
           "kvinner": 0.105386746244,
-          "menn": 0.0583155808205,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0583155808205
         },
         {
           "alder": 23,
           "kvinner": 0.106666023131,
-          "menn": 0.0610060729772,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0610060729772
         },
         {
           "alder": 24,
           "kvinner": 0.110085937177,
-          "menn": 0.063095964922,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.063095964922
         },
         {
           "alder": 25,
           "kvinner": 0.114861032331,
-          "menn": 0.0657969370391,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0657969370391
         },
         {
           "alder": 26,
           "kvinner": 0.116148930983,
-          "menn": 0.0675180914342,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0675180914342
         },
         {
           "alder": 27,
           "kvinner": 0.117190047024,
-          "menn": 0.0705538157679,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0705538157679
         },
         {
           "alder": 28,
           "kvinner": 0.118251245278,
-          "menn": 0.0721223339538,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0721223339538
         },
         {
           "alder": 29,
           "kvinner": 0.119782194741,
-          "menn": 0.0736428325195,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0736428325195
         },
         {
           "alder": 30,
           "kvinner": 0.12487523685,
-          "menn": 0.0776505570067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0776505570067
         },
         {
           "alder": 31,
           "kvinner": 0.127991434597,
-          "menn": 0.0798415406234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0798415406234
         },
         {
           "alder": 32,
           "kvinner": 0.131615530282,
-          "menn": 0.08101717132,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.08101717132
         },
         {
           "alder": 33,
           "kvinner": 0.13202356472,
-          "menn": 0.0824921721594,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0824921721594
         },
         {
           "alder": 34,
           "kvinner": 0.131680372171,
-          "menn": 0.0825278411378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0825278411378
         },
         {
           "alder": 35,
           "kvinner": 0.131427298636,
-          "menn": 0.0821165525262,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0821165525262
         },
         {
           "alder": 36,
           "kvinner": 0.130968441201,
-          "menn": 0.0841159634785,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0841159634785
         },
         {
           "alder": 37,
           "kvinner": 0.128318891618,
-          "menn": 0.085767061601,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.085767061601
         },
         {
           "alder": 38,
           "kvinner": 0.129104425439,
-          "menn": 0.0853601689106,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0853601689106
         },
         {
           "alder": 39,
           "kvinner": 0.128883559039,
-          "menn": 0.08724380612,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.08724380612
         },
         {
           "alder": 40,
           "kvinner": 0.131118653689,
-          "menn": 0.0921137866333,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0921137866333
         },
         {
           "alder": 41,
           "kvinner": 0.131955994868,
-          "menn": 0.0923563851501,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0923563851501
         },
         {
           "alder": 42,
           "kvinner": 0.131646200096,
-          "menn": 0.093347308712,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.093347308712
         },
         {
           "alder": 43,
           "kvinner": 0.131874945164,
-          "menn": 0.0925595981461,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0925595981461
         },
         {
           "alder": 44,
           "kvinner": 0.129887373215,
-          "menn": 0.0953075240763,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0953075240763
         },
         {
           "alder": 45,
           "kvinner": 0.131939238509,
-          "menn": 0.0951364708525,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0951364708525
         },
         {
           "alder": 46,
           "kvinner": 0.131652135526,
-          "menn": 0.096988913153,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.096988913153
         },
         {
           "alder": 47,
           "kvinner": 0.136847559313,
-          "menn": 0.101262276456,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101262276456
         },
         {
           "alder": 48,
           "kvinner": 0.141175897141,
-          "menn": 0.105091672758,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.105091672758
         },
         {
           "alder": 49,
           "kvinner": 0.146604016298,
-          "menn": 0.11014225298,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11014225298
         },
         {
           "alder": 50,
           "kvinner": 0.151955772653,
-          "menn": 0.118422479919,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118422479919
         },
         {
           "alder": 51,
           "kvinner": 0.158608935068,
-          "menn": 0.122890012945,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.122890012945
         },
         {
           "alder": 52,
           "kvinner": 0.161003013012,
-          "menn": 0.125822398599,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125822398599
         },
         {
           "alder": 53,
           "kvinner": 0.1656156114,
-          "menn": 0.130938938129,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.130938938129
         },
         {
           "alder": 54,
           "kvinner": 0.168972842625,
-          "menn": 0.13897043577,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13897043577
         },
         {
           "alder": 55,
           "kvinner": 0.17121528288,
-          "menn": 0.144042249118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.144042249118
         },
         {
           "alder": 56,
           "kvinner": 0.174378465498,
-          "menn": 0.147694392137,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147694392137
         },
         {
           "alder": 57,
           "kvinner": 0.17605685804,
-          "menn": 0.153872026057,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.153872026057
         },
         {
           "alder": 58,
           "kvinner": 0.177025108965,
-          "menn": 0.156148246594,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.156148246594
         },
         {
           "alder": 59,
           "kvinner": 0.176338674227,
-          "menn": 0.158041829182,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.158041829182
         },
         {
           "alder": 60,
           "kvinner": 0.178980953302,
-          "menn": 0.162185163168,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162185163168
         },
         {
           "alder": 61,
           "kvinner": 0.178360562137,
-          "menn": 0.165867427846,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.165867427846
         },
         {
           "alder": 62,
           "kvinner": 0.180591065833,
-          "menn": 0.16810386528,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16810386528
         },
         {
           "alder": 63,
           "kvinner": 0.181289271585,
-          "menn": 0.174835241755,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.174835241755
         },
         {
           "alder": 64,
           "kvinner": 0.188165104761,
-          "menn": 0.179111540776,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.179111540776
         },
         {
           "alder": 65,
           "kvinner": 0.190433343178,
-          "menn": 0.184141139441,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.184141139441
         },
         {
           "alder": 66,
           "kvinner": 0.198394324916,
-          "menn": 0.187950658059,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.187950658059
         },
         {
           "alder": 67,
           "kvinner": 0.20002749121,
-          "menn": 0.193549328663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.193549328663
         },
         {
           "alder": 68,
           "kvinner": 0.202363161188,
-          "menn": 0.194292770744,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.194292770744
         },
         {
           "alder": 69,
           "kvinner": 0.204771832291,
-          "menn": 0.194735254186,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.194735254186
         },
         {
           "alder": 70,
           "kvinner": 0.206773524817,
-          "menn": 0.19943541619,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.19943541619
         },
         {
           "alder": 71,
           "kvinner": 0.205238583813,
-          "menn": 0.195959488192,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.195959488192
         },
         {
           "alder": 72,
           "kvinner": 0.210318901092,
-          "menn": 0.203102840353,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.203102840353
         },
         {
           "alder": 73,
           "kvinner": 0.222715849588,
-          "menn": 0.213566102632,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.213566102632
         },
         {
           "alder": 74,
           "kvinner": 0.236369893319,
-          "menn": 0.231634736522,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.231634736522
         },
         {
           "alder": 75,
           "kvinner": 0.249878678255,
-          "menn": 0.25031856825,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25031856825
         },
         {
           "alder": 76,
           "kvinner": 0.271555927695,
-          "menn": 0.274099518877,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.274099518877
         },
         {
           "alder": 77,
           "kvinner": 0.275928035595,
-          "menn": 0.277984939976,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.277984939976
         },
         {
           "alder": 78,
           "kvinner": 0.27174257449,
-          "menn": 0.270283783784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.270283783784
         },
         {
           "alder": 79,
           "kvinner": 0.262604829746,
-          "menn": 0.272104663709,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.272104663709
         },
         {
           "alder": 80,
           "kvinner": 0.251382679477,
-          "menn": 0.253814768128,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.253814768128
         },
         {
           "alder": 81,
           "kvinner": 0.249651104237,
-          "menn": 0.249318185923,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.249318185923
         },
         {
           "alder": 82,
           "kvinner": 0.253273684701,
-          "menn": 0.258776450615,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.258776450615
         },
         {
           "alder": 83,
           "kvinner": 0.261741913747,
-          "menn": 0.263393364068,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.263393364068
         },
         {
           "alder": 84,
           "kvinner": 0.260482007263,
-          "menn": 0.263156547558,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.263156547558
         },
         {
           "alder": 85,
           "kvinner": 0.25096336287,
-          "menn": 0.254875010738,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.254875010738
         },
         {
           "alder": 86,
           "kvinner": 0.245904379806,
-          "menn": 0.252148349163,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.252148349163
         },
         {
           "alder": 87,
           "kvinner": 0.233025140478,
-          "menn": 0.241254041487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.241254041487
         },
         {
           "alder": 88,
           "kvinner": 0.22919215149,
-          "menn": 0.24256014754,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.24256014754
         },
         {
           "alder": 89,
           "kvinner": 0.228329409218,
-          "menn": 0.246056782334,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.246056782334
         },
         {
           "alder": 90,
           "kvinner": 0.23188675731,
-          "menn": 0.245521982993,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.245521982993
         },
         {
           "alder": 91,
           "kvinner": 0.231978183645,
-          "menn": 0.255673445329,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.255673445329
         },
         {
           "alder": 92,
           "kvinner": 0.228903810787,
-          "menn": 0.24726149237,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.24726149237
         },
         {
           "alder": 93,
           "kvinner": 0.223163406746,
-          "menn": 0.241772920461,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.241772920461
         },
         {
           "alder": 94,
           "kvinner": 0.228750239479,
-          "menn": 0.244877888871,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.244877888871
         },
         {
           "alder": 95,
           "kvinner": 0.212929915639,
-          "menn": 0.235828166519,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.235828166519
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/b12_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/b12_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 22234.3333333,
           "tot_pas": 16937,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.31276692055,
-          "borhf": null
+          "prove_pr_pas": 1.31276692055
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 63958.3333333,
           "tot_pas": 47822.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.33740625087,
-          "borhf": null
+          "prove_pr_pas": 1.33740625087
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 47064.3333333,
           "tot_pas": 35802.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.31456050351,
-          "borhf": null
+          "prove_pr_pas": 1.31456050351
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 32081.6666667,
           "tot_pas": 23130.6666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.38697544386,
-          "borhf": null
+          "prove_pr_pas": 1.38697544386
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 53851.6666667,
           "tot_pas": 39134.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.3760721617,
-          "borhf": null
+          "prove_pr_pas": 1.3760721617
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 119693.666667,
           "tot_pas": 90287,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.32570211289,
-          "borhf": null
+          "prove_pr_pas": 1.32570211289
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 111414,
           "tot_pas": 82713.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.34698417432,
-          "borhf": null
+          "prove_pr_pas": 1.34698417432
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 45237.6666667,
           "tot_pas": 31593.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.43185870586,
-          "borhf": null
+          "prove_pr_pas": 1.43185870586
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 234270,
           "tot_pas": 156104.333333,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.50072707783,
-          "borhf": null
+          "prove_pr_pas": 1.50072707783
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 76459,
           "tot_pas": 54593.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.40051898889,
-          "borhf": null
+          "prove_pr_pas": 1.40051898889
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 138391,
           "tot_pas": 103064.666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.34275891511,
-          "borhf": null
+          "prove_pr_pas": 1.34275891511
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 173588.333333,
           "tot_pas": 122254.333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.41989513664,
-          "borhf": null
+          "prove_pr_pas": 1.41989513664
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 278859.333333,
           "tot_pas": 200695.333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.38946595669,
-          "borhf": null
+          "prove_pr_pas": 1.38946595669
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 129002.666667,
           "tot_pas": 92843.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.38946113718,
-          "borhf": null
+          "prove_pr_pas": 1.38946113718
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 63863.6666667,
           "tot_pas": 48147.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.32641249489,
-          "borhf": null
+          "prove_pr_pas": 1.32641249489
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 63235.3333333,
           "tot_pas": 45423,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.39214348091,
-          "borhf": null
+          "prove_pr_pas": 1.39214348091
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 168495,
           "tot_pas": 117032.333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.43973033093,
-          "borhf": null
+          "prove_pr_pas": 1.43973033093
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 237642.666667,
           "tot_pas": 169375.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.4030508121,
-          "borhf": null
+          "prove_pr_pas": 1.4030508121
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 131611.666667,
           "tot_pas": 90984,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.44653638735,
-          "borhf": null
+          "prove_pr_pas": 1.44653638735
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 73913.6666667,
           "tot_pas": 53179,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.38990328262,
-          "borhf": null
+          "prove_pr_pas": 1.38990328262
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 141661.333333,
           "tot_pas": 98354.6666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.44031125451,
-          "borhf": null
+          "prove_pr_pas": 1.44031125451
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 2406570.66667,
           "tot_pas": 1719509,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.39956852024,
-          "borhf": null
+          "prove_pr_pas": 1.39956852024
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 165338.666667,
           "tot_pas": 123625.333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.33741735782,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.33741735782
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 284959.333333,
           "tot_pas": 212016.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.34404424816,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.34404424816
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 494357.666667,
           "tot_pas": 345118.666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.43242807305,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.43242807305
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1461915,
           "tot_pas": 1034465.33333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.41320830471,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41320830471
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 2406570.66667,
           "tot_pas": 1713559,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.40442824943,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40442824943
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.0153944407726,
-          "menn": 0.0185623012187,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185623012187
         },
         {
           "alder": 1,
           "kvinner": 0.0284906306713,
-          "menn": 0.0336968862894,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0336968862894
         },
         {
           "alder": 2,
           "kvinner": 0.0337571925836,
-          "menn": 0.0389021065013,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0389021065013
         },
         {
           "alder": 3,
           "kvinner": 0.0424818412045,
-          "menn": 0.0489064876488,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0489064876488
         },
         {
           "alder": 4,
           "kvinner": 0.0475605679159,
-          "menn": 0.0542200940882,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0542200940882
         },
         {
           "alder": 5,
           "kvinner": 0.0521711169764,
-          "menn": 0.0565769516351,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0565769516351
         },
         {
           "alder": 6,
           "kvinner": 0.0599716439863,
-          "menn": 0.0614082557262,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0614082557262
         },
         {
           "alder": 7,
           "kvinner": 0.0664386684907,
-          "menn": 0.0675149682042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0675149682042
         },
         {
           "alder": 8,
           "kvinner": 0.075171279978,
-          "menn": 0.0761515240043,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0761515240043
         },
         {
           "alder": 9,
           "kvinner": 0.0829286491135,
-          "menn": 0.0827108206385,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0827108206385
         },
         {
           "alder": 10,
           "kvinner": 0.0931722808211,
-          "menn": 0.0904801438222,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0904801438222
         },
         {
           "alder": 11,
           "kvinner": 0.10256732394,
-          "menn": 0.0939610517343,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0939610517343
         },
         {
           "alder": 12,
           "kvinner": 0.122607182408,
-          "menn": 0.096064174979,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.096064174979
         },
         {
           "alder": 13,
           "kvinner": 0.159810379305,
-          "menn": 0.108941736606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.108941736606
         },
         {
           "alder": 14,
           "kvinner": 0.205912308069,
-          "menn": 0.127350154632,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127350154632
         },
         {
           "alder": 15,
           "kvinner": 0.233353017904,
-          "menn": 0.133862456774,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133862456774
         },
         {
           "alder": 16,
           "kvinner": 0.249244319366,
-          "menn": 0.129181914036,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129181914036
         },
         {
           "alder": 17,
           "kvinner": 0.26210467123,
-          "menn": 0.131218510003,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131218510003
         },
         {
           "alder": 18,
           "kvinner": 0.257004769068,
-          "menn": 0.124022137777,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124022137777
         },
         {
           "alder": 19,
           "kvinner": 0.244135219225,
-          "menn": 0.119198827553,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.119198827553
         },
         {
           "alder": 20,
           "kvinner": 0.248055006122,
-          "menn": 0.118235992444,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118235992444
         },
         {
           "alder": 21,
           "kvinner": 0.254412772499,
-          "menn": 0.120245603152,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.120245603152
         },
         {
           "alder": 22,
           "kvinner": 0.257859366114,
-          "menn": 0.125357423588,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125357423588
         },
         {
           "alder": 23,
           "kvinner": 0.26405873871,
-          "menn": 0.129071911494,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129071911494
         },
         {
           "alder": 24,
           "kvinner": 0.267469851015,
-          "menn": 0.132646944552,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132646944552
         },
         {
           "alder": 25,
           "kvinner": 0.276737240557,
-          "menn": 0.136551551115,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136551551115
         },
         {
           "alder": 26,
           "kvinner": 0.279826734778,
-          "menn": 0.137548583822,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137548583822
         },
         {
           "alder": 27,
           "kvinner": 0.280901359886,
-          "menn": 0.140273237607,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140273237607
         },
         {
           "alder": 28,
           "kvinner": 0.285630660661,
-          "menn": 0.141889292139,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141889292139
         },
         {
           "alder": 29,
           "kvinner": 0.289164295342,
-          "menn": 0.144090513848,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.144090513848
         },
         {
           "alder": 30,
           "kvinner": 0.300173467482,
-          "menn": 0.149968510278,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.149968510278
         },
         {
           "alder": 31,
           "kvinner": 0.310033142513,
-          "menn": 0.152071223756,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.152071223756
         },
         {
           "alder": 32,
           "kvinner": 0.316018476964,
-          "menn": 0.153902215231,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.153902215231
         },
         {
           "alder": 33,
           "kvinner": 0.317556827655,
-          "menn": 0.154317253091,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.154317253091
         },
         {
           "alder": 34,
           "kvinner": 0.317494184829,
-          "menn": 0.155829867168,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.155829867168
         },
         {
           "alder": 35,
           "kvinner": 0.313022222476,
-          "menn": 0.152915966749,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.152915966749
         },
         {
           "alder": 36,
           "kvinner": 0.30831229029,
-          "menn": 0.155483126748,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.155483126748
         },
         {
           "alder": 37,
           "kvinner": 0.303548260044,
-          "menn": 0.157860796572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157860796572
         },
         {
           "alder": 38,
           "kvinner": 0.301956374822,
-          "menn": 0.157662672407,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157662672407
         },
         {
           "alder": 39,
           "kvinner": 0.302600251543,
-          "menn": 0.160720983079,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160720983079
         },
         {
           "alder": 40,
           "kvinner": 0.305823290798,
-          "menn": 0.167005450322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167005450322
         },
         {
           "alder": 41,
           "kvinner": 0.305523214371,
-          "menn": 0.166578127709,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.166578127709
         },
         {
           "alder": 42,
           "kvinner": 0.302367639298,
-          "menn": 0.16869664647,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16869664647
         },
         {
           "alder": 43,
           "kvinner": 0.296200976808,
-          "menn": 0.167890544778,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167890544778
         },
         {
           "alder": 44,
           "kvinner": 0.294855882743,
-          "menn": 0.171282770868,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.171282770868
         },
         {
           "alder": 45,
           "kvinner": 0.292404813573,
-          "menn": 0.170103175495,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170103175495
         },
         {
           "alder": 46,
           "kvinner": 0.293499613729,
-          "menn": 0.174633588107,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.174633588107
         },
         {
           "alder": 47,
           "kvinner": 0.301172620671,
-          "menn": 0.183484049038,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.183484049038
         },
         {
           "alder": 48,
           "kvinner": 0.309664106758,
-          "menn": 0.190072988192,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.190072988192
         },
         {
           "alder": 49,
           "kvinner": 0.319210088647,
-          "menn": 0.199313084711,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.199313084711
         },
         {
           "alder": 50,
           "kvinner": 0.324434851755,
-          "menn": 0.211637697255,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.211637697255
         },
         {
           "alder": 51,
           "kvinner": 0.333163984398,
-          "menn": 0.218024631028,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.218024631028
         },
         {
           "alder": 52,
           "kvinner": 0.337010385511,
-          "menn": 0.224908651502,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.224908651502
         },
         {
           "alder": 53,
           "kvinner": 0.340626140671,
-          "menn": 0.232630603375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.232630603375
         },
         {
           "alder": 54,
           "kvinner": 0.344071883792,
-          "menn": 0.243634796084,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.243634796084
         },
         {
           "alder": 55,
           "kvinner": 0.348561351947,
-          "menn": 0.254248358716,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.254248358716
         },
         {
           "alder": 56,
           "kvinner": 0.348678750556,
-          "menn": 0.261447664539,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.261447664539
         },
         {
           "alder": 57,
           "kvinner": 0.35115992862,
-          "menn": 0.271956429381,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.271956429381
         },
         {
           "alder": 58,
           "kvinner": 0.351161242511,
-          "menn": 0.276702812094,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276702812094
         },
         {
           "alder": 59,
           "kvinner": 0.350492147931,
-          "menn": 0.279616719388,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.279616719388
         },
         {
           "alder": 60,
           "kvinner": 0.351213381031,
-          "menn": 0.288770689278,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.288770689278
         },
         {
           "alder": 61,
           "kvinner": 0.351543542297,
-          "menn": 0.295147478592,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.295147478592
         },
         {
           "alder": 62,
           "kvinner": 0.351820529966,
-          "menn": 0.298683624965,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.298683624965
         },
         {
           "alder": 63,
           "kvinner": 0.35368197081,
-          "menn": 0.309388908699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.309388908699
         },
         {
           "alder": 64,
           "kvinner": 0.36402640487,
-          "menn": 0.31872173284,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.31872173284
         },
         {
           "alder": 65,
           "kvinner": 0.371367342313,
-          "menn": 0.329056171399,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.329056171399
         },
         {
           "alder": 66,
           "kvinner": 0.38140447012,
-          "menn": 0.33685199553,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.33685199553
         },
         {
           "alder": 67,
           "kvinner": 0.385556986385,
-          "menn": 0.34360040864,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.34360040864
         },
         {
           "alder": 68,
           "kvinner": 0.39258659403,
-          "menn": 0.349768645946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.349768645946
         },
         {
           "alder": 69,
           "kvinner": 0.39631763396,
-          "menn": 0.352911449691,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.352911449691
         },
         {
           "alder": 70,
           "kvinner": 0.39847975003,
-          "menn": 0.362317845426,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.362317845426
         },
         {
           "alder": 71,
           "kvinner": 0.395265497911,
-          "menn": 0.35761044345,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.35761044345
         },
         {
           "alder": 72,
           "kvinner": 0.406175304832,
-          "menn": 0.37042115573,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.37042115573
         },
         {
           "alder": 73,
           "kvinner": 0.430936690345,
-          "menn": 0.392509533838,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.392509533838
         },
         {
           "alder": 74,
           "kvinner": 0.46021991708,
-          "menn": 0.427481645597,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.427481645597
         },
         {
           "alder": 75,
           "kvinner": 0.491701592624,
-          "menn": 0.461286825539,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.461286825539
         },
         {
           "alder": 76,
           "kvinner": 0.533911244644,
-          "menn": 0.504291101383,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.504291101383
         },
         {
           "alder": 77,
           "kvinner": 0.548588870021,
-          "menn": 0.519859503933,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.519859503933
         },
         {
           "alder": 78,
           "kvinner": 0.539366059169,
-          "menn": 0.512391891892,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.512391891892
         },
         {
           "alder": 79,
           "kvinner": 0.534859048196,
-          "menn": 0.522973864045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.522973864045
         },
         {
           "alder": 80,
           "kvinner": 0.514044218565,
-          "menn": 0.491226033305,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.491226033305
         },
         {
           "alder": 81,
           "kvinner": 0.519271994821,
-          "menn": 0.48958766052,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.48958766052
         },
         {
           "alder": 82,
           "kvinner": 0.531074762726,
-          "menn": 0.508013500677,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.508013500677
         },
         {
           "alder": 83,
           "kvinner": 0.549865229111,
-          "menn": 0.527218222697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.527218222697
         },
         {
           "alder": 84,
           "kvinner": 0.550383331499,
-          "menn": 0.534529538241,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.534529538241
         },
         {
           "alder": 85,
           "kvinner": 0.539972223852,
-          "menn": 0.520659737136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.520659737136
         },
         {
           "alder": 86,
           "kvinner": 0.528084252758,
-          "menn": 0.517962137365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.517962137365
         },
         {
           "alder": 87,
           "kvinner": 0.516756587342,
-          "menn": 0.512660297163,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.512660297163
         },
         {
           "alder": 88,
           "kvinner": 0.522703919362,
-          "menn": 0.513748009054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.513748009054
         },
         {
           "alder": 89,
           "kvinner": 0.533571486563,
-          "menn": 0.532087933754,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.532087933754
         },
         {
           "alder": 90,
           "kvinner": 0.544111255976,
-          "menn": 0.540860020505,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.540860020505
         },
         {
           "alder": 91,
           "kvinner": 0.544511823173,
-          "menn": 0.54133510168,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.54133510168
         },
         {
           "alder": 92,
           "kvinner": 0.548094606732,
-          "menn": 0.552195487314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.552195487314
         },
         {
           "alder": 93,
           "kvinner": 0.535397094307,
-          "menn": 0.555798421372,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.555798421372
         },
         {
           "alder": 94,
           "kvinner": 0.538284692509,
-          "menn": 0.568267497132,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.568267497132
         },
         {
           "alder": 95,
           "kvinner": 0.533500973394,
-          "menn": 0.558680248007,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.558680248007
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/b9_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/b9_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 18834.3333333,
           "tot_pas": 14590.3333333,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.29087752165,
-          "borhf": null
+          "prove_pr_pas": 1.29087752165
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 53853.6666667,
           "tot_pas": 40585.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.32691344235,
-          "borhf": null
+          "prove_pr_pas": 1.32691344235
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 37785,
           "tot_pas": 29215,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.29334246106,
-          "borhf": null
+          "prove_pr_pas": 1.29334246106
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 25898.3333333,
           "tot_pas": 18885.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.37134637108,
-          "borhf": null
+          "prove_pr_pas": 1.37134637108
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 41458.6666667,
           "tot_pas": 30710.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.34997612122,
-          "borhf": null
+          "prove_pr_pas": 1.34997612122
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 90500.3333333,
           "tot_pas": 69873.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.29520561015,
-          "borhf": null
+          "prove_pr_pas": 1.29520561015
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 94746.6666667,
           "tot_pas": 70788.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.33845030961,
-          "borhf": null
+          "prove_pr_pas": 1.33845030961
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 37886.6666667,
           "tot_pas": 26911,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.40785056916,
-          "borhf": null
+          "prove_pr_pas": 1.40785056916
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 217497.333333,
           "tot_pas": 146432,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.48531286422,
-          "borhf": null
+          "prove_pr_pas": 1.48531286422
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 68674,
           "tot_pas": 49115,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.39822864705,
-          "borhf": null
+          "prove_pr_pas": 1.39822864705
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 117380,
           "tot_pas": 88596,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.32489051424,
-          "borhf": null
+          "prove_pr_pas": 1.32489051424
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 113583,
           "tot_pas": 82976.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.36885469811,
-          "borhf": null
+          "prove_pr_pas": 1.36885469811
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 187125.666667,
           "tot_pas": 139280,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.34352144361,
-          "borhf": null
+          "prove_pr_pas": 1.34352144361
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 75795.6666667,
           "tot_pas": 57269,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.32350253482,
-          "borhf": null
+          "prove_pr_pas": 1.32350253482
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 35518.6666667,
           "tot_pas": 28104.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.26381459561,
-          "borhf": null
+          "prove_pr_pas": 1.26381459561
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 36615.3333333,
           "tot_pas": 27521.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.33041845818,
-          "borhf": null
+          "prove_pr_pas": 1.33041845818
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 135704.333333,
           "tot_pas": 95593,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.4196053407,
-          "borhf": null
+          "prove_pr_pas": 1.4196053407
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 156021.666667,
           "tot_pas": 114326.333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.36470454459,
-          "borhf": null
+          "prove_pr_pas": 1.36470454459
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 103441.666667,
           "tot_pas": 73290.3333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.41139577298,
-          "borhf": null
+          "prove_pr_pas": 1.41139577298
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 65033,
           "tot_pas": 47554.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.36755150249,
-          "borhf": null
+          "prove_pr_pas": 1.36755150249
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 114400.666667,
           "tot_pas": 79922.6666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.43139201228,
-          "borhf": null
+          "prove_pr_pas": 1.43139201228
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 1827777.66667,
           "tot_pas": 1331561,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.37265785545,
-          "borhf": null
+          "prove_pr_pas": 1.37265785545
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 136371.333333,
           "tot_pas": 103225.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.32109908066,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.32109908066
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 226705.666667,
           "tot_pas": 171281.666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.32358396014,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.32358396014
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 441438,
           "tot_pas": 310847,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.42011343201,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.42011343201
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1023262.66667,
           "tot_pas": 743755.666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.37580486782,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.37580486782
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 1827777.66667,
           "tot_pas": 1327957,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.37638317104,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.37638317104
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.010515450137,
-          "menn": 0.0131864111008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0131864111008
         },
         {
           "alder": 1,
           "kvinner": 0.0227618929615,
-          "menn": 0.0266299673146,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0266299673146
         },
         {
           "alder": 2,
           "kvinner": 0.0269446615046,
-          "menn": 0.030935896065,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.030935896065
         },
         {
           "alder": 3,
           "kvinner": 0.0335415912949,
-          "menn": 0.0393874232968,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0393874232968
         },
         {
           "alder": 4,
           "kvinner": 0.0374016688158,
-          "menn": 0.0437529442892,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0437529442892
         },
         {
           "alder": 5,
           "kvinner": 0.0415801390694,
-          "menn": 0.0455852208183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0455852208183
         },
         {
           "alder": 6,
           "kvinner": 0.0475294491778,
-          "menn": 0.0495846967027,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0495846967027
         },
         {
           "alder": 7,
           "kvinner": 0.0535144290274,
-          "menn": 0.0540838715276,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0540838715276
         },
         {
           "alder": 8,
           "kvinner": 0.0598632318981,
-          "menn": 0.0622687213945,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0622687213945
         },
         {
           "alder": 9,
           "kvinner": 0.0670258239118,
-          "menn": 0.0669378365912,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0669378365912
         },
         {
           "alder": 10,
           "kvinner": 0.0751893438181,
-          "menn": 0.0733863309224,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0733863309224
         },
         {
           "alder": 11,
           "kvinner": 0.082264923709,
-          "menn": 0.0771096977247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0771096977247
         },
         {
           "alder": 12,
           "kvinner": 0.0991741813004,
-          "menn": 0.0783800024036,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0783800024036
         },
         {
           "alder": 13,
           "kvinner": 0.129814787603,
-          "menn": 0.0886521807781,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0886521807781
         },
         {
           "alder": 14,
           "kvinner": 0.169292353707,
-          "menn": 0.10379338275,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.10379338275
         },
         {
           "alder": 15,
           "kvinner": 0.192476167609,
-          "menn": 0.10803521166,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.10803521166
         },
         {
           "alder": 16,
           "kvinner": 0.20501094434,
-          "menn": 0.103578738448,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103578738448
         },
         {
           "alder": 17,
           "kvinner": 0.215928848901,
-          "menn": 0.104448955633,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104448955633
         },
         {
           "alder": 18,
           "kvinner": 0.208910796018,
-          "menn": 0.0962896941301,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0962896941301
         },
         {
           "alder": 19,
           "kvinner": 0.198336800982,
-          "menn": 0.0925387539171,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0925387539171
         },
         {
           "alder": 20,
           "kvinner": 0.201494458573,
-          "menn": 0.0908787873471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0908787873471
         },
         {
           "alder": 21,
           "kvinner": 0.204892173387,
-          "menn": 0.0929857210141,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0929857210141
         },
         {
           "alder": 22,
           "kvinner": 0.207917764827,
-          "menn": 0.0957040817489,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0957040817489
         },
         {
           "alder": 23,
           "kvinner": 0.21160053333,
-          "menn": 0.098554778029,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.098554778029
         },
         {
           "alder": 24,
           "kvinner": 0.214127291116,
-          "menn": 0.101232169618,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101232169618
         },
         {
           "alder": 25,
           "kvinner": 0.219639529096,
-          "menn": 0.10344583097,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.10344583097
         },
         {
           "alder": 26,
           "kvinner": 0.222699104759,
-          "menn": 0.103738538513,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103738538513
         },
         {
           "alder": 27,
           "kvinner": 0.223632515707,
-          "menn": 0.104663628346,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104663628346
         },
         {
           "alder": 28,
           "kvinner": 0.226930519195,
-          "menn": 0.105430363029,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.105430363029
         },
         {
           "alder": 29,
           "kvinner": 0.22992040908,
-          "menn": 0.106973250256,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106973250256
         },
         {
           "alder": 30,
           "kvinner": 0.238968802541,
-          "menn": 0.111200016519,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111200016519
         },
         {
           "alder": 31,
           "kvinner": 0.245286876426,
-          "menn": 0.112694898293,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112694898293
         },
         {
           "alder": 32,
           "kvinner": 0.250905787187,
-          "menn": 0.113744920697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113744920697
         },
         {
           "alder": 33,
           "kvinner": 0.252525982326,
-          "menn": 0.113294061455,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113294061455
         },
         {
           "alder": 34,
           "kvinner": 0.251815295456,
-          "menn": 0.114412988058,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114412988058
         },
         {
           "alder": 35,
           "kvinner": 0.248136704494,
-          "menn": 0.113160615067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113160615067
         },
         {
           "alder": 36,
           "kvinner": 0.243505482722,
-          "menn": 0.114156990347,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114156990347
         },
         {
           "alder": 37,
           "kvinner": 0.239191881748,
-          "menn": 0.116250601145,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.116250601145
         },
         {
           "alder": 38,
           "kvinner": 0.238394584139,
-          "menn": 0.115906660451,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115906660451
         },
         {
           "alder": 39,
           "kvinner": 0.238620608968,
-          "menn": 0.118957795574,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118957795574
         },
         {
           "alder": 40,
           "kvinner": 0.240677885923,
-          "menn": 0.123737937813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123737937813
         },
         {
           "alder": 41,
           "kvinner": 0.240275863708,
-          "menn": 0.122452174983,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.122452174983
         },
         {
           "alder": 42,
           "kvinner": 0.238252228,
-          "menn": 0.124180954997,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124180954997
         },
         {
           "alder": 43,
           "kvinner": 0.232135232358,
-          "menn": 0.122942857936,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.122942857936
         },
         {
           "alder": 44,
           "kvinner": 0.230252789692,
-          "menn": 0.125750242544,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125750242544
         },
         {
           "alder": 45,
           "kvinner": 0.229253445312,
-          "menn": 0.125457978317,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125457978317
         },
         {
           "alder": 46,
           "kvinner": 0.229693190597,
-          "menn": 0.128664118932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128664118932
         },
         {
           "alder": 47,
           "kvinner": 0.235058631034,
-          "menn": 0.13423295823,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13423295823
         },
         {
           "alder": 48,
           "kvinner": 0.243725696212,
-          "menn": 0.14017541873,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.14017541873
         },
         {
           "alder": 49,
           "kvinner": 0.250025566087,
-          "menn": 0.146789696271,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146789696271
         },
         {
           "alder": 50,
           "kvinner": 0.252370674499,
-          "menn": 0.155975102663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.155975102663
         },
         {
           "alder": 51,
           "kvinner": 0.261299944279,
-          "menn": 0.161141407472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161141407472
         },
         {
           "alder": 52,
           "kvinner": 0.263230214001,
-          "menn": 0.1652870466,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.1652870466
         },
         {
           "alder": 53,
           "kvinner": 0.265882352941,
-          "menn": 0.171313064599,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.171313064599
         },
         {
           "alder": 54,
           "kvinner": 0.268105873572,
-          "menn": 0.178896879877,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.178896879877
         },
         {
           "alder": 55,
           "kvinner": 0.270060249816,
-          "menn": 0.186252288866,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.186252288866
         },
         {
           "alder": 56,
           "kvinner": 0.271713113867,
-          "menn": 0.191458457723,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.191458457723
         },
         {
           "alder": 57,
           "kvinner": 0.271798658544,
-          "menn": 0.199124339124,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.199124339124
         },
         {
           "alder": 58,
           "kvinner": 0.271770941932,
-          "menn": 0.202217053795,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.202217053795
         },
         {
           "alder": 59,
           "kvinner": 0.2704934221,
-          "menn": 0.205755351494,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.205755351494
         },
         {
           "alder": 60,
           "kvinner": 0.270488897483,
-          "menn": 0.210612934514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.210612934514
         },
         {
           "alder": 61,
           "kvinner": 0.270622737241,
-          "menn": 0.215572470663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.215572470663
         },
         {
           "alder": 62,
           "kvinner": 0.270365417142,
-          "menn": 0.217830722297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.217830722297
         },
         {
           "alder": 63,
           "kvinner": 0.271285614548,
-          "menn": 0.227009786442,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.227009786442
         },
         {
           "alder": 64,
           "kvinner": 0.279784869226,
-          "menn": 0.233999689019,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.233999689019
         },
         {
           "alder": 65,
           "kvinner": 0.284004972903,
-          "menn": 0.240623144991,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.240623144991
         },
         {
           "alder": 66,
           "kvinner": 0.291669321553,
-          "menn": 0.24777740606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.24777740606
         },
         {
           "alder": 67,
           "kvinner": 0.295132608916,
-          "menn": 0.25350262697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25350262697
         },
         {
           "alder": 68,
           "kvinner": 0.300739868222,
-          "menn": 0.258722270989,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.258722270989
         },
         {
           "alder": 69,
           "kvinner": 0.303787725945,
-          "menn": 0.262452858651,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.262452858651
         },
         {
           "alder": 70,
           "kvinner": 0.305612306213,
-          "menn": 0.267765316243,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.267765316243
         },
         {
           "alder": 71,
           "kvinner": 0.302359816211,
-          "menn": 0.265422455247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.265422455247
         },
         {
           "alder": 72,
           "kvinner": 0.314385343863,
-          "menn": 0.276513222331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276513222331
         },
         {
           "alder": 73,
           "kvinner": 0.333221813315,
-          "menn": 0.291674459072,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.291674459072
         },
         {
           "alder": 74,
           "kvinner": 0.355718335709,
-          "menn": 0.31966636257,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.31966636257
         },
         {
           "alder": 75,
           "kvinner": 0.380641461155,
-          "menn": 0.346687841153,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.346687841153
         },
         {
           "alder": 76,
           "kvinner": 0.413121213614,
-          "menn": 0.378668024793,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.378668024793
         },
         {
           "alder": 77,
           "kvinner": 0.426509468435,
-          "menn": 0.393617533139,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.393617533139
         },
         {
           "alder": 78,
           "kvinner": 0.418809336604,
-          "menn": 0.388067567568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.388067567568
         },
         {
           "alder": 79,
           "kvinner": 0.417929675659,
-          "menn": 0.398393478,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.398393478
         },
         {
           "alder": 80,
           "kvinner": 0.403864708041,
-          "menn": 0.377463013335,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.377463013335
         },
         {
           "alder": 81,
           "kvinner": 0.410171930077,
-          "menn": 0.376794841693,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.376794841693
         },
         {
           "alder": 82,
           "kvinner": 0.421113130466,
-          "menn": 0.396208492492,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.396208492492
         },
         {
           "alder": 83,
           "kvinner": 0.437870619946,
-          "menn": 0.411168896055,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.411168896055
         },
         {
           "alder": 84,
           "kvinner": 0.441454825575,
-          "menn": 0.423620354254,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.423620354254
         },
         {
           "alder": 85,
           "kvinner": 0.434755393854,
-          "menn": 0.414483291813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414483291813
         },
         {
           "alder": 86,
           "kvinner": 0.426048980274,
-          "menn": 0.413710667442,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.413710667442
         },
         {
           "alder": 87,
           "kvinner": 0.419597483714,
-          "menn": 0.412177135176,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.412177135176
         },
         {
           "alder": 88,
           "kvinner": 0.426921759554,
-          "menn": 0.413655796798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.413655796798
         },
         {
           "alder": 89,
           "kvinner": 0.435874536548,
-          "menn": 0.434591876972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.434591876972
         },
         {
           "alder": 90,
           "kvinner": 0.448935245545,
-          "menn": 0.441529461432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.441529461432
         },
         {
           "alder": 91,
           "kvinner": 0.453371129212,
-          "menn": 0.441865605659,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.441865605659
         },
         {
           "alder": 92,
           "kvinner": 0.454471579488,
-          "menn": 0.453328340043,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.453328340043
         },
         {
           "alder": 93,
           "kvinner": 0.447712921608,
-          "menn": 0.462416514876,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.462416514876
         },
         {
           "alder": 94,
           "kvinner": 0.455073759499,
-          "menn": 0.463202753647,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.463202753647
         },
         {
           "alder": 95,
           "kvinner": 0.456440622972,
-          "menn": 0.460584588131,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.460584588131
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/ca125_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/ca125_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 535.333333333,
           "tot_pas": 370,
           "tot_pop": 36125.6666667,
-          "prove_pr_pas": 1.44684684685,
-          "borhf": null
+          "prove_pr_pas": 1.44684684685
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 1800,
           "tot_pas": 1321.33333333,
           "tot_pop": 94805,
-          "prove_pr_pas": 1.36226034309,
-          "borhf": null
+          "prove_pr_pas": 1.36226034309
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 1560.33333333,
           "tot_pas": 1210,
           "tot_pop": 68295.3333333,
-          "prove_pr_pas": 1.28953168044,
-          "borhf": null
+          "prove_pr_pas": 1.28953168044
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 708.666666667,
           "tot_pas": 528.333333333,
           "tot_pop": 37869,
-          "prove_pr_pas": 1.34132492114,
-          "borhf": null
+          "prove_pr_pas": 1.34132492114
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 1396.33333333,
           "tot_pas": 1049.66666667,
           "tot_pop": 66769.6666667,
-          "prove_pr_pas": 1.33026357574,
-          "borhf": null
+          "prove_pr_pas": 1.33026357574
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 3690.33333333,
           "tot_pas": 2360.33333333,
           "tot_pop": 166899.666667,
-          "prove_pr_pas": 1.5634797345,
-          "borhf": null
+          "prove_pr_pas": 1.5634797345
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 2558,
           "tot_pas": 1771,
           "tot_pop": 130852,
-          "prove_pr_pas": 1.44438170525,
-          "borhf": null
+          "prove_pr_pas": 1.44438170525
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 1221.33333333,
           "tot_pas": 825.666666667,
           "tot_pop": 53122,
-          "prove_pr_pas": 1.47920872023,
-          "borhf": null
+          "prove_pr_pas": 1.47920872023
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 6305.33333333,
           "tot_pas": 3889.66666667,
           "tot_pop": 228427,
-          "prove_pr_pas": 1.62104721913,
-          "borhf": null
+          "prove_pr_pas": 1.62104721913
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 3761,
           "tot_pas": 2650.66666667,
           "tot_pop": 88873.3333333,
-          "prove_pr_pas": 1.41888832998,
-          "borhf": null
+          "prove_pr_pas": 1.41888832998
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 4006.33333333,
           "tot_pas": 2999.33333333,
           "tot_pop": 185999.333333,
-          "prove_pr_pas": 1.33574127584,
-          "borhf": null
+          "prove_pr_pas": 1.33574127584
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 5494.33333333,
           "tot_pas": 4126.66666667,
           "tot_pop": 161320.666667,
-          "prove_pr_pas": 1.33142164782,
-          "borhf": null
+          "prove_pr_pas": 1.33142164782
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 12253.3333333,
           "tot_pas": 8771,
           "tot_pop": 295089.666667,
-          "prove_pr_pas": 1.39702808498,
-          "borhf": null
+          "prove_pr_pas": 1.39702808498
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 4827.33333333,
           "tot_pas": 3687.66666667,
           "tot_pop": 142479.333333,
-          "prove_pr_pas": 1.30904817861,
-          "borhf": null
+          "prove_pr_pas": 1.30904817861
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 2322.66666667,
           "tot_pas": 1804.33333333,
           "tot_pop": 80220.6666667,
-          "prove_pr_pas": 1.28727138371,
-          "borhf": null
+          "prove_pr_pas": 1.28727138371
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 2855.33333333,
           "tot_pas": 2126.33333333,
           "tot_pop": 74026.6666667,
-          "prove_pr_pas": 1.34284370591,
-          "borhf": null
+          "prove_pr_pas": 1.34284370591
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 4838.66666667,
           "tot_pas": 3534.66666667,
           "tot_pop": 168998,
-          "prove_pr_pas": 1.36891738966,
-          "borhf": null
+          "prove_pr_pas": 1.36891738966
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 8468,
           "tot_pas": 6227.66666667,
           "tot_pop": 247013.333333,
-          "prove_pr_pas": 1.35973879998,
-          "borhf": null
+          "prove_pr_pas": 1.35973879998
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 4122,
           "tot_pas": 2807.33333333,
           "tot_pop": 125303,
-          "prove_pr_pas": 1.46829731655,
-          "borhf": null
+          "prove_pr_pas": 1.46829731655
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 2053.33333333,
           "tot_pas": 1475.66666667,
           "tot_pop": 86985,
-          "prove_pr_pas": 1.39146148633,
-          "borhf": null
+          "prove_pr_pas": 1.39146148633
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 2927.33333333,
           "tot_pas": 1973.33333333,
           "tot_pop": 155046.333333,
-          "prove_pr_pas": 1.48344594595,
-          "borhf": null
+          "prove_pr_pas": 1.48344594595
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 77713.6666667,
           "tot_pas": 55418.3333333,
           "tot_pop": 2694520.66667,
-          "prove_pr_pas": 1.40230970497,
-          "borhf": null
+          "prove_pr_pas": 1.40230970497
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 4604.33333333,
           "tot_pas": 3428.66666667,
           "tot_pop": 237095,
-          "prove_pr_pas": 1.34289325297,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.34289325297
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 7644.66666667,
           "tot_pas": 5180,
           "tot_pop": 364521.333333,
-          "prove_pr_pas": 1.4758043758,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.4758043758
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 15294,
           "tot_pas": 10361,
           "tot_pop": 556421.666667,
-          "prove_pr_pas": 1.47611234437,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.47611234437
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 50170.6666667,
           "tot_pas": 36468.6666667,
           "tot_pop": 1536482.66667,
-          "prove_pr_pas": 1.37571979599,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.37571979599
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 77713.6666667,
           "tot_pas": 55418.3333333,
           "tot_pop": 2694520.66667,
-          "prove_pr_pas": 1.40230970497,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40230970497
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 3.7130826755e-05,
-          "menn": 7.03650538996e-06,
-          "bohf": null,
-          "borhf": null
+          "menn": 7.03650538996e-06
         },
         {
           "alder": 1,
           "kvinner": 3.64423518436e-05,
-          "menn": 3.44056425254e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.44056425254e-05
         },
         {
           "alder": 2,
           "kvinner": 3.55189315905e-05,
-          "menn": 2.00491873396e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 2.00491873396e-05
         },
         {
           "alder": 3,
           "kvinner": 4.87017504801e-05,
-          "menn": 3.93349766612e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.93349766612e-05
         },
         {
           "alder": 4,
           "kvinner": 2.0467896105e-05,
-          "menn": 4.51726563458e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 4.51726563458e-05
         },
         {
           "alder": 5,
           "kvinner": 5.35912860569e-05,
-          "menn": 3.17313245289e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.17313245289e-05
         },
         {
           "alder": 6,
           "kvinner": 6.62523685222e-05,
-          "menn": 3.77548452051e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.77548452051e-05
         },
         {
           "alder": 7,
           "kvinner": 9.11992704058e-05,
-          "menn": 7.43761698752e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 7.43761698752e-05
         },
         {
           "alder": 8,
           "kvinner": 0.000134337237643,
-          "menn": 6.69490700166e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 6.69490700166e-05
         },
         {
           "alder": 9,
           "kvinner": 0.000164402964312,
-          "menn": 7.18859888217e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 7.18859888217e-05
         },
         {
           "alder": 10,
           "kvinner": 0.000176426852167,
-          "menn": 3.58360857438e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.58360857438e-05
         },
         {
           "alder": 11,
           "kvinner": 0.000201013863675,
-          "menn": 8.34520538147e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 8.34520538147e-05
         },
         {
           "alder": 12,
           "kvinner": 0.000360702420503,
-          "menn": 0.000102151183752,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000102151183752
         },
         {
           "alder": 13,
           "kvinner": 0.00051110699386,
-          "menn": 0.00010323928437,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00010323928437
         },
         {
           "alder": 14,
           "kvinner": 0.00100558227081,
-          "menn": 9.81787835649e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 9.81787835649e-05
         },
         {
           "alder": 15,
           "kvinner": 0.00132384147647,
-          "menn": 0.000148467995868,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000148467995868
         },
         {
           "alder": 16,
           "kvinner": 0.00179799874922,
-          "menn": 0.000241890467035,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000241890467035
         },
         {
           "alder": 17,
           "kvinner": 0.00271470400031,
-          "menn": 0.000189551435699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000189551435699
         },
         {
           "alder": 18,
           "kvinner": 0.00318151265884,
-          "menn": 0.000295090062692,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000295090062692
         },
         {
           "alder": 19,
           "kvinner": 0.00401483772039,
-          "menn": 0.000220429659109,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000220429659109
         },
         {
           "alder": 20,
           "kvinner": 0.00441430410348,
-          "menn": 0.000233922232554,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000233922232554
         },
         {
           "alder": 21,
           "kvinner": 0.0054885690825,
-          "menn": 0.000224006616811,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000224006616811
         },
         {
           "alder": 22,
           "kvinner": 0.00580929609676,
-          "menn": 0.00022214374409,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00022214374409
         },
         {
           "alder": 23,
           "kvinner": 0.00596678149755,
-          "menn": 0.000242467985768,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000242467985768
         },
         {
           "alder": 24,
           "kvinner": 0.00731027874874,
-          "menn": 0.000338569129156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000338569129156
         },
         {
           "alder": 25,
           "kvinner": 0.00832879947214,
-          "menn": 0.000278153497098,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000278153497098
         },
         {
           "alder": 26,
           "kvinner": 0.00877665455246,
-          "menn": 0.000327471064442,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000327471064442
         },
         {
           "alder": 27,
           "kvinner": 0.00909537992275,
-          "menn": 0.000411915990262,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000411915990262
         },
         {
           "alder": 28,
           "kvinner": 0.00992428061161,
-          "menn": 0.000467955450641,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000467955450641
         },
         {
           "alder": 29,
           "kvinner": 0.0105211921522,
-          "menn": 0.000452775047979,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000452775047979
         },
         {
           "alder": 30,
           "kvinner": 0.0116410023752,
-          "menn": 0.000511062700682,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000511062700682
         },
         {
           "alder": 31,
           "kvinner": 0.0125199070288,
-          "menn": 0.000502963335528,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000502963335528
         },
         {
           "alder": 32,
           "kvinner": 0.0129218341233,
-          "menn": 0.000566260322454,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000566260322454
         },
         {
           "alder": 33,
           "kvinner": 0.0140888123159,
-          "menn": 0.000583771161705,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000583771161705
         },
         {
           "alder": 34,
           "kvinner": 0.0148506166062,
-          "menn": 0.000670870790286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000670870790286
         },
         {
           "alder": 35,
           "kvinner": 0.0158258753919,
-          "menn": 0.00066761424818,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00066761424818
         },
         {
           "alder": 36,
           "kvinner": 0.0167825475342,
-          "menn": 0.00071280103601,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00071280103601
         },
         {
           "alder": 37,
           "kvinner": 0.017156294889,
-          "menn": 0.000694049752984,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000694049752984
         },
         {
           "alder": 38,
           "kvinner": 0.0171226492042,
-          "menn": 0.000855521127533,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000855521127533
         },
         {
           "alder": 39,
           "kvinner": 0.0184562286115,
-          "menn": 0.000794228605467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000794228605467
         },
         {
           "alder": 40,
           "kvinner": 0.0193715481864,
-          "menn": 0.0009549231594,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0009549231594
         },
         {
           "alder": 41,
           "kvinner": 0.0207848215559,
-          "menn": 0.000945036878806,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000945036878806
         },
         {
           "alder": 42,
           "kvinner": 0.0211860135548,
-          "menn": 0.000936051432383,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000936051432383
         },
         {
           "alder": 43,
           "kvinner": 0.0217705378294,
-          "menn": 0.0010323869786,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0010323869786
         },
         {
           "alder": 44,
           "kvinner": 0.0230853157995,
-          "menn": 0.000981139107986,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000981139107986
         },
         {
           "alder": 45,
           "kvinner": 0.0231040216442,
-          "menn": 0.00103228981135,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00103228981135
         },
         {
           "alder": 46,
           "kvinner": 0.0239984549167,
-          "menn": 0.00129136569797,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00129136569797
         },
         {
           "alder": 47,
           "kvinner": 0.0248213798746,
-          "menn": 0.00133854223412,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00133854223412
         },
         {
           "alder": 48,
           "kvinner": 0.0263645324466,
-          "menn": 0.00130225758964,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00130225758964
         },
         {
           "alder": 49,
           "kvinner": 0.0268201708353,
-          "menn": 0.00136870434448,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00136870434448
         },
         {
           "alder": 50,
           "kvinner": 0.0266251223879,
-          "menn": 0.00144115292234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00144115292234
         },
         {
           "alder": 51,
           "kvinner": 0.0282703464551,
-          "menn": 0.00168435061526,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00168435061526
         },
         {
           "alder": 52,
           "kvinner": 0.0273102519673,
-          "menn": 0.00162513826781,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00162513826781
         },
         {
           "alder": 53,
           "kvinner": 0.0268370068791,
-          "menn": 0.00184293506051,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00184293506051
         },
         {
           "alder": 54,
           "kvinner": 0.0265430326692,
-          "menn": 0.00176250395608,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00176250395608
         },
         {
           "alder": 55,
           "kvinner": 0.0261396032329,
-          "menn": 0.00190924925193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00190924925193
         },
         {
           "alder": 56,
           "kvinner": 0.0263528223139,
-          "menn": 0.00198640518073,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00198640518073
         },
         {
           "alder": 57,
           "kvinner": 0.0262568457326,
-          "menn": 0.0022363576284,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0022363576284
         },
         {
           "alder": 58,
           "kvinner": 0.0257809654202,
-          "menn": 0.00236203823965,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00236203823965
         },
         {
           "alder": 59,
           "kvinner": 0.0261650686459,
-          "menn": 0.00229722674365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00229722674365
         },
         {
           "alder": 60,
           "kvinner": 0.026426890973,
-          "menn": 0.00237164043678,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00237164043678
         },
         {
           "alder": 61,
           "kvinner": 0.0268935805769,
-          "menn": 0.00232159847764,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00232159847764
         },
         {
           "alder": 62,
           "kvinner": 0.026983440192,
-          "menn": 0.00257341322309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00257341322309
         },
         {
           "alder": 63,
           "kvinner": 0.027254895442,
-          "menn": 0.00276027840511,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00276027840511
         },
         {
           "alder": 64,
           "kvinner": 0.0272426910265,
-          "menn": 0.0026703804109,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0026703804109
         },
         {
           "alder": 65,
           "kvinner": 0.0288964138774,
-          "menn": 0.00285757671972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00285757671972
         },
         {
           "alder": 66,
           "kvinner": 0.0298409192277,
-          "menn": 0.00301802988134,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00301802988134
         },
         {
           "alder": 67,
           "kvinner": 0.0299654189516,
-          "menn": 0.00317425569177,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00317425569177
         },
         {
           "alder": 68,
           "kvinner": 0.0298008613391,
-          "menn": 0.00321366402333,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00321366402333
         },
         {
           "alder": 69,
           "kvinner": 0.0290897950339,
-          "menn": 0.00332629355861,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00332629355861
         },
         {
           "alder": 70,
           "kvinner": 0.0294811320755,
-          "menn": 0.00357061112383,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00357061112383
         },
         {
           "alder": 71,
           "kvinner": 0.0283713253335,
-          "menn": 0.00370367547877,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00370367547877
         },
         {
           "alder": 72,
           "kvinner": 0.029537684185,
-          "menn": 0.00340058765916,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00340058765916
         },
         {
           "alder": 73,
           "kvinner": 0.0307561835256,
-          "menn": 0.0040168153322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0040168153322
         },
         {
           "alder": 74,
           "kvinner": 0.031520901955,
-          "menn": 0.00446587601547,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00446587601547
         },
         {
           "alder": 75,
           "kvinner": 0.0338818546786,
-          "menn": 0.00487837349512,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00487837349512
         },
         {
           "alder": 76,
           "kvinner": 0.0364379648328,
-          "menn": 0.0051146460925,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0051146460925
         },
         {
           "alder": 77,
           "kvinner": 0.0357457601616,
-          "menn": 0.00541294777107,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00541294777107
         },
         {
           "alder": 78,
           "kvinner": 0.0344783073005,
-          "menn": 0.00495945945946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00495945945946
         },
         {
           "alder": 79,
           "kvinner": 0.0336970799232,
-          "menn": 0.00551492626783,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00551492626783
         },
         {
           "alder": 80,
           "kvinner": 0.0309421245023,
-          "menn": 0.00474358123798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00474358123798
         },
         {
           "alder": 81,
           "kvinner": 0.0302712035105,
-          "menn": 0.00520165441508,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00520165441508
         },
         {
           "alder": 82,
           "kvinner": 0.0297621821458,
-          "menn": 0.00501222740961,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00501222740961
         },
         {
           "alder": 83,
           "kvinner": 0.028167115903,
-          "menn": 0.00479186064997,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00479186064997
         },
         {
           "alder": 84,
           "kvinner": 0.0270166171454,
-          "menn": 0.00445377290877,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00445377290877
         },
         {
           "alder": 85,
           "kvinner": 0.0251745789566,
-          "menn": 0.00501102425336,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00501102425336
         },
         {
           "alder": 86,
           "kvinner": 0.0235289200936,
-          "menn": 0.00436131033146,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00436131033146
         },
         {
           "alder": 87,
           "kvinner": 0.0212003850545,
-          "menn": 0.00356014095252,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00356014095252
         },
         {
           "alder": 88,
           "kvinner": 0.0221167490336,
-          "menn": 0.00347891692514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00347891692514
         },
         {
           "alder": 89,
           "kvinner": 0.0195123271359,
-          "menn": 0.00443611987382,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00443611987382
         },
         {
           "alder": 90,
           "kvinner": 0.017911467064,
-          "menn": 0.00398045956215,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00398045956215
         },
         {
           "alder": 91,
           "kvinner": 0.016936380925,
-          "menn": 0.00272620100206,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00272620100206
         },
         {
           "alder": 92,
           "kvinner": 0.0148838800736,
-          "menn": 0.00224698061979,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00224698061979
         },
         {
           "alder": 93,
           "kvinner": 0.014785153242,
-          "menn": 0.00437158469945,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00437158469945
         },
         {
           "alder": 94,
           "kvinner": 0.0143687336356,
-          "menn": 0.00442550401574,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00442550401574
         },
         {
           "alder": 95,
           "kvinner": 0.0125730045425,
-          "menn": 0.00155004428698,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00155004428698
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/cea_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/cea_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 1018.66666667,
           "tot_pas": 618.333333333,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.6474393531,
-          "borhf": null
+          "prove_pr_pas": 1.6474393531
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 2438,
           "tot_pas": 1490.66666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.635509839,
-          "borhf": null
+          "prove_pr_pas": 1.635509839
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 2677,
           "tot_pas": 1849,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.44780962683,
-          "borhf": null
+          "prove_pr_pas": 1.44780962683
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 1583,
           "tot_pas": 1032.33333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.53341943817,
-          "borhf": null
+          "prove_pr_pas": 1.53341943817
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 2711,
           "tot_pas": 1742.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.55595944136,
-          "borhf": null
+          "prove_pr_pas": 1.55595944136
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 5577,
           "tot_pas": 3619.33333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.54089150857,
-          "borhf": null
+          "prove_pr_pas": 1.54089150857
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 5801.33333333,
           "tot_pas": 3933,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.47504025765,
-          "borhf": null
+          "prove_pr_pas": 1.47504025765
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 1982.33333333,
           "tot_pas": 1155.33333333,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.71581073283,
-          "borhf": null
+          "prove_pr_pas": 1.71581073283
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 10889.3333333,
           "tot_pas": 6675.33333333,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.63127933686,
-          "borhf": null
+          "prove_pr_pas": 1.63127933686
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 7869.66666667,
           "tot_pas": 5098,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.54367725906,
-          "borhf": null
+          "prove_pr_pas": 1.54367725906
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 7937.66666667,
           "tot_pas": 5474,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.45006698332,
-          "borhf": null
+          "prove_pr_pas": 1.45006698332
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 9653.66666667,
           "tot_pas": 6931.33333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.39275752621,
-          "borhf": null
+          "prove_pr_pas": 1.39275752621
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 20451.3333333,
           "tot_pas": 12229.6666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.67227234321,
-          "borhf": null
+          "prove_pr_pas": 1.67227234321
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 7330.66666667,
           "tot_pas": 4953,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.48004576351,
-          "borhf": null
+          "prove_pr_pas": 1.48004576351
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 3142,
           "tot_pas": 2238.66666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.40351399643,
-          "borhf": null
+          "prove_pr_pas": 1.40351399643
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 4187.33333333,
           "tot_pas": 2893.66666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.4470683101,
-          "borhf": null
+          "prove_pr_pas": 1.4470683101
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 9713.66666667,
           "tot_pas": 6490,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.49671289163,
-          "borhf": null
+          "prove_pr_pas": 1.49671289163
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 12076,
           "tot_pas": 7905,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.52764073371,
-          "borhf": null
+          "prove_pr_pas": 1.52764073371
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 7948.66666667,
           "tot_pas": 5065.33333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.56922874441,
-          "borhf": null
+          "prove_pr_pas": 1.56922874441
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 2829.33333333,
           "tot_pas": 1820.66666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.55400952032,
-          "borhf": null
+          "prove_pr_pas": 1.55400952032
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 5048,
           "tot_pas": 2862,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.76380153739,
-          "borhf": null
+          "prove_pr_pas": 1.76380153739
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 132867.666667,
           "tot_pas": 86079,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.54355495146,
-          "borhf": null
+          "prove_pr_pas": 1.54355495146
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 7716.66666667,
           "tot_pas": 4988.66666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.54683950287,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.54683950287
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 14089.3333333,
           "tot_pas": 9293.66666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.51601449015,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.51601449015
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 28679,
           "tot_pas": 18397.3333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.55886722713,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.55886722713
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 82382.6666667,
           "tot_pas": 53306.6666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.54544772386,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.54544772386
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 132867.666667,
           "tot_pas": 85964.6666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.54560788541,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.54560788541
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 3.7130826755e-05,
-          "menn": 1.40730107799e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 1.40730107799e-05
         },
         {
           "alder": 1,
           "kvinner": 4.37308222123e-05,
-          "menn": 3.44056425254e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 3.44056425254e-05
         },
         {
           "alder": 2,
           "kvinner": 2.84151452724e-05,
-          "menn": 2.67322497861e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 2.67322497861e-05
         },
         {
           "alder": 3,
           "kvinner": 2.78295717029e-05,
-          "menn": 6.55582944354e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 6.55582944354e-05
         },
         {
           "alder": 4,
           "kvinner": 5.45810562799e-05,
-          "menn": 7.74388394499e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 7.74388394499e-05
         },
         {
           "alder": 5,
           "kvinner": 6.0290196814e-05,
-          "menn": 7.61551788695e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 7.61551788695e-05
         },
         {
           "alder": 6,
           "kvinner": 7.95028422266e-05,
-          "menn": 5.03397936068e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 5.03397936068e-05
         },
         {
           "alder": 7,
           "kvinner": 0.00014982737281,
-          "menn": 0.000105366240656,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000105366240656
         },
         {
           "alder": 8,
           "kvinner": 0.00017271930554,
-          "menn": 6.69490700166e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 6.69490700166e-05
         },
         {
           "alder": 9,
           "kvinner": 0.000221311682728,
-          "menn": 0.000131790979507,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000131790979507
         },
         {
           "alder": 10,
           "kvinner": 0.000176426852167,
-          "menn": 0.000185153109676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000185153109676
         },
         {
           "alder": 11,
           "kvinner": 0.000175887130716,
-          "menn": 0.000196708412563,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000196708412563
         },
         {
           "alder": 12,
           "kvinner": 0.000278436956178,
-          "menn": 0.00019228458118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00019228458118
         },
         {
           "alder": 13,
           "kvinner": 0.000300275358893,
-          "menn": 0.000188259871497,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000188259871497
         },
         {
           "alder": 14,
           "kvinner": 0.000560805497183,
-          "menn": 0.000263855480831,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000263855480831
         },
         {
           "alder": 15,
           "kvinner": 0.000694367833248,
-          "menn": 0.000488707153064,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000488707153064
         },
         {
           "alder": 16,
           "kvinner": 0.000827340004169,
-          "menn": 0.00055820877008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00055820877008
         },
         {
           "alder": 17,
           "kvinner": 0.00137027916206,
-          "menn": 0.000629799931517,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000629799931517
         },
         {
           "alder": 18,
           "kvinner": 0.00165797138559,
-          "menn": 0.000800958741591,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000800958741591
         },
         {
           "alder": 19,
           "kvinner": 0.0018260830836,
-          "menn": 0.000881718636434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000881718636434
         },
         {
           "alder": 20,
           "kvinner": 0.00195912216257,
-          "menn": 0.00102925782324,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00102925782324
         },
         {
           "alder": 21,
           "kvinner": 0.00253745994703,
-          "menn": 0.00114875188108,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00114875188108
         },
         {
           "alder": 22,
           "kvinner": 0.00245824950621,
-          "menn": 0.00130438249735,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00130438249735
         },
         {
           "alder": 23,
           "kvinner": 0.00275714776985,
-          "menn": 0.00147172428571,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00147172428571
         },
         {
           "alder": 24,
           "kvinner": 0.00328844254393,
-          "menn": 0.00168729533219,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00168729533219
         },
         {
           "alder": 25,
           "kvinner": 0.00357113917603,
-          "menn": 0.00172891487412,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00172891487412
         },
         {
           "alder": 26,
           "kvinner": 0.00363426070293,
-          "menn": 0.00205608881445,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00205608881445
         },
         {
           "alder": 27,
           "kvinner": 0.00390670328395,
-          "menn": 0.00216519943599,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00216519943599
         },
         {
           "alder": 28,
           "kvinner": 0.00443909657068,
-          "menn": 0.00227218368811,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00227218368811
         },
         {
           "alder": 29,
           "kvinner": 0.00419884892702,
-          "menn": 0.00238221417289,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00238221417289
         },
         {
           "alder": 30,
           "kvinner": 0.00536414827467,
-          "menn": 0.00293731996655,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00293731996655
         },
         {
           "alder": 31,
           "kvinner": 0.0051489260965,
-          "menn": 0.00308000228148,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00308000228148
         },
         {
           "alder": 32,
           "kvinner": 0.00571384787154,
-          "menn": 0.00376458251409,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00376458251409
         },
         {
           "alder": 33,
           "kvinner": 0.00611348857889,
-          "menn": 0.0034654778963,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0034654778963
         },
         {
           "alder": 34,
           "kvinner": 0.00627642294828,
-          "menn": 0.00389105058366,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00389105058366
         },
         {
           "alder": 35,
           "kvinner": 0.00723615450075,
-          "menn": 0.00401106947495,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00401106947495
         },
         {
           "alder": 36,
           "kvinner": 0.00786375638498,
-          "menn": 0.00432033605032,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00432033605032
         },
         {
           "alder": 37,
           "kvinner": 0.0082190352625,
-          "menn": 0.00444847636952,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00444847636952
         },
         {
           "alder": 38,
           "kvinner": 0.00851180350027,
-          "menn": 0.00494666703227,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00494666703227
         },
         {
           "alder": 39,
           "kvinner": 0.00940653426541,
-          "menn": 0.00515697045911,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00515697045911
         },
         {
           "alder": 40,
           "kvinner": 0.00948472627931,
-          "menn": 0.00599758756254,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00599758756254
         },
         {
           "alder": 41,
           "kvinner": 0.0107220928575,
-          "menn": 0.00572054868058,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00572054868058
         },
         {
           "alder": 42,
           "kvinner": 0.0105010999176,
-          "menn": 0.00622165922123,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00622165922123
         },
         {
           "alder": 43,
           "kvinner": 0.0114994297078,
-          "menn": 0.0068104237782,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0068104237782
         },
         {
           "alder": 44,
           "kvinner": 0.012117048728,
-          "menn": 0.00732839657752,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00732839657752
         },
         {
           "alder": 45,
           "kvinner": 0.0127215849844,
-          "menn": 0.00718858811637,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00718858811637
         },
         {
           "alder": 46,
           "kvinner": 0.0134532612294,
-          "menn": 0.00791092726356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00791092726356
         },
         {
           "alder": 47,
           "kvinner": 0.0134551404418,
-          "menn": 0.00858119711331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00858119711331
         },
         {
           "alder": 48,
           "kvinner": 0.0143412658008,
-          "menn": 0.00913639218028,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00913639218028
         },
         {
           "alder": 49,
           "kvinner": 0.01536118153,
-          "menn": 0.00991413558888,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00991413558888
         },
         {
           "alder": 50,
           "kvinner": 0.0157359774536,
-          "menn": 0.0107957333609,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107957333609
         },
         {
           "alder": 51,
           "kvinner": 0.0173282200881,
-          "menn": 0.0116344959165,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0116344959165
         },
         {
           "alder": 52,
           "kvinner": 0.0173110245345,
-          "menn": 0.0128490770787,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0128490770787
         },
         {
           "alder": 53,
           "kvinner": 0.0186101361786,
-          "menn": 0.0132467615476,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0132467615476
         },
         {
           "alder": 54,
           "kvinner": 0.0186197393351,
-          "menn": 0.0139090482479,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0139090482479
         },
         {
           "alder": 55,
           "kvinner": 0.0197972079353,
-          "menn": 0.0151735072127,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0151735072127
         },
         {
           "alder": 56,
           "kvinner": 0.0206336224005,
-          "menn": 0.0160462499426,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160462499426
         },
         {
           "alder": 57,
           "kvinner": 0.0217278936681,
-          "menn": 0.017772847432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.017772847432
         },
         {
           "alder": 58,
           "kvinner": 0.022006456232,
-          "menn": 0.0182680399915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0182680399915
         },
         {
           "alder": 59,
           "kvinner": 0.0224890899245,
-          "menn": 0.0192745923037,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0192745923037
         },
         {
           "alder": 60,
           "kvinner": 0.0233781301363,
-          "menn": 0.0202496792966,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0202496792966
         },
         {
           "alder": 61,
           "kvinner": 0.0242658603999,
-          "menn": 0.0207040913416,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0207040913416
         },
         {
           "alder": 62,
           "kvinner": 0.0249118252501,
-          "menn": 0.0222513173425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0222513173425
         },
         {
           "alder": 63,
           "kvinner": 0.025738887596,
-          "menn": 0.023528401812,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.023528401812
         },
         {
           "alder": 64,
           "kvinner": 0.0268778335574,
-          "menn": 0.0246148229774,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0246148229774
         },
         {
           "alder": 65,
           "kvinner": 0.0292604523693,
-          "menn": 0.0258148235067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0258148235067
         },
         {
           "alder": 66,
           "kvinner": 0.0306196858031,
-          "menn": 0.0279808383575,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0279808383575
         },
         {
           "alder": 67,
           "kvinner": 0.0317885202494,
-          "menn": 0.0295534150613,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0295534150613
         },
         {
           "alder": 68,
           "kvinner": 0.0324511355689,
-          "menn": 0.0312513948195,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0312513948195
         },
         {
           "alder": 69,
           "kvinner": 0.0325569578635,
-          "menn": 0.0326293558606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0326293558606
         },
         {
           "alder": 70,
           "kvinner": 0.0342131354405,
-          "menn": 0.0330586709392,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0330586709392
         },
         {
           "alder": 71,
           "kvinner": 0.0341110169366,
-          "menn": 0.0335845634464,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0335845634464
         },
         {
           "alder": 72,
           "kvinner": 0.0368294454026,
-          "menn": 0.0352908912831,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0352908912831
         },
         {
           "alder": 73,
           "kvinner": 0.0378441883807,
-          "menn": 0.0378832846816,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0378832846816
         },
         {
           "alder": 74,
           "kvinner": 0.0409845468102,
-          "menn": 0.0426343455406,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0426343455406
         },
         {
           "alder": 75,
           "kvinner": 0.0452022764371,
-          "menn": 0.0469103634531,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0469103634531
         },
         {
           "alder": 76,
           "kvinner": 0.0491947002906,
-          "menn": 0.0514498721338,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0514498721338
         },
         {
           "alder": 77,
           "kvinner": 0.051028523526,
-          "menn": 0.0541294777107,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0541294777107
         },
         {
           "alder": 78,
           "kvinner": 0.050849048854,
-          "menn": 0.0539324324324,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0539324324324
         },
         {
           "alder": 79,
           "kvinner": 0.0498004445792,
-          "menn": 0.0560784078648,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0560784078648
         },
         {
           "alder": 80,
           "kvinner": 0.0486757531696,
-          "menn": 0.0502222517084,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0502222517084
         },
         {
           "alder": 81,
           "kvinner": 0.0468599381339,
-          "menn": 0.0512399082486,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0512399082486
         },
         {
           "alder": 82,
           "kvinner": 0.0476257048325,
-          "menn": 0.0521029123467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0521029123467
         },
         {
           "alder": 83,
           "kvinner": 0.0462938005391,
-          "menn": 0.0521654213885,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0521654213885
         },
         {
           "alder": 84,
           "kvinner": 0.0473386889696,
-          "menn": 0.0530357325689,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0530357325689
         },
         {
           "alder": 85,
           "kvinner": 0.0425640122841,
-          "menn": 0.050711565444,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.050711565444
         },
         {
           "alder": 86,
           "kvinner": 0.0397233366767,
-          "menn": 0.0459391354914,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0459391354914
         },
         {
           "alder": 87,
           "kvinner": 0.0363786966353,
-          "menn": 0.0453373051913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0453373051913
         },
         {
           "alder": 88,
           "kvinner": 0.0366247492293,
-          "menn": 0.0441361388214,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0441361388214
         },
         {
           "alder": 89,
           "kvinner": 0.0335850179968,
-          "menn": 0.0423895899054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0423895899054
         },
         {
           "alder": 90,
           "kvinner": 0.0320668032532,
-          "menn": 0.0398649056149,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0398649056149
         },
         {
           "alder": 91,
           "kvinner": 0.0307868958341,
-          "menn": 0.0381668140289,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0381668140289
         },
         {
           "alder": 92,
           "kvinner": 0.0270304948462,
-          "menn": 0.032393970602,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.032393970602
         },
         {
           "alder": 93,
           "kvinner": 0.024333898044,
-          "menn": 0.0349726775956,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0349726775956
         },
         {
           "alder": 94,
           "kvinner": 0.0241394725078,
-          "menn": 0.0342566792329,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0342566792329
         },
         {
           "alder": 95,
           "kvinner": 0.0250648929267,
-          "menn": 0.031665190434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.031665190434
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/crp_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/crp_rb1.json
@@ -72,17 +72,23 @@
       "type": "linechart",
       "data": "datasett_3",
       "linevars": [
-        "kvinner",
-        "menn"
+        "kvinner_s",
+        "menn_s",
+        "kvinner_l",
+        "menn_l"
       ],
       "linevarsLabels": {
         "nb": [
-          "Kvinner",
-          "Menn"
+          "Kvinner i spes",
+          "Menn i spes",
+          "Kvinner hos lege",
+          "Menn hos lege"
         ],
         "en": [
-          "Women",
-          "Men"
+          "Women at specialist",
+          "Men at specialist",
+          "Women at GP",
+          "Men at GP"
         ]
       },
       "x": [
@@ -200,8 +206,7 @@
           "tot_events": 56270,
           "tot_pas": 30004.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.87537494168,
-          "borhf": null
+          "prove_pr_pas": 1.87537494168
         },
         {
           "bohf": "UNN",
@@ -213,8 +218,7 @@
           "tot_events": 141141.666667,
           "tot_pas": 76281,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.85028600394,
-          "borhf": null
+          "prove_pr_pas": 1.85028600394
         },
         {
           "bohf": "Nordland",
@@ -226,8 +230,7 @@
           "tot_events": 109587.333333,
           "tot_pas": 58531.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.87228493001,
-          "borhf": null
+          "prove_pr_pas": 1.87228493001
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +242,7 @@
           "tot_events": 71549.6666667,
           "tot_pas": 36721.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.94844958426,
-          "borhf": null
+          "prove_pr_pas": 1.94844958426
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +254,7 @@
           "tot_events": 103735,
           "tot_pas": 57586.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.80138227241,
-          "borhf": null
+          "prove_pr_pas": 1.80138227241
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +266,7 @@
           "tot_events": 251321,
           "tot_pas": 138446,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.81529982809,
-          "borhf": null
+          "prove_pr_pas": 1.81529982809
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +278,7 @@
           "tot_events": 192658.333333,
           "tot_pas": 106105.333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.81572713907,
-          "borhf": null
+          "prove_pr_pas": 1.81572713907
         },
         {
           "bohf": "Førde",
@@ -291,8 +290,7 @@
           "tot_events": 80049.6666667,
           "tot_pas": 44125.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.81412934271,
-          "borhf": null
+          "prove_pr_pas": 1.81412934271
         },
         {
           "bohf": "Bergen",
@@ -304,8 +302,7 @@
           "tot_events": 361971.666667,
           "tot_pas": 196122,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.84564539759,
-          "borhf": null
+          "prove_pr_pas": 1.84564539759
         },
         {
           "bohf": "Fonna",
@@ -317,8 +314,7 @@
           "tot_events": 149977.666667,
           "tot_pas": 79276.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.89182609427,
-          "borhf": null
+          "prove_pr_pas": 1.89182609427
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +326,7 @@
           "tot_events": 262079,
           "tot_pas": 148967.666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.75930123539,
-          "borhf": null
+          "prove_pr_pas": 1.75930123539
         },
         {
           "bohf": "Østfold",
@@ -343,8 +338,7 @@
           "tot_events": 294667,
           "tot_pas": 161386.333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.82584853323,
-          "borhf": null
+          "prove_pr_pas": 1.82584853323
         },
         {
           "bohf": "Akershus",
@@ -356,8 +350,7 @@
           "tot_events": 487095,
           "tot_pas": 265574.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.83411695895,
-          "borhf": null
+          "prove_pr_pas": 1.83411695895
         },
         {
           "bohf": "OUS",
@@ -369,8 +362,7 @@
           "tot_events": 205947,
           "tot_pas": 117087.666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.75891283739,
-          "borhf": null
+          "prove_pr_pas": 1.75891283739
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +374,7 @@
           "tot_events": 97061.6666667,
           "tot_pas": 58205,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.66758296824,
-          "borhf": null
+          "prove_pr_pas": 1.66758296824
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +386,7 @@
           "tot_events": 98311.6666667,
           "tot_pas": 55321,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.77711297096,
-          "borhf": null
+          "prove_pr_pas": 1.77711297096
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +398,7 @@
           "tot_events": 309595.333333,
           "tot_pas": 159304.333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.94342066443,
-          "borhf": null
+          "prove_pr_pas": 1.94342066443
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +410,7 @@
           "tot_events": 407820,
           "tot_pas": 222081.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.83635149232,
-          "borhf": null
+          "prove_pr_pas": 1.83635149232
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +422,7 @@
           "tot_events": 233682.333333,
           "tot_pas": 122476.333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.9079795008,
-          "borhf": null
+          "prove_pr_pas": 1.9079795008
         },
         {
           "bohf": "Telemark",
@@ -447,8 +434,7 @@
           "tot_events": 136862.666667,
           "tot_pas": 75379.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.81564436033,
-          "borhf": null
+          "prove_pr_pas": 1.81564436033
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +446,7 @@
           "tot_events": 269830.666667,
           "tot_pas": 145416.333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.8555733079,
-          "borhf": null
+          "prove_pr_pas": 1.8555733079
         },
         {
           "bohf": "Norge",
@@ -473,8 +458,7 @@
           "tot_events": 4321300,
           "tot_pas": 2354456,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.83537088822,
-          "borhf": null
+          "prove_pr_pas": 1.83537088822
         }
       ]
     },
@@ -493,9 +477,7 @@
           "tot_events": 378548.666667,
           "tot_pas": 201394.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.87963600493,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.87963600493
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +489,7 @@
           "tot_events": 547714.333333,
           "tot_pas": 301910.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.81416226231,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.81416226231
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +501,7 @@
           "tot_events": 854078,
           "tot_pas": 468183.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.82423836816,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.82423836816
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +513,7 @@
           "tot_events": 2540959,
           "tot_pas": 1377344.33333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.84482481142,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.84482481142
         },
         {
           "borhf": "Norge",
@@ -549,9 +525,7 @@
           "tot_events": 4321300,
           "tot_pas": 2346519.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.84157869003,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.84157869003
         }
       ]
     },
@@ -562,675 +536,675 @@
       "data": [
         {
           "alder": 0,
-          "kvinner": 0.175688219874,
-          "menn": 0.20750654395,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0579943463435,
+          "menn_s": 0.0724097900745,
+          "kvinner_l": 0.241902975142,
+          "menn_l": 0.284197542807
         },
         {
           "alder": 1,
-          "kvinner": 0.359226839063,
-          "menn": 0.400261482883,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0565347071584,
+          "menn_s": 0.0693136725446,
+          "kvinner_l": 0.550926838888,
+          "menn_l": 0.613585667661
         },
         {
           "alder": 2,
-          "kvinner": 0.325985650352,
-          "menn": 0.356127031651,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0544163940498,
+          "menn_s": 0.0653483882291,
+          "kvinner_l": 0.512079501265,
+          "menn_l": 0.558158310419
         },
         {
           "alder": 3,
-          "kvinner": 0.265800239334,
-          "menn": 0.283664184193,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0563288465021,
+          "menn_s": 0.0673337431414,
+          "kvinner_l": 0.404877165449,
+          "menn_l": 0.425221410195
         },
         {
           "alder": 4,
-          "kvinner": 0.233293079804,
-          "menn": 0.246713689251,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0576791969344,
+          "menn_s": 0.0667526995577,
+          "kvinner_l": 0.344253238357,
+          "menn_l": 0.354929794955
         },
         {
           "alder": 5,
-          "kvinner": 0.208389715832,
-          "menn": 0.216674176413,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0595592273892,
+          "menn_s": 0.0646261430877,
+          "kvinner_l": 0.296400128158,
+          "menn_l": 0.302689618074
         },
         {
           "alder": 6,
-          "kvinner": 0.190150922895,
-          "menn": 0.192644097659,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0620164627564,
+          "menn_s": 0.0631383767747,
+          "kvinner_l": 0.260727779777,
+          "menn_l": 0.261241788515
         },
         {
           "alder": 7,
-          "kvinner": 0.174092892971,
-          "menn": 0.175664117217,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0659851611253,
+          "menn_s": 0.0680713642861,
+          "kvinner_l": 0.23129289536,
+          "menn_l": 0.232018635184
         },
         {
           "alder": 8,
-          "kvinner": 0.164243265546,
-          "menn": 0.162035008277,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0712375608259,
+          "menn_s": 0.0715039440004,
+          "kvinner_l": 0.210150804436,
+          "menn_l": 0.206644726532
         },
         {
           "alder": 9,
-          "kvinner": 0.16026759744,
-          "menn": 0.156615607646,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0753908274313,
+          "menn_s": 0.0763584777648,
+          "kvinner_l": 0.198253152531,
+          "menn_l": 0.192397047637
         },
         {
           "alder": 10,
-          "kvinner": 0.160586241226,
-          "menn": 0.158604542821,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0813302044354,
+          "menn_s": 0.0808690767564,
+          "kvinner_l": 0.188072133782,
+          "menn_l": 0.18550134414
         },
         {
           "alder": 11,
-          "kvinner": 0.162067427588,
-          "menn": 0.158213172311,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0848882147606,
+          "menn_s": 0.0817454774388,
+          "kvinner_l": 0.183147024601,
+          "menn_l": 0.179348200321
         },
         {
           "alder": 12,
-          "kvinner": 0.1667584243,
-          "menn": 0.15655570244,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0937657294887,
+          "menn_s": 0.0806613275206,
+          "kvinner_l": 0.176930425582,
+          "menn_l": 0.172873505055
         },
         {
           "alder": 13,
-          "kvinner": 0.18231186471,
-          "menn": 0.161259762185,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.116124826687,
+          "menn_s": 0.0902794083118,
+          "kvinner_l": 0.179138298533,
+          "menn_l": 0.169503795883
         },
         {
           "alder": 14,
-          "kvinner": 0.221511725347,
-          "menn": 0.180329880713,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.147091418535,
+          "menn_s": 0.103700482328,
+          "kvinner_l": 0.212184258949,
+          "menn_l": 0.186763659366
         },
         {
           "alder": 15,
-          "kvinner": 0.256747373408,
-          "menn": 0.191418549839,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.170874628476,
+          "menn_s": 0.113854167714,
+          "kvinner_l": 0.247601620427,
+          "menn_l": 0.197309011192
         },
         {
           "alder": 16,
-          "kvinner": 0.303881332083,
-          "menn": 0.207790113502,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.189575876024,
+          "menn_s": 0.115258379536,
+          "kvinner_l": 0.305893974317,
+          "menn_l": 0.223073893417
         },
         {
           "alder": 17,
-          "kvinner": 0.350791465488,
-          "menn": 0.228244386832,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.211943430364,
+          "menn_s": 0.123475019858,
+          "kvinner_l": 0.369083687518,
+          "menn_l": 0.256654921689
         },
         {
           "alder": 18,
-          "kvinner": 0.37353647217,
-          "menn": 0.237186165696,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.215896031362,
+          "menn_s": 0.125851523024,
+          "kvinner_l": 0.410837226787,
+          "menn_l": 0.276998138412
         },
         {
           "alder": 19,
-          "kvinner": 0.379780742777,
-          "menn": 0.241644524408,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.207756322037,
+          "menn_s": 0.122988082074,
+          "kvinner_l": 0.434005676931,
+          "menn_l": 0.292306589671
         },
         {
           "alder": 20,
-          "kvinner": 0.34074283382,
-          "menn": 0.200284215513,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.21215753243,
+          "menn_s": 0.118330210327,
+          "kvinner_l": 0.36342133455,
+          "menn_l": 0.22484643827
         },
         {
           "alder": 21,
-          "kvinner": 0.333790199601,
-          "menn": 0.195012119332,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.213835429453,
+          "menn_s": 0.11939907161,
+          "kvinner_l": 0.349511831699,
+          "menn_l": 0.210315225202
         },
         {
           "alder": 22,
-          "kvinner": 0.331839223144,
-          "menn": 0.193527073057,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.219214530064,
+          "menn_s": 0.120535671552,
+          "kvinner_l": 0.338257501823,
+          "menn_l": 0.204696219859
         },
         {
           "alder": 23,
-          "kvinner": 0.332172958233,
-          "menn": 0.194594655554,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.224817622076,
+          "menn_s": 0.125169371879,
+          "kvinner_l": 0.334589827478,
+          "menn_l": 0.201824952386
         },
         {
           "alder": 24,
-          "kvinner": 0.332067637822,
-          "menn": 0.194405283899,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.225943204667,
+          "menn_s": 0.129439878008,
+          "kvinner_l": 0.330173634842,
+          "menn_l": 0.196237958865
         },
         {
           "alder": 25,
-          "kvinner": 0.337463970273,
-          "menn": 0.194598368166,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.234325602081,
+          "menn_s": 0.130582100941,
+          "kvinner_l": 0.329372637359,
+          "menn_l": 0.19353402856
         },
         {
           "alder": 26,
-          "kvinner": 0.339681477744,
-          "menn": 0.198136099122,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.238361689437,
+          "menn_s": 0.135712558115,
+          "kvinner_l": 0.328873992861,
+          "menn_l": 0.194906524057
         },
         {
           "alder": 27,
-          "kvinner": 0.344287206237,
-          "menn": 0.201147027604,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.242929292929,
+          "menn_s": 0.140580019192,
+          "kvinner_l": 0.339805462028,
+          "menn_l": 0.197844475246
         },
         {
           "alder": 28,
-          "kvinner": 0.343745426755,
-          "menn": 0.202895084388,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.244447504935,
+          "menn_s": 0.141874890792,
+          "kvinner_l": 0.337841435982,
+          "menn_l": 0.199047702254
         },
         {
           "alder": 29,
-          "kvinner": 0.351895633197,
-          "menn": 0.207623085353,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.249440625421,
+          "menn_s": 0.144320457307,
+          "kvinner_l": 0.341735184436,
+          "menn_l": 0.200996080713
         },
         {
           "alder": 30,
-          "kvinner": 0.36576552534,
-          "menn": 0.214450168806,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.255561212845,
+          "menn_s": 0.146606441213,
+          "kvinner_l": 0.346015415138,
+          "menn_l": 0.20216945965
         },
         {
           "alder": 31,
-          "kvinner": 0.380089743038,
-          "menn": 0.221293497254,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.259524903949,
+          "menn_s": 0.150607490293,
+          "kvinner_l": 0.353165138808,
+          "menn_l": 0.205770113983
         },
         {
           "alder": 32,
-          "kvinner": 0.389094431735,
-          "menn": 0.227101848211,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.260796780265,
+          "menn_s": 0.151215316918,
+          "kvinner_l": 0.355853550642,
+          "menn_l": 0.210448970049
         },
         {
           "alder": 33,
-          "kvinner": 0.393197354527,
-          "menn": 0.229480443666,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.264938639752,
+          "menn_s": 0.154989366227,
+          "kvinner_l": 0.359233151296,
+          "menn_l": 0.212862611655
         },
         {
           "alder": 34,
-          "kvinner": 0.394820394696,
-          "menn": 0.230881524218,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.270047540733,
+          "menn_s": 0.158095172449,
+          "kvinner_l": 0.356897001069,
+          "menn_l": 0.212556973368
         },
         {
           "alder": 35,
-          "kvinner": 0.388347906541,
-          "menn": 0.230116940173,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.270070108701,
+          "menn_s": 0.158623351786,
+          "kvinner_l": 0.354724297305,
+          "menn_l": 0.216340459877
         },
         {
           "alder": 36,
-          "kvinner": 0.379305176012,
-          "menn": 0.229086635253,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.268996577865,
+          "menn_s": 0.160798952657,
+          "kvinner_l": 0.344488684576,
+          "menn_l": 0.211626919539
         },
         {
           "alder": 37,
-          "kvinner": 0.370684861684,
-          "menn": 0.232916539151,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.267843975118,
+          "menn_s": 0.165456885917,
+          "kvinner_l": 0.337177863072,
+          "menn_l": 0.215534657537
         },
         {
           "alder": 38,
-          "kvinner": 0.368751602153,
-          "menn": 0.229153527654,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.274126724695,
+          "menn_s": 0.164668990799,
+          "kvinner_l": 0.327321448934,
+          "menn_l": 0.210771276596
         },
         {
           "alder": 39,
-          "kvinner": 0.365503524525,
-          "menn": 0.231252895625,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.274883284861,
+          "menn_s": 0.169505190876,
+          "kvinner_l": 0.322860860248,
+          "menn_l": 0.210325584766
         },
         {
           "alder": 40,
-          "kvinner": 0.365765105195,
-          "menn": 0.235916279485,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.274974154765,
+          "menn_s": 0.172560704196,
+          "kvinner_l": 0.317130604587,
+          "menn_l": 0.211204273139
         },
         {
           "alder": 41,
-          "kvinner": 0.36456303759,
-          "menn": 0.232400785108,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.279824222523,
+          "menn_s": 0.175034630804,
+          "kvinner_l": 0.31291288391,
+          "menn_l": 0.206225288284
         },
         {
           "alder": 42,
-          "kvinner": 0.359616718747,
-          "menn": 0.235195533858,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.279248804386,
+          "menn_s": 0.179610847757,
+          "kvinner_l": 0.310286169758,
+          "menn_l": 0.205875868151
         },
         {
           "alder": 43,
-          "kvinner": 0.348708800047,
-          "menn": 0.232170510365,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.28569596907,
+          "menn_s": 0.184259059887,
+          "kvinner_l": 0.3022950755,
+          "menn_l": 0.207335910951
         },
         {
           "alder": 44,
-          "kvinner": 0.345916052347,
-          "menn": 0.230348441414,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.289315964139,
+          "menn_s": 0.189695043995,
+          "kvinner_l": 0.304294417752,
+          "menn_l": 0.205365872001
         },
         {
           "alder": 45,
-          "kvinner": 0.34167347744,
-          "menn": 0.229296705765,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.295117501667,
+          "menn_s": 0.193710762437,
+          "kvinner_l": 0.299433088783,
+          "menn_l": 0.20738952667
         },
         {
           "alder": 46,
-          "kvinner": 0.343643085752,
-          "menn": 0.230802746514,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.295825443196,
+          "menn_s": 0.196497771309,
+          "kvinner_l": 0.296767501832,
+          "menn_l": 0.203456745201
         },
         {
           "alder": 47,
-          "kvinner": 0.34933187892,
-          "menn": 0.239567931018,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.300826107608,
+          "menn_s": 0.204219146379,
+          "kvinner_l": 0.295703681627,
+          "menn_l": 0.206800480662
         },
         {
           "alder": 48,
-          "kvinner": 0.359896448262,
-          "menn": 0.246744356026,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.305134492157,
+          "menn_s": 0.207485032542,
+          "kvinner_l": 0.300576980922,
+          "menn_l": 0.20905781045
         },
         {
           "alder": 49,
-          "kvinner": 0.368921326422,
-          "menn": 0.255153146226,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.315163286508,
+          "menn_s": 0.215925808033,
+          "kvinner_l": 0.304042639686,
+          "menn_l": 0.212278151051
         },
         {
           "alder": 50,
-          "kvinner": 0.37772296241,
-          "menn": 0.267935638834,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.316346464031,
+          "menn_s": 0.22570336863,
+          "kvinner_l": 0.309365927094,
+          "menn_l": 0.218686816764
         },
         {
           "alder": 51,
-          "kvinner": 0.391878899123,
-          "menn": 0.280787485899,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.326240881133,
+          "menn_s": 0.235687668651,
+          "kvinner_l": 0.31507473895,
+          "menn_l": 0.227001327794
         },
         {
           "alder": 52,
-          "kvinner": 0.39938967188,
-          "menn": 0.286611481864,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.328914820391,
+          "menn_s": 0.240269216902,
+          "kvinner_l": 0.319746181975,
+          "menn_l": 0.229074738595
         },
         {
           "alder": 53,
-          "kvinner": 0.408058402359,
-          "menn": 0.295119950571,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.334473299525,
+          "menn_s": 0.247214068629,
+          "kvinner_l": 0.321217808738,
+          "menn_l": 0.232537600332
         },
         {
           "alder": 54,
-          "kvinner": 0.415944192456,
-          "menn": 0.31121563663,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.341034133775,
+          "menn_s": 0.256539358959,
+          "kvinner_l": 0.325494525715,
+          "menn_l": 0.243750109647
         },
         {
           "alder": 55,
-          "kvinner": 0.421213813373,
-          "menn": 0.321384708142,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.342214500376,
+          "menn_s": 0.266883354615,
+          "kvinner_l": 0.330766341097,
+          "menn_l": 0.247176061935
         },
         {
           "alder": 56,
-          "kvinner": 0.427905606139,
-          "menn": 0.331890414734,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.346941897486,
+          "menn_s": 0.272522236916,
+          "kvinner_l": 0.333355642455,
+          "menn_l": 0.251109581348
         },
         {
           "alder": 57,
-          "kvinner": 0.428988985293,
-          "menn": 0.342581665408,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.348159959306,
+          "menn_s": 0.285140487047,
+          "kvinner_l": 0.333809402696,
+          "menn_l": 0.258438117352
         },
         {
           "alder": 58,
-          "kvinner": 0.428598344491,
-          "menn": 0.347032349654,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.352431464112,
+          "menn_s": 0.292324663261,
+          "kvinner_l": 0.334376635401,
+          "menn_l": 0.263546988698
         },
         {
           "alder": 59,
-          "kvinner": 0.430484502915,
-          "menn": 0.349227603575,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.357068236122,
+          "menn_s": 0.300281413678,
+          "kvinner_l": 0.341852936005,
+          "menn_l": 0.269115599932
         },
         {
           "alder": 60,
-          "kvinner": 0.430049308711,
-          "menn": 0.3576796721,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.361709105142,
+          "menn_s": 0.308804459919,
+          "kvinner_l": 0.344106041532,
+          "menn_l": 0.274813914784
         },
         {
           "alder": 61,
-          "kvinner": 0.430316753825,
-          "menn": 0.364180145893,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.362385075617,
+          "menn_s": 0.31623630389,
+          "kvinner_l": 0.347475677238,
+          "menn_l": 0.278908250319
         },
         {
           "alder": 62,
-          "kvinner": 0.432154610654,
-          "menn": 0.371674395506,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.365666004834,
+          "menn_s": 0.321774261426,
+          "kvinner_l": 0.345659962017,
+          "menn_l": 0.284519400724
         },
         {
           "alder": 63,
-          "kvinner": 0.432308254929,
-          "menn": 0.38284004913,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.3662162605,
+          "menn_s": 0.334858689697,
+          "kvinner_l": 0.343987241526,
+          "menn_l": 0.287905642744
         },
         {
           "alder": 64,
-          "kvinner": 0.441896448045,
-          "menn": 0.391274954536,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.374342901133,
+          "menn_s": 0.343086707607,
+          "kvinner_l": 0.344913669856,
+          "menn_l": 0.290466651341
         },
         {
           "alder": 65,
-          "kvinner": 0.44602957641,
-          "menn": 0.401261751267,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.380873589947,
+          "menn_s": 0.353111011638,
+          "kvinner_l": 0.34510939439,
+          "menn_l": 0.297448522829
         },
         {
           "alder": 66,
-          "kvinner": 0.460343082075,
-          "menn": 0.414181893244,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.386150860748,
+          "menn_s": 0.36288751919,
+          "kvinner_l": 0.35173227721,
+          "menn_l": 0.303748596568
         },
         {
           "alder": 67,
-          "kvinner": 0.465353840811,
-          "menn": 0.423847051956,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.391521660797,
+          "menn_s": 0.373722558668,
+          "kvinner_l": 0.356162313585,
+          "menn_l": 0.313304314913
         },
         {
           "alder": 68,
-          "kvinner": 0.467935362756,
-          "menn": 0.43397110678,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.399795743872,
+          "menn_s": 0.388814654649,
+          "kvinner_l": 0.35502565077,
+          "menn_l": 0.319829450208
         },
         {
           "alder": 69,
-          "kvinner": 0.476563025398,
-          "menn": 0.438173178458,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.417293880362,
+          "menn_s": 0.400037615197,
+          "kvinner_l": 0.367055293192,
+          "menn_l": 0.328355588991
         },
         {
           "alder": 70,
-          "kvinner": 0.480749008533,
-          "menn": 0.446494239719,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.427800474101,
+          "menn_s": 0.415434339289,
+          "kvinner_l": 0.379242951531,
+          "menn_l": 0.335146019572
         },
         {
           "alder": 71,
-          "kvinner": 0.474736435146,
-          "menn": 0.450034674328,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.43529562982,
+          "menn_s": 0.425710391108,
+          "kvinner_l": 0.385437017995,
+          "menn_l": 0.348301352627
         },
         {
           "alder": 72,
-          "kvinner": 0.489531330368,
-          "menn": 0.47182761998,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.439735983769,
+          "menn_s": 0.436874407333,
+          "kvinner_l": 0.391324447184,
+          "menn_l": 0.356205879254
         },
         {
           "alder": 73,
-          "kvinner": 0.52605289161,
-          "menn": 0.500060984038,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.462529018687,
+          "menn_s": 0.451645448632,
+          "kvinner_l": 0.40465838111,
+          "menn_l": 0.364759919818
         },
         {
           "alder": 74,
-          "kvinner": 0.562836963112,
-          "menn": 0.552056996394,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.464869664489,
+          "menn_s": 0.463923269789,
+          "kvinner_l": 0.406469207839,
+          "menn_l": 0.378981440947
         },
         {
           "alder": 75,
-          "kvinner": 0.608752812459,
-          "menn": 0.5997926929,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.480530510911,
+          "menn_s": 0.484488439629,
+          "kvinner_l": 0.420985234549,
+          "menn_l": 0.396124204177
         },
         {
           "alder": 76,
-          "kvinner": 0.667270846673,
-          "menn": 0.664719778076,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.49732413259,
+          "menn_s": 0.504912737225,
+          "kvinner_l": 0.439409234854,
+          "menn_l": 0.412475511089
         },
         {
           "alder": 77,
-          "kvinner": 0.69390409045,
-          "menn": 0.689260711622,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.525460103755,
+          "menn_s": 0.529648087876,
+          "kvinner_l": 0.471405632411,
+          "menn_l": 0.441687008408
         },
         {
           "alder": 78,
-          "kvinner": 0.6862919977,
-          "menn": 0.700702702703,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.523077972344,
+          "menn_s": 0.535611722866,
+          "kvinner_l": 0.474057528688,
+          "menn_l": 0.450523953519
         },
         {
           "alder": 79,
-          "kvinner": 0.672135495605,
-          "menn": 0.706045438197,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.544273012044,
+          "menn_s": 0.576668228365,
+          "kvinner_l": 0.491137615036,
+          "menn_l": 0.474421613904
         },
         {
           "alder": 80,
-          "kvinner": 0.657883651089,
-          "menn": 0.685712864062,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.53299599856,
+          "menn_s": 0.556730286288,
+          "kvinner_l": 0.491986534838,
+          "menn_l": 0.481516825716
         },
         {
           "alder": 81,
-          "kvinner": 0.659477735415,
-          "menn": 0.684469088085,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.539819976241,
+          "menn_s": 0.569001289744,
+          "kvinner_l": 0.507356300832,
+          "menn_l": 0.493551281332
         },
         {
           "alder": 82,
-          "kvinner": 0.672802398372,
-          "menn": 0.703571212029,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.546092979629,
+          "menn_s": 0.569193450576,
+          "kvinner_l": 0.49561076505,
+          "menn_l": 0.486355366889
         },
         {
           "alder": 83,
-          "kvinner": 0.70340296496,
-          "menn": 0.737219812413,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.572450476889,
+          "menn_s": 0.58925831202,
+          "kvinner_l": 0.521617230898,
+          "menn_l": 0.517715260017
         },
         {
           "alder": 84,
-          "kvinner": 0.709181614761,
-          "menn": 0.748822565783,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.579124967554,
+          "menn_s": 0.600015542431,
+          "kvinner_l": 0.536036685606,
+          "menn_l": 0.53671899285
         },
         {
           "alder": 85,
-          "kvinner": 0.68612953074,
-          "menn": 0.744323225382,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.58160978421,
+          "menn_s": 0.605103884372,
+          "kvinner_l": 0.541429211756,
+          "menn_l": 0.568970189702
         },
         {
           "alder": 86,
-          "kvinner": 0.668986125042,
-          "menn": 0.740808942301,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.588792284135,
+          "menn_s": 0.624192447082,
+          "kvinner_l": 0.538139322046,
+          "menn_l": 0.580230054099
         },
         {
           "alder": 87,
-          "kvinner": 0.653853903154,
-          "menn": 0.73102771824,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.591613278975,
+          "menn_s": 0.631963915641,
+          "kvinner_l": 0.542418947777,
+          "menn_l": 0.594599536755
         },
         {
           "alder": 88,
-          "kvinner": 0.657116993688,
-          "menn": 0.746961187023,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.596164360516,
+          "menn_s": 0.621109887083,
+          "kvinner_l": 0.533456701855,
+          "menn_l": 0.605893693197
         },
         {
           "alder": 89,
-          "kvinner": 0.658899623826,
-          "menn": 0.765230678233,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.592277637325,
+          "menn_s": 0.638652082998,
+          "kvinner_l": 0.526867386808,
+          "menn_l": 0.609940485765
         },
         {
           "alder": 90,
-          "kvinner": 0.678369652946,
-          "menn": 0.789699053133,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.596131271372,
+          "menn_s": 0.622165290825,
+          "kvinner_l": 0.519216046547,
+          "menn_l": 0.620267577569
         },
         {
           "alder": 91,
-          "kvinner": 0.692346334637,
-          "menn": 0.803934571176,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.618262674177,
+          "menn_s": 0.651820895522,
+          "kvinner_l": 0.525822709754,
+          "menn_l": 0.650985074627
         },
         {
           "alder": 92,
-          "kvinner": 0.696291860913,
-          "menn": 0.808538526355,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.627766313243,
+          "menn_s": 0.654826139089,
+          "kvinner_l": 0.530705187504,
+          "menn_l": 0.639538369305
         },
         {
           "alder": 93,
-          "kvinner": 0.674213255301,
-          "menn": 0.809957498482,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.634714798914,
+          "menn_s": 0.674197384067,
+          "kvinner_l": 0.515990537107,
+          "menn_l": 0.647641696393
         },
         {
           "alder": 94,
-          "kvinner": 0.684781914554,
-          "menn": 0.853794459925,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.648461205028,
+          "menn_s": 0.70407623081,
+          "kvinner_l": 0.513545730386,
+          "menn_l": 0.674695606141
         },
         {
           "alder": 95,
-          "kvinner": 0.675129785853,
-          "menn": 0.823516386182,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.659677867259,
+          "menn_s": 0.662451703548,
+          "kvinner_l": 0.495973340739,
+          "menn_l": 0.643835616438
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/dvit_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/dvit_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 15023.6666667,
           "tot_pas": 11746.3333333,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.27900905247,
-          "borhf": null
+          "prove_pr_pas": 1.27900905247
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 45727,
           "tot_pas": 35082.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.3034195749,
-          "borhf": null
+          "prove_pr_pas": 1.3034195749
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 31053,
           "tot_pas": 24281,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.27890119847,
-          "borhf": null
+          "prove_pr_pas": 1.27890119847
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 30488.3333333,
           "tot_pas": 22210,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.3727300015,
-          "borhf": null
+          "prove_pr_pas": 1.3727300015
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 42765,
           "tot_pas": 31623.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.35232423316,
-          "borhf": null
+          "prove_pr_pas": 1.35232423316
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 96684,
           "tot_pas": 73182.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.32113852615,
-          "borhf": null
+          "prove_pr_pas": 1.32113852615
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 104209.666667,
           "tot_pas": 76607.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.36030928284,
-          "borhf": null
+          "prove_pr_pas": 1.36030928284
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 35815,
           "tot_pas": 25582.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.39997133476,
-          "borhf": null
+          "prove_pr_pas": 1.39997133476
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 148622.333333,
           "tot_pas": 104347.666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.42429953712,
-          "borhf": null
+          "prove_pr_pas": 1.42429953712
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 64040.6666667,
           "tot_pas": 46807.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.36817592685,
-          "borhf": null
+          "prove_pr_pas": 1.36817592685
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 122485.333333,
           "tot_pas": 91304.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.34150624468,
-          "borhf": null
+          "prove_pr_pas": 1.34150624468
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 155210.666667,
           "tot_pas": 109824,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.41326728827,
-          "borhf": null
+          "prove_pr_pas": 1.41326728827
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 232523.333333,
           "tot_pas": 172510.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.34787800561,
-          "borhf": null
+          "prove_pr_pas": 1.34787800561
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 118991.666667,
           "tot_pas": 86377.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.3775797663,
-          "borhf": null
+          "prove_pr_pas": 1.3775797663
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 60414.3333333,
           "tot_pas": 45230.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.33569407187,
-          "borhf": null
+          "prove_pr_pas": 1.33569407187
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 57147.6666667,
           "tot_pas": 41445.3333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.37886854974,
-          "borhf": null
+          "prove_pr_pas": 1.37886854974
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 139870,
           "tot_pas": 99452,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.40640711097,
-          "borhf": null
+          "prove_pr_pas": 1.40640711097
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 211977.666667,
           "tot_pas": 152596.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.38913694052,
-          "borhf": null
+          "prove_pr_pas": 1.38913694052
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 104111,
           "tot_pas": 73679,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.41303492176,
-          "borhf": null
+          "prove_pr_pas": 1.41303492176
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 63877.6666667,
           "tot_pas": 45247.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.4117339384,
-          "borhf": null
+          "prove_pr_pas": 1.4117339384
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 116646.666667,
           "tot_pas": 82487.6666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.41411039226,
-          "borhf": null
+          "prove_pr_pas": 1.41411039226
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 1997725.66667,
           "tot_pas": 1451662.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.37616415388,
-          "borhf": null
+          "prove_pr_pas": 1.37616415388
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 122292,
           "tot_pas": 93268,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.31118926105,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.31118926105
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 243658.666667,
           "tot_pas": 181315.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.34383927816,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.34383927816
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 370963.333333,
           "tot_pas": 267863.666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.38489604787,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.38489604787
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1260811.66667,
           "tot_pas": 905275,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.39273885468,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39273885468
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 1997725.66667,
           "tot_pas": 1446286,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38127982063,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.38127982063
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00945350849182,
-          "menn": 0.0117017084635,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0117017084635
         },
         {
           "alder": 1,
           "kvinner": 0.0247152030203,
-          "menn": 0.0288525718218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0288525718218
         },
         {
           "alder": 2,
           "kvinner": 0.03050365845,
-          "menn": 0.0359281437126,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0359281437126
         },
         {
           "alder": 3,
           "kvinner": 0.0386552750953,
-          "menn": 0.0445075260922,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0445075260922
         },
         {
           "alder": 4,
           "kvinner": 0.0431940834135,
-          "menn": 0.0500771161776,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0500771161776
         },
         {
           "alder": 5,
           "kvinner": 0.0483795334879,
-          "menn": 0.0528897717249,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0528897717249
         },
         {
           "alder": 6,
           "kvinner": 0.0553074772423,
-          "menn": 0.0572552227536,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0572552227536
         },
         {
           "alder": 7,
           "kvinner": 0.0626864699368,
-          "menn": 0.0633994868044,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0633994868044
         },
         {
           "alder": 8,
           "kvinner": 0.0711539568713,
-          "menn": 0.0726823449216,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0726823449216
         },
         {
           "alder": 9,
           "kvinner": 0.0783443356856,
-          "menn": 0.0789188347281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0789188347281
         },
         {
           "alder": 10,
           "kvinner": 0.0885536778698,
-          "menn": 0.0875774208769,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0875774208769
         },
         {
           "alder": 11,
           "kvinner": 0.0980696387404,
-          "menn": 0.0915051770078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0915051770078
         },
         {
           "alder": 12,
           "kvinner": 0.116753678215,
-          "menn": 0.0945319072227,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0945319072227
         },
         {
           "alder": 13,
           "kvinner": 0.152035164161,
-          "menn": 0.106221077818,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106221077818
         },
         {
           "alder": 14,
           "kvinner": 0.194999162015,
-          "menn": 0.123711403466,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123711403466
         },
         {
           "alder": 15,
           "kvinner": 0.220575351889,
-          "menn": 0.132445824647,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132445824647
         },
         {
           "alder": 16,
           "kvinner": 0.233023243694,
-          "menn": 0.125913291571,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125913291571
         },
         {
           "alder": 17,
           "kvinner": 0.24264282898,
-          "menn": 0.127109524042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127109524042
         },
         {
           "alder": 18,
           "kvinner": 0.23183433089,
-          "menn": 0.116500352301,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.116500352301
         },
         {
           "alder": 19,
           "kvinner": 0.216114069747,
-          "menn": 0.109493964993,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.109493964993
         },
         {
           "alder": 20,
           "kvinner": 0.217707450316,
-          "menn": 0.106826435552,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106826435552
         },
         {
           "alder": 21,
           "kvinner": 0.22296308644,
-          "menn": 0.108304327348,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.108304327348
         },
         {
           "alder": 22,
           "kvinner": 0.224483431276,
-          "menn": 0.112484478418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112484478418
         },
         {
           "alder": 23,
           "kvinner": 0.230164523894,
-          "menn": 0.115662868002,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115662868002
         },
         {
           "alder": 24,
           "kvinner": 0.23409452498,
-          "menn": 0.118915468724,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118915468724
         },
         {
           "alder": 25,
           "kvinner": 0.243416254761,
-          "menn": 0.122027575374,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.122027575374
         },
         {
           "alder": 26,
           "kvinner": 0.246744190002,
-          "menn": 0.124734265284,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124734265284
         },
         {
           "alder": 27,
           "kvinner": 0.250686574092,
-          "menn": 0.127028554228,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127028554228
         },
         {
           "alder": 28,
           "kvinner": 0.254882193206,
-          "menn": 0.127575054855,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127575054855
         },
         {
           "alder": 29,
           "kvinner": 0.260317935771,
-          "menn": 0.129442212012,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129442212012
         },
         {
           "alder": 30,
           "kvinner": 0.270107549839,
-          "menn": 0.134590169012,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.134590169012
         },
         {
           "alder": 31,
           "kvinner": 0.278553135626,
-          "menn": 0.136629730837,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136629730837
         },
         {
           "alder": 32,
           "kvinner": 0.28583469247,
-          "menn": 0.13840346048,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13840346048
         },
         {
           "alder": 33,
           "kvinner": 0.286127938643,
-          "menn": 0.137775301173,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137775301173
         },
         {
           "alder": 34,
           "kvinner": 0.287470358192,
-          "menn": 0.139965114719,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.139965114719
         },
         {
           "alder": 35,
           "kvinner": 0.283603570674,
-          "menn": 0.13842227678,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13842227678
         },
         {
           "alder": 36,
           "kvinner": 0.279267125578,
-          "menn": 0.139877681166,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.139877681166
         },
         {
           "alder": 37,
           "kvinner": 0.274158982438,
-          "menn": 0.141602544485,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141602544485
         },
         {
           "alder": 38,
           "kvinner": 0.272406842068,
-          "menn": 0.140629027393,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140629027393
         },
         {
           "alder": 39,
           "kvinner": 0.272795343532,
-          "menn": 0.142762591833,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.142762591833
         },
         {
           "alder": 40,
           "kvinner": 0.274217391819,
-          "menn": 0.148063348821,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.148063348821
         },
         {
           "alder": 41,
           "kvinner": 0.272970821651,
-          "menn": 0.147045501569,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147045501569
         },
         {
           "alder": 42,
           "kvinner": 0.269571714033,
-          "menn": 0.148540712632,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.148540712632
         },
         {
           "alder": 43,
           "kvinner": 0.263469131109,
-          "menn": 0.147048538839,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147048538839
         },
         {
           "alder": 44,
           "kvinner": 0.261518123618,
-          "menn": 0.148437028957,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.148437028957
         },
         {
           "alder": 45,
           "kvinner": 0.258450525604,
-          "menn": 0.147617443023,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147617443023
         },
         {
           "alder": 46,
           "kvinner": 0.258299304713,
-          "menn": 0.150260372921,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.150260372921
         },
         {
           "alder": 47,
           "kvinner": 0.263686937551,
-          "menn": 0.156438232502,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.156438232502
         },
         {
           "alder": 48,
           "kvinner": 0.270382686496,
-          "menn": 0.161479941115,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161479941115
         },
         {
           "alder": 49,
           "kvinner": 0.276506649874,
-          "menn": 0.168135332564,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.168135332564
         },
         {
           "alder": 50,
           "kvinner": 0.280872862606,
-          "menn": 0.177204989798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.177204989798
         },
         {
           "alder": 51,
           "kvinner": 0.287696526708,
-          "menn": 0.181790298348,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181790298348
         },
         {
           "alder": 52,
           "kvinner": 0.291412363283,
-          "menn": 0.187257867504,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.187257867504
         },
         {
           "alder": 53,
           "kvinner": 0.294179418784,
-          "menn": 0.192778464292,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.192778464292
         },
         {
           "alder": 54,
           "kvinner": 0.295923522995,
-          "menn": 0.199986903995,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.199986903995
         },
         {
           "alder": 55,
           "kvinner": 0.298921381337,
-          "menn": 0.207868116654,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.207868116654
         },
         {
           "alder": 56,
           "kvinner": 0.299292767708,
-          "menn": 0.213085013549,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.213085013549
         },
         {
           "alder": 57,
           "kvinner": 0.30073226263,
-          "menn": 0.21875,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.21875
         },
         {
           "alder": 58,
           "kvinner": 0.300095461796,
-          "menn": 0.22096233425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.22096233425
         },
         {
           "alder": 59,
           "kvinner": 0.299684643073,
-          "menn": 0.222566874482,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.222566874482
         },
         {
           "alder": 60,
           "kvinner": 0.299448902639,
-          "menn": 0.228365820844,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.228365820844
         },
         {
           "alder": 61,
           "kvinner": 0.297548758808,
-          "menn": 0.231278147796,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.231278147796
         },
         {
           "alder": 62,
           "kvinner": 0.296798174881,
-          "menn": 0.232858423575,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.232858423575
         },
         {
           "alder": 63,
           "kvinner": 0.297376907477,
-          "menn": 0.238400887515,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.238400887515
         },
         {
           "alder": 64,
           "kvinner": 0.30575731573,
-          "menn": 0.244228260061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.244228260061
         },
         {
           "alder": 65,
           "kvinner": 0.307880403052,
-          "menn": 0.250058670053,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.250058670053
         },
         {
           "alder": 66,
           "kvinner": 0.316377461079,
-          "menn": 0.253165728278,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.253165728278
         },
         {
           "alder": 67,
           "kvinner": 0.318000954958,
-          "menn": 0.258464681845,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.258464681845
         },
         {
           "alder": 68,
           "kvinner": 0.32142673096,
-          "menn": 0.258841295583,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.258841295583
         },
         {
           "alder": 69,
           "kvinner": 0.323223265858,
-          "menn": 0.26050686378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.26050686378
         },
         {
           "alder": 70,
           "kvinner": 0.323443696671,
-          "menn": 0.264187075608,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.264187075608
         },
         {
           "alder": 71,
           "kvinner": 0.317028743067,
-          "menn": 0.25828182989,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25828182989
         },
         {
           "alder": 72,
           "kvinner": 0.324445553841,
-          "menn": 0.26607639569,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.26607639569
         },
         {
           "alder": 73,
           "kvinner": 0.342465007353,
-          "menn": 0.279396339331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.279396339331
         },
         {
           "alder": 74,
           "kvinner": 0.362617373777,
-          "menn": 0.30323645684,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.30323645684
         },
         {
           "alder": 75,
           "kvinner": 0.38666784312,
-          "menn": 0.327830502672,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.327830502672
         },
         {
           "alder": 76,
           "kvinner": 0.418223907797,
-          "menn": 0.353625763946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.353625763946
         },
         {
           "alder": 77,
           "kvinner": 0.429830406466,
-          "menn": 0.36657685183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.36657685183
         },
         {
           "alder": 78,
           "kvinner": 0.417635806743,
-          "menn": 0.356972972973,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.356972972973
         },
         {
           "alder": 79,
           "kvinner": 0.410136910175,
-          "menn": 0.363340726532,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.363340726532
         },
         {
           "alder": 80,
           "kvinner": 0.392993518053,
-          "menn": 0.339547535328,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.339547535328
         },
         {
           "alder": 81,
           "kvinner": 0.395583051579,
-          "menn": 0.335253851572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.335253851572
         },
         {
           "alder": 82,
           "kvinner": 0.401199186045,
-          "menn": 0.348794438044,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.348794438044
         },
         {
           "alder": 83,
           "kvinner": 0.417267520216,
-          "menn": 0.363477391956,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.363477391956
         },
         {
           "alder": 84,
           "kvinner": 0.41783133414,
-          "menn": 0.365158185727,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.365158185727
         },
         {
           "alder": 85,
           "kvinner": 0.402949748645,
-          "menn": 0.354837785986,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.354837785986
         },
         {
           "alder": 86,
           "kvinner": 0.393681043129,
-          "menn": 0.352167732765,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.352167732765
         },
         {
           "alder": 87,
           "kvinner": 0.380308491347,
-          "menn": 0.351327787263,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.351327787263
         },
         {
           "alder": 88,
           "kvinner": 0.384718892205,
-          "menn": 0.351119121469,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.351119121469
         },
         {
           "alder": 89,
           "kvinner": 0.389678222511,
-          "menn": 0.369430205047,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.369430205047
         },
         {
           "alder": 90,
           "kvinner": 0.398491339169,
-          "menn": 0.366564139678,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.366564139678
         },
         {
           "alder": 91,
           "kvinner": 0.398363773368,
-          "menn": 0.373268493958,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.373268493958
         },
         {
           "alder": 92,
           "kvinner": 0.403190624866,
-          "menn": 0.379084355397,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.379084355397
         },
         {
           "alder": 93,
           "kvinner": 0.391087838185,
-          "menn": 0.37547055252,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.37547055252
         },
         {
           "alder": 94,
           "kvinner": 0.392170636695,
-          "menn": 0.387313555155,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.387313555155
         },
         {
           "alder": 95,
           "kvinner": 0.386924075276,
-          "menn": 0.378875110717,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.378875110717
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/ferritin_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/ferritin_rb1.json
@@ -148,20 +148,6 @@
           "label_en": "Proportion** in private",
           "typeVar": "number",
           "format": ",.0%"
-        },
-        {
-          "id": "ratesnitt_andel_int",
-          "label_no": "Andel** gjentatte***",
-          "label_en": "Proportion** of tests repeated***",
-          "typeVar": "number",
-          "format": ",.1%"
-        },
-        {
-          "id": "antsnitt_i_int",
-          "label_no": "Antall gjentatte***",
-          "label_en": "Number of tests repeated***",
-          "typeVar": "number",
-          "format": ",.0f"
         }
       ]
     },
@@ -214,8 +200,7 @@
           "tot_events": 26066.3333333,
           "tot_pas": 18269,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.42680679475,
-          "borhf": null
+          "prove_pr_pas": 1.42680679475
         },
         {
           "bohf": "UNN",
@@ -227,8 +212,7 @@
           "tot_events": 68685,
           "tot_pas": 48136.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.42687487016,
-          "borhf": null
+          "prove_pr_pas": 1.42687487016
         },
         {
           "bohf": "Nordland",
@@ -240,8 +224,7 @@
           "tot_events": 60290.6666667,
           "tot_pas": 41616.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.44872606108,
-          "borhf": null
+          "prove_pr_pas": 1.44872606108
         },
         {
           "bohf": "Helgeland",
@@ -253,8 +236,7 @@
           "tot_events": 35005.3333333,
           "tot_pas": 23688.6666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.47772493175,
-          "borhf": null
+          "prove_pr_pas": 1.47772493175
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -266,8 +248,7 @@
           "tot_events": 66938.6666667,
           "tot_pas": 44257.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.51247618115,
-          "borhf": null
+          "prove_pr_pas": 1.51247618115
         },
         {
           "bohf": "St. Olav",
@@ -279,8 +260,7 @@
           "tot_events": 163179.666667,
           "tot_pas": 110691.333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.47418647651,
-          "borhf": null
+          "prove_pr_pas": 1.47418647651
         },
         {
           "bohf": "Møre og Romsdal",
@@ -292,8 +272,7 @@
           "tot_events": 130325.666667,
           "tot_pas": 88349.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.47511214907,
-          "borhf": null
+          "prove_pr_pas": 1.47511214907
         },
         {
           "bohf": "Førde",
@@ -305,8 +284,7 @@
           "tot_events": 49409.3333333,
           "tot_pas": 32041.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.54203381014,
-          "borhf": null
+          "prove_pr_pas": 1.54203381014
         },
         {
           "bohf": "Bergen",
@@ -318,8 +296,7 @@
           "tot_events": 258674.666667,
           "tot_pas": 162820.666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.58870905004,
-          "borhf": null
+          "prove_pr_pas": 1.58870905004
         },
         {
           "bohf": "Fonna",
@@ -331,8 +308,7 @@
           "tot_events": 86959.6666667,
           "tot_pas": 57716,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.50668214475,
-          "borhf": null
+          "prove_pr_pas": 1.50668214475
         },
         {
           "bohf": "Stavanger",
@@ -344,8 +320,7 @@
           "tot_events": 169126.666667,
           "tot_pas": 115357,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.46611533471,
-          "borhf": null
+          "prove_pr_pas": 1.46611533471
         },
         {
           "bohf": "Østfold",
@@ -357,8 +332,7 @@
           "tot_events": 200178.333333,
           "tot_pas": 129735,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.54297863594,
-          "borhf": null
+          "prove_pr_pas": 1.54297863594
         },
         {
           "bohf": "Akershus",
@@ -370,8 +344,7 @@
           "tot_events": 354235,
           "tot_pas": 226748,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.56224090179,
-          "borhf": null
+          "prove_pr_pas": 1.56224090179
         },
         {
           "bohf": "OUS",
@@ -383,8 +356,7 @@
           "tot_events": 162362.666667,
           "tot_pas": 105796.666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.53466712877,
-          "borhf": null
+          "prove_pr_pas": 1.53466712877
         },
         {
           "bohf": "Lovisenberg",
@@ -396,8 +368,7 @@
           "tot_events": 79643.3333333,
           "tot_pas": 55196.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.44290114137,
-          "borhf": null
+          "prove_pr_pas": 1.44290114137
         },
         {
           "bohf": "Diakonhjemmet",
@@ -409,8 +380,7 @@
           "tot_events": 80203.3333333,
           "tot_pas": 52517.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.52716863532,
-          "borhf": null
+          "prove_pr_pas": 1.52716863532
         },
         {
           "bohf": "Innlandet",
@@ -422,8 +392,7 @@
           "tot_events": 193552.666667,
           "tot_pas": 123927.666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.56181966362,
-          "borhf": null
+          "prove_pr_pas": 1.56181966362
         },
         {
           "bohf": "Vestre Viken",
@@ -435,8 +404,7 @@
           "tot_events": 295794.333333,
           "tot_pas": 189242.333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.56304526647,
-          "borhf": null
+          "prove_pr_pas": 1.56304526647
         },
         {
           "bohf": "Vestfold",
@@ -448,8 +416,7 @@
           "tot_events": 154255.666667,
           "tot_pas": 97119,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.58831605213,
-          "borhf": null
+          "prove_pr_pas": 1.58831605213
         },
         {
           "bohf": "Telemark",
@@ -461,8 +428,7 @@
           "tot_events": 87161.6666667,
           "tot_pas": 57449.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.51718315743,
-          "borhf": null
+          "prove_pr_pas": 1.51718315743
         },
         {
           "bohf": "Sørlandet",
@@ -474,8 +440,7 @@
           "tot_events": 181446,
           "tot_pas": 113817.333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.59418600565,
-          "borhf": null
+          "prove_pr_pas": 1.59418600565
         },
         {
           "bohf": "Norge",
@@ -487,8 +452,7 @@
           "tot_events": 2903540,
           "tot_pas": 1894531.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.5325898485,
-          "borhf": null
+          "prove_pr_pas": 1.5325898485
         }
       ]
     },
@@ -507,9 +471,7 @@
           "tot_events": 190047.333333,
           "tot_pas": 131614,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.44397505838,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44397505838
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -521,9 +483,7 @@
           "tot_events": 360444,
           "tot_pas": 243118.666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.48258463631,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.48258463631
         },
         {
           "borhf": "Helse Vest",
@@ -535,9 +495,7 @@
           "tot_events": 564170.333333,
           "tot_pas": 367659,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.53449346632,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.53449346632
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -549,9 +507,7 @@
           "tot_events": 1788878.33333,
           "tot_pas": 1146327.33333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.560530122,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.560530122
         },
         {
           "borhf": "Norge",
@@ -563,9 +519,7 @@
           "tot_events": 2903540,
           "tot_pas": 1886522.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.53909627025,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.53909627025
         }
       ]
     },
@@ -577,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.0200654987784,
-          "menn": 0.0239170818205,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0239170818205
         },
         {
           "alder": 1,
           "kvinner": 0.0409247611204,
-          "menn": 0.0483399277482,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0483399277482
         },
         {
           "alder": 2,
           "kvinner": 0.0466860836826,
-          "menn": 0.0536583083832,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0536583083832
         },
         {
           "alder": 3,
           "kvinner": 0.0563340105196,
-          "menn": 0.0651452771805,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0651452771805
         },
         {
           "alder": 4,
           "kvinner": 0.0621814683669,
-          "menn": 0.070766192784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.070766192784
         },
         {
           "alder": 5,
           "kvinner": 0.0680609332922,
-          "menn": 0.072683771966,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.072683771966
         },
         {
           "alder": 6,
           "kvinner": 0.0763624799587,
-          "menn": 0.0773659702995,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0773659702995
         },
         {
           "alder": 7,
           "kvinner": 0.0835841313269,
-          "menn": 0.0838281414635,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0838281414635
         },
         {
           "alder": 8,
           "kvinner": 0.0926990909847,
-          "menn": 0.0929313954621,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0929313954621
         },
         {
           "alder": 9,
           "kvinner": 0.101348104307,
-          "menn": 0.100227039915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.100227039915
         },
         {
           "alder": 10,
           "kvinner": 0.111344246594,
-          "menn": 0.10812344337,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.10812344337
         },
         {
           "alder": 11,
           "kvinner": 0.121902344952,
-          "menn": 0.111855556417,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111855556417
         },
         {
           "alder": 12,
           "kvinner": 0.143433001107,
-          "menn": 0.113375796178,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113375796178
         },
         {
           "alder": 13,
           "kvinner": 0.185065453639,
-          "menn": 0.126006583023,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126006583023
         },
         {
           "alder": 14,
           "kvinner": 0.23596374747,
-          "menn": 0.145586863679,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145586863679
         },
         {
           "alder": 15,
           "kvinner": 0.266650226805,
-          "menn": 0.153225157902,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.153225157902
         },
         {
           "alder": 16,
           "kvinner": 0.282852564103,
-          "menn": 0.146213483843,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146213483843
         },
         {
           "alder": 17,
           "kvinner": 0.294719900719,
-          "menn": 0.147269236413,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147269236413
         },
         {
           "alder": 18,
           "kvinner": 0.288538232564,
-          "menn": 0.136169008317,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136169008317
         },
         {
           "alder": 19,
           "kvinner": 0.272309072515,
-          "menn": 0.129040713954,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129040713954
         },
         {
           "alder": 20,
           "kvinner": 0.27654390757,
-          "menn": 0.125826768891,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125826768891
         },
         {
           "alder": 21,
           "kvinner": 0.285924197243,
-          "menn": 0.128246660004,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128246660004
         },
         {
           "alder": 22,
           "kvinner": 0.293779161138,
-          "menn": 0.132893222907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132893222907
         },
         {
           "alder": 23,
           "kvinner": 0.303949900755,
-          "menn": 0.137795120191,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137795120191
         },
         {
           "alder": 24,
           "kvinner": 0.312887027804,
-          "menn": 0.141666204141,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141666204141
         },
         {
           "alder": 25,
           "kvinner": 0.32894416984,
-          "menn": 0.145959684105,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145959684105
         },
         {
           "alder": 26,
           "kvinner": 0.339913934357,
-          "menn": 0.148274603277,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.148274603277
         },
         {
           "alder": 27,
           "kvinner": 0.347193749275,
-          "menn": 0.151009458225,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151009458225
         },
         {
           "alder": 28,
           "kvinner": 0.357398765292,
-          "menn": 0.152834250179,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.152834250179
         },
         {
           "alder": 29,
           "kvinner": 0.364850553071,
-          "menn": 0.15552308381,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.15552308381
         },
         {
           "alder": 30,
           "kvinner": 0.38134023645,
-          "menn": 0.160654366747,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160654366747
         },
         {
           "alder": 31,
           "kvinner": 0.392276072827,
-          "menn": 0.16317789865,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16317789865
         },
         {
           "alder": 32,
           "kvinner": 0.39729851024,
-          "menn": 0.165022938786,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.165022938786
         },
         {
           "alder": 33,
           "kvinner": 0.391379981104,
-          "menn": 0.166433158202,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.166433158202
         },
         {
           "alder": 34,
           "kvinner": 0.386800835347,
-          "menn": 0.167723064538,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167723064538
         },
         {
           "alder": 35,
           "kvinner": 0.375194896426,
-          "menn": 0.165977516475,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.165977516475
         },
         {
           "alder": 36,
           "kvinner": 0.363583428459,
-          "menn": 0.168068690078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.168068690078
         },
         {
           "alder": 37,
           "kvinner": 0.352567072888,
-          "menn": 0.171064136755,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.171064136755
         },
         {
           "alder": 38,
           "kvinner": 0.34715457575,
-          "menn": 0.169914173682,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.169914173682
         },
         {
           "alder": 39,
           "kvinner": 0.342472725146,
-          "menn": 0.17456482891,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.17456482891
         },
         {
           "alder": 40,
           "kvinner": 0.342035549984,
-          "menn": 0.179961132952,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.179961132952
         },
         {
           "alder": 41,
           "kvinner": 0.338123128831,
-          "menn": 0.181251363034,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181251363034
         },
         {
           "alder": 42,
           "kvinner": 0.331457642797,
-          "menn": 0.183180220729,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.183180220729
         },
         {
           "alder": 43,
           "kvinner": 0.324914456175,
-          "menn": 0.182754697083,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.182754697083
         },
         {
           "alder": 44,
           "kvinner": 0.321768546474,
-          "menn": 0.186432874189,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.186432874189
         },
         {
           "alder": 45,
           "kvinner": 0.31937547558,
-          "menn": 0.185796120088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.185796120088
         },
         {
           "alder": 46,
           "kvinner": 0.320097119523,
-          "menn": 0.18938980346,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.18938980346
         },
         {
           "alder": 47,
           "kvinner": 0.32755931279,
-          "menn": 0.199691823997,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.199691823997
         },
         {
           "alder": 48,
           "kvinner": 0.336142372808,
-          "menn": 0.206492757801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.206492757801
         },
         {
           "alder": 49,
           "kvinner": 0.343904237512,
-          "menn": 0.216978085352,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.216978085352
         },
         {
           "alder": 50,
           "kvinner": 0.349182908424,
-          "menn": 0.230321031018,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.230321031018
         },
         {
           "alder": 51,
           "kvinner": 0.358304106985,
-          "menn": 0.238839877521,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.238839877521
         },
         {
           "alder": 52,
           "kvinner": 0.360794419857,
-          "menn": 0.244221584982,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.244221584982
         },
         {
           "alder": 53,
           "kvinner": 0.364340867612,
-          "menn": 0.252684506562,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.252684506562
         },
         {
           "alder": 54,
           "kvinner": 0.366819773784,
-          "menn": 0.265827067259,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.265827067259
         },
         {
           "alder": 55,
           "kvinner": 0.369763409258,
-          "menn": 0.276171229512,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276171229512
         },
         {
           "alder": 56,
           "kvinner": 0.370322704803,
-          "menn": 0.285359160428,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.285359160428
         },
         {
           "alder": 57,
           "kvinner": 0.372937050028,
-          "menn": 0.296644873489,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.296644873489
         },
         {
           "alder": 58,
           "kvinner": 0.372282164973,
-          "menn": 0.301114567916,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.301114567916
         },
         {
           "alder": 59,
           "kvinner": 0.371127321377,
-          "menn": 0.304198274009,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.304198274009
         },
         {
           "alder": 60,
           "kvinner": 0.373057462374,
-          "menn": 0.31448953412,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.31448953412
         },
         {
           "alder": 61,
           "kvinner": 0.373343887469,
-          "menn": 0.32185220425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.32185220425
         },
         {
           "alder": 62,
           "kvinner": 0.374457512226,
-          "menn": 0.3263913523,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.3263913523
         },
         {
           "alder": 63,
           "kvinner": 0.375830313508,
-          "menn": 0.336919053845,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.336919053845
         },
         {
           "alder": 64,
           "kvinner": 0.386863779788,
-          "menn": 0.346669460989,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.346669460989
         },
         {
           "alder": 65,
           "kvinner": 0.394075101828,
-          "menn": 0.359336821326,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.359336821326
         },
         {
           "alder": 66,
           "kvinner": 0.4045479968,
-          "menn": 0.366512680708,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.366512680708
         },
         {
           "alder": 67,
           "kvinner": 0.410733147165,
-          "menn": 0.374124343257,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.374124343257
         },
         {
           "alder": 68,
           "kvinner": 0.417440276806,
-          "menn": 0.381406870695,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.381406870695
         },
         {
           "alder": 69,
           "kvinner": 0.4234123159,
-          "menn": 0.385299441846,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.385299441846
         },
         {
           "alder": 70,
           "kvinner": 0.422860834034,
-          "menn": 0.393102922103,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.393102922103
         },
         {
           "alder": 71,
           "kvinner": 0.41942870738,
-          "menn": 0.389068822826,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.389068822826
         },
         {
           "alder": 72,
           "kvinner": 0.430728268434,
-          "menn": 0.403659157689,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.403659157689
         },
         {
           "alder": 73,
           "kvinner": 0.457242447112,
-          "menn": 0.426831350674,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.426831350674
         },
         {
           "alder": 74,
           "kvinner": 0.488848466971,
-          "menn": 0.465372083931,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.465372083931
         },
         {
           "alder": 75,
           "kvinner": 0.521524683461,
-          "menn": 0.5000855855,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.5000855855
         },
         {
           "alder": 76,
           "kvinner": 0.564113677782,
-          "menn": 0.546281045468,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.546281045468
         },
         {
           "alder": 77,
           "kvinner": 0.580282870838,
-          "menn": 0.565039574663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.565039574663
         },
         {
           "alder": 78,
           "kvinner": 0.5702298945,
-          "menn": 0.55672972973,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.55672972973
         },
         {
           "alder": 79,
           "kvinner": 0.564072446196,
-          "menn": 0.569356192303,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.569356192303
         },
         {
           "alder": 80,
           "kvinner": 0.541453206322,
-          "menn": 0.533105552976,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.533105552976
         },
         {
           "alder": 81,
           "kvinner": 0.547068556219,
-          "menn": 0.531345386241,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.531345386241
         },
         {
           "alder": 82,
           "kvinner": 0.557807912764,
-          "menn": 0.55108227733,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.55108227733
         },
         {
           "alder": 83,
           "kvinner": 0.579026280323,
-          "menn": 0.568618990303,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.568618990303
         },
         {
           "alder": 84,
           "kvinner": 0.57897729357,
-          "menn": 0.579195249309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.579195249309
         },
         {
           "alder": 85,
           "kvinner": 0.563229857403,
-          "menn": 0.567219311056,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.567219311056
         },
         {
           "alder": 86,
           "kvinner": 0.55069374791,
-          "menn": 0.561122956645,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.561122956645
         },
         {
           "alder": 87,
           "kvinner": 0.539882244957,
-          "menn": 0.546626948087,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.546626948087
         },
         {
           "alder": 88,
           "kvinner": 0.546166267065,
-          "menn": 0.553944169671,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.553944169671
         },
         {
           "alder": 89,
           "kvinner": 0.551920110416,
-          "menn": 0.566196766562,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.566196766562
         },
         {
           "alder": 90,
           "kvinner": 0.565965108338,
-          "menn": 0.579699656233,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.579699656233
         },
         {
           "alder": 91,
           "kvinner": 0.567763464782,
-          "menn": 0.582007073386,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.582007073386
         },
         {
           "alder": 92,
           "kvinner": 0.567169924298,
-          "menn": 0.583840464376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.583840464376
         },
         {
           "alder": 93,
           "kvinner": 0.554391909236,
-          "menn": 0.592106860959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.592106860959
         },
         {
           "alder": 94,
           "kvinner": 0.558337058561,
-          "menn": 0.599246025242,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.599246025242
         },
         {
           "alder": 95,
           "kvinner": 0.550616482803,
-          "menn": 0.587023914969,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.587023914969
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/fosfat_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/fosfat_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 3548.66666667,
           "tot_pas": 2734.33333333,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.29781787151,
-          "borhf": null
+          "prove_pr_pas": 1.29781787151
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 5563,
           "tot_pas": 4232,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.31450850662,
-          "borhf": null
+          "prove_pr_pas": 1.31450850662
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 6282.33333333,
           "tot_pas": 4734.66666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.32687975218,
-          "borhf": null
+          "prove_pr_pas": 1.32687975218
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 4824.33333333,
           "tot_pas": 3474.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.3884305449,
-          "borhf": null
+          "prove_pr_pas": 1.3884305449
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 4908,
           "tot_pas": 3713.66666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.32160488287,
-          "borhf": null
+          "prove_pr_pas": 1.32160488287
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 14503,
           "tot_pas": 10839.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.33795627172,
-          "borhf": null
+          "prove_pr_pas": 1.33795627172
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 8405.33333333,
           "tot_pas": 6712,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.25228446563,
-          "borhf": null
+          "prove_pr_pas": 1.25228446563
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 5659.66666667,
           "tot_pas": 4253,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.33074692374,
-          "borhf": null
+          "prove_pr_pas": 1.33074692374
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 36690.3333333,
           "tot_pas": 24111.6666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.52168383217,
-          "borhf": null
+          "prove_pr_pas": 1.52168383217
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 14862,
           "tot_pas": 10549.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.40880940344,
-          "borhf": null
+          "prove_pr_pas": 1.40880940344
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 15213,
           "tot_pas": 11158,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.36341638286,
-          "borhf": null
+          "prove_pr_pas": 1.36341638286
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 17796.6666667,
           "tot_pas": 12757.3333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.39501463211,
-          "borhf": null
+          "prove_pr_pas": 1.39501463211
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 30432.6666667,
           "tot_pas": 22490,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.35316436935,
-          "borhf": null
+          "prove_pr_pas": 1.35316436935
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 15337.3333333,
           "tot_pas": 11180,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.37185450209,
-          "borhf": null
+          "prove_pr_pas": 1.37185450209
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 7594.33333333,
           "tot_pas": 5805.33333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.30816490583,
-          "borhf": null
+          "prove_pr_pas": 1.30816490583
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 7783,
           "tot_pas": 5711,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.36280861495,
-          "borhf": null
+          "prove_pr_pas": 1.36280861495
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 15267.3333333,
           "tot_pas": 11128.6666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.37189240999,
-          "borhf": null
+          "prove_pr_pas": 1.37189240999
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 24610.3333333,
           "tot_pas": 17711,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.38955075,
-          "borhf": null
+          "prove_pr_pas": 1.38955075
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 26471.6666667,
           "tot_pas": 18276.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.44838592012,
-          "borhf": null
+          "prove_pr_pas": 1.44838592012
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 22188.6666667,
           "tot_pas": 16035.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.38370715281,
-          "borhf": null
+          "prove_pr_pas": 1.38370715281
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 11144.6666667,
           "tot_pas": 8083.33333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.37872164948,
-          "borhf": null
+          "prove_pr_pas": 1.37872164948
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 299086.333333,
           "tot_pas": 215692,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38663619111,
-          "borhf": null
+          "prove_pr_pas": 1.38663619111
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 20218.3333333,
           "tot_pas": 15173.6666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.33246194064,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.33246194064
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 27816.3333333,
           "tot_pas": 21257.6666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.30853182381,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.30853182381
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 72425,
           "tot_pas": 50059.6666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.44677351694,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44677351694
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 178626.666667,
           "tot_pas": 128961.666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.38511443969,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.38511443969
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 299086.333333,
           "tot_pas": 215386.666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38860189427,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.38860189427
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.000705485708345,
-          "menn": 0.000745869571336,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000745869571336
         },
         {
           "alder": 1,
           "kvinner": 0.00174194441812,
-          "menn": 0.00209874419405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00209874419405
         },
         {
           "alder": 2,
           "kvinner": 0.0021169283228,
-          "menn": 0.00226555816938,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00226555816938
         },
         {
           "alder": 3,
           "kvinner": 0.00251161884619,
-          "menn": 0.00302879320292,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00302879320292
         },
         {
           "alder": 4,
           "kvinner": 0.00285186019062,
-          "menn": 0.00314272623434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00314272623434
         },
         {
           "alder": 5,
           "kvinner": 0.00305470330524,
-          "menn": 0.00359833220158,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00359833220158
         },
         {
           "alder": 6,
           "kvinner": 0.00339874650519,
-          "menn": 0.00353007802668,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00353007802668
         },
         {
           "alder": 7,
           "kvinner": 0.00398671096346,
-          "menn": 0.00392334296092,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00392334296092
         },
         {
           "alder": 8,
           "kvinner": 0.00440114378562,
-          "menn": 0.00432734443471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00432734443471
         },
         {
           "alder": 9,
           "kvinner": 0.00496370488403,
-          "menn": 0.00499008572404,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00499008572404
         },
         {
           "alder": 10,
           "kvinner": 0.00565826118735,
-          "menn": 0.0058472546572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0058472546572
         },
         {
           "alder": 11,
           "kvinner": 0.00671511938339,
-          "menn": 0.00615756939932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00615756939932
         },
         {
           "alder": 12,
           "kvinner": 0.00856193640247,
-          "menn": 0.00624323999519,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00624323999519
         },
         {
           "alder": 13,
           "kvinner": 0.0120685138925,
-          "menn": 0.0077793837222,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0077793837222
         },
         {
           "alder": 14,
           "kvinner": 0.0157347841221,
-          "menn": 0.00950493348387,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00950493348387
         },
         {
           "alder": 15,
           "kvinner": 0.0188128256877,
-          "menn": 0.010708254202,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.010708254202
         },
         {
           "alder": 16,
           "kvinner": 0.0215759849906,
-          "menn": 0.0102958506481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0102958506481
         },
         {
           "alder": 17,
           "kvinner": 0.0224932617169,
-          "menn": 0.0107860881475,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107860881475
         },
         {
           "alder": 18,
           "kvinner": 0.0230387606824,
-          "menn": 0.0107677761652,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107677761652
         },
         {
           "alder": 19,
           "kvinner": 0.022511086933,
-          "menn": 0.0110095678387,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0110095678387
         },
         {
           "alder": 20,
           "kvinner": 0.0233776019591,
-          "menn": 0.0111171541021,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0111171541021
         },
         {
           "alder": 21,
           "kvinner": 0.0238928710341,
-          "menn": 0.0112233058782,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0112233058782
         },
         {
           "alder": 22,
           "kvinner": 0.0245947251591,
-          "menn": 0.0115628666796,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0115628666796
         },
         {
           "alder": 23,
           "kvinner": 0.0252245838637,
-          "menn": 0.0122587302572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0122587302572
         },
         {
           "alder": 24,
           "kvinner": 0.0252074498601,
-          "menn": 0.0125770106011,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0125770106011
         },
         {
           "alder": 25,
           "kvinner": 0.0260803130101,
-          "menn": 0.0130513984031,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0130513984031
         },
         {
           "alder": 26,
           "kvinner": 0.0260748283506,
-          "menn": 0.01331894608,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.01331894608
         },
         {
           "alder": 27,
           "kvinner": 0.0268551314852,
-          "menn": 0.0138150285965,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0138150285965
         },
         {
           "alder": 28,
           "kvinner": 0.0272741562193,
-          "menn": 0.0139190749041,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0139190749041
         },
         {
           "alder": 29,
           "kvinner": 0.0281670553499,
-          "menn": 0.0146174308103,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0146174308103
         },
         {
           "alder": 30,
           "kvinner": 0.028993087988,
-          "menn": 0.015398990264,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.015398990264
         },
         {
           "alder": 31,
           "kvinner": 0.0304254723884,
-          "menn": 0.015524455944,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.015524455944
         },
         {
           "alder": 32,
           "kvinner": 0.0304902744179,
-          "menn": 0.0160335561673,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160335561673
         },
         {
           "alder": 33,
           "kvinner": 0.0317456788751,
-          "menn": 0.0156079180598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0156079180598
         },
         {
           "alder": 34,
           "kvinner": 0.0315009649505,
-          "menn": 0.0165141553737,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0165141553737
         },
         {
           "alder": 35,
           "kvinner": 0.0319658695665,
-          "menn": 0.0161465736314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0161465736314
         },
         {
           "alder": 36,
           "kvinner": 0.0318297646638,
-          "menn": 0.0168079572537,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0168079572537
         },
         {
           "alder": 37,
           "kvinner": 0.0316308326769,
-          "menn": 0.0164058059721,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0164058059721
         },
         {
           "alder": 38,
           "kvinner": 0.031116729976,
-          "menn": 0.0170665496723,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0170665496723
         },
         {
           "alder": 39,
           "kvinner": 0.0316066571119,
-          "menn": 0.0171255543054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0171255543054
         },
         {
           "alder": 40,
           "kvinner": 0.0327116619558,
-          "menn": 0.0181044496069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0181044496069
         },
         {
           "alder": 41,
           "kvinner": 0.0330276101316,
-          "menn": 0.0182744409464,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0182744409464
         },
         {
           "alder": 42,
           "kvinner": 0.0327188420922,
-          "menn": 0.0183791176454,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0183791176454
         },
         {
           "alder": 43,
           "kvinner": 0.0328078846548,
-          "menn": 0.0179613132406,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0179613132406
         },
         {
           "alder": 44,
           "kvinner": 0.0334993967453,
-          "menn": 0.0187622299812,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0187622299812
         },
         {
           "alder": 45,
           "kvinner": 0.0333342727503,
-          "menn": 0.0192551467403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0192551467403
         },
         {
           "alder": 46,
           "kvinner": 0.0344829489019,
-          "menn": 0.0195857130858,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0195857130858
         },
         {
           "alder": 47,
           "kvinner": 0.0352386146714,
-          "menn": 0.0207214638879,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0207214638879
         },
         {
           "alder": 48,
           "kvinner": 0.0364055848615,
-          "menn": 0.0218964576535,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0218964576535
         },
         {
           "alder": 49,
           "kvinner": 0.0386559235278,
-          "menn": 0.0222324746892,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0222324746892
         },
         {
           "alder": 50,
           "kvinner": 0.0396509847833,
-          "menn": 0.0235336656422,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0235336656422
         },
         {
           "alder": 51,
           "kvinner": 0.0407092988954,
-          "menn": 0.0251196980646,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0251196980646
         },
         {
           "alder": 52,
           "kvinner": 0.0416965576611,
-          "menn": 0.0252997331628,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0252997331628
         },
         {
           "alder": 53,
           "kvinner": 0.0436164537414,
-          "menn": 0.0264828702915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0264828702915
         },
         {
           "alder": 54,
           "kvinner": 0.044433599357,
-          "menn": 0.0290021935808,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0290021935808
         },
         {
           "alder": 55,
           "kvinner": 0.0455429831007,
-          "menn": 0.0299394846144,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0299394846144
         },
         {
           "alder": 56,
           "kvinner": 0.0465293898317,
-          "menn": 0.0304620401415,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0304620401415
         },
         {
           "alder": 57,
           "kvinner": 0.0476278382869,
-          "menn": 0.0330969127644,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0330969127644
         },
         {
           "alder": 58,
           "kvinner": 0.0484405813121,
-          "menn": 0.0333222581327,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0333222581327
         },
         {
           "alder": 59,
           "kvinner": 0.0487242378874,
-          "menn": 0.0344031202973,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0344031202973
         },
         {
           "alder": 60,
           "kvinner": 0.0491475716265,
-          "menn": 0.0364882200181,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0364882200181
         },
         {
           "alder": 61,
           "kvinner": 0.0506858025252,
-          "menn": 0.0366000634317,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0366000634317
         },
         {
           "alder": 62,
           "kvinner": 0.0506431184361,
-          "menn": 0.0377111456526,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0377111456526
         },
         {
           "alder": 63,
           "kvinner": 0.0515043718209,
-          "menn": 0.0401429005375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0401429005375
         },
         {
           "alder": 64,
           "kvinner": 0.053215137531,
-          "menn": 0.0420568013575,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0420568013575
         },
         {
           "alder": 65,
           "kvinner": 0.054468400772,
-          "menn": 0.0435538867185,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0435538867185
         },
         {
           "alder": 66,
           "kvinner": 0.0570906696685,
-          "menn": 0.0455694040103,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0455694040103
         },
         {
           "alder": 67,
           "kvinner": 0.058512870227,
-          "menn": 0.0471978984238,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0471978984238
         },
         {
           "alder": 68,
           "kvinner": 0.0603231862186,
-          "menn": 0.0484058143514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0484058143514
         },
         {
           "alder": 69,
           "kvinner": 0.0614151105532,
-          "menn": 0.0485819882335,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0485819882335
         },
         {
           "alder": 70,
           "kvinner": 0.0632511116452,
-          "menn": 0.0518196383612,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0518196383612
         },
         {
           "alder": 71,
           "kvinner": 0.0631589121351,
-          "menn": 0.0517904908513,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0517904908513
         },
         {
           "alder": 72,
           "kvinner": 0.065966234002,
-          "menn": 0.054346718903,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.054346718903
         },
         {
           "alder": 73,
           "kvinner": 0.0712846328009,
-          "menn": 0.0579348365221,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0579348365221
         },
         {
           "alder": 74,
           "kvinner": 0.0764793602412,
-          "menn": 0.0658673269907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0658673269907
         },
         {
           "alder": 75,
           "kvinner": 0.0836899457361,
-          "menn": 0.0723387664277,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0723387664277
         },
         {
           "alder": 76,
           "kvinner": 0.0932768556371,
-          "menn": 0.080414806467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.080414806467
         },
         {
           "alder": 77,
           "kvinner": 0.0962857081444,
-          "menn": 0.0839488055429,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0839488055429
         },
         {
           "alder": 78,
           "kvinner": 0.0966636546067,
-          "menn": 0.0853378378378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0853378378378
         },
         {
           "alder": 79,
           "kvinner": 0.0957739719107,
-          "menn": 0.0894077448747,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0894077448747
         },
         {
           "alder": 80,
           "kvinner": 0.0953946921415,
-          "menn": 0.0890665428249,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0890665428249
         },
         {
           "alder": 81,
           "kvinner": 0.0972879648946,
-          "menn": 0.0897646612603,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0897646612603
         },
         {
           "alder": 82,
           "kvinner": 0.103126893145,
-          "menn": 0.0946664241395,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0946664241395
         },
         {
           "alder": 83,
           "kvinner": 0.107698787062,
-          "menn": 0.101968977812,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101968977812
         },
         {
           "alder": 84,
           "kvinner": 0.11085433403,
-          "menn": 0.104663663356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104663663356
         },
         {
           "alder": 85,
           "kvinner": 0.11026348219,
-          "menn": 0.106548692839,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106548692839
         },
         {
           "alder": 86,
           "kvinner": 0.107907054497,
-          "menn": 0.107255928151,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107255928151
         },
         {
           "alder": 87,
           "kvinner": 0.107345138687,
-          "menn": 0.111199912813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111199912813
         },
         {
           "alder": 88,
           "kvinner": 0.112540979596,
-          "menn": 0.115977869059,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115977869059
         },
         {
           "alder": 89,
           "kvinner": 0.116884522746,
-          "menn": 0.125739353312,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125739353312
         },
         {
           "alder": 90,
           "kvinner": 0.120320357608,
-          "menn": 0.126530366082,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126530366082
         },
         {
           "alder": 91,
           "kvinner": 0.123757580107,
-          "menn": 0.130857648099,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.130857648099
         },
         {
           "alder": 92,
           "kvinner": 0.130747187888,
-          "menn": 0.13191648722,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13191648722
         },
         {
           "alder": 93,
           "kvinner": 0.124031007752,
-          "menn": 0.136612021858,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136612021858
         },
         {
           "alder": 94,
           "kvinner": 0.133788875407,
-          "menn": 0.145386002295,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145386002295
         },
         {
           "alder": 95,
           "kvinner": 0.126135626217,
-          "menn": 0.143268379097,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.143268379097
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/gammagt_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/gammagt_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 20627.6666667,
           "tot_pas": 14350,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.43746806039,
-          "borhf": null
+          "prove_pr_pas": 1.43746806039
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 55225,
           "tot_pas": 38586.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.43119384934,
-          "borhf": null
+          "prove_pr_pas": 1.43119384934
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 38193,
           "tot_pas": 26884.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.42062389962,
-          "borhf": null
+          "prove_pr_pas": 1.42062389962
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 26105,
           "tot_pas": 17871.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.46071921513,
-          "borhf": null
+          "prove_pr_pas": 1.46071921513
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 30860,
           "tot_pas": 22628.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.36377697577,
-          "borhf": null
+          "prove_pr_pas": 1.36377697577
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 84799.3333333,
           "tot_pas": 60432.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.4032035654,
-          "borhf": null
+          "prove_pr_pas": 1.4032035654
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 71257.3333333,
           "tot_pas": 50132,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.42139418602,
-          "borhf": null
+          "prove_pr_pas": 1.42139418602
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 28104,
           "tot_pas": 19280,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.45767634855,
-          "borhf": null
+          "prove_pr_pas": 1.45767634855
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 145796,
           "tot_pas": 92897.6666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.56942585569,
-          "borhf": null
+          "prove_pr_pas": 1.56942585569
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 80739,
           "tot_pas": 50206.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.60813305006,
-          "borhf": null
+          "prove_pr_pas": 1.60813305006
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 112334.666667,
           "tot_pas": 74104.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.51589875536,
-          "borhf": null
+          "prove_pr_pas": 1.51589875536
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 127290.333333,
           "tot_pas": 83710.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.52059872896,
-          "borhf": null
+          "prove_pr_pas": 1.52059872896
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 191535.333333,
           "tot_pas": 131021.333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.46186371685,
-          "borhf": null
+          "prove_pr_pas": 1.46186371685
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 85720.3333333,
           "tot_pas": 59126,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.44979084216,
-          "borhf": null
+          "prove_pr_pas": 1.44979084216
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 39212,
           "tot_pas": 28648,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.36875174532,
-          "borhf": null
+          "prove_pr_pas": 1.36875174532
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 43878.3333333,
           "tot_pas": 30663.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.43095520214,
-          "borhf": null
+          "prove_pr_pas": 1.43095520214
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 110479.666667,
           "tot_pas": 74664.6666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.47967802709,
-          "borhf": null
+          "prove_pr_pas": 1.47967802709
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 185787.333333,
           "tot_pas": 124628,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.49073509431,
-          "borhf": null
+          "prove_pr_pas": 1.49073509431
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 103642.333333,
           "tot_pas": 68840.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.50553936142,
-          "borhf": null
+          "prove_pr_pas": 1.50553936142
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 49190,
           "tot_pas": 33677,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.46064079342,
-          "borhf": null
+          "prove_pr_pas": 1.46064079342
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 147760.666667,
           "tot_pas": 93085.6666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.58736217892,
-          "borhf": null
+          "prove_pr_pas": 1.58736217892
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 1778541.33333,
           "tot_pas": 1195443,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.48776757514,
-          "borhf": null
+          "prove_pr_pas": 1.48776757514
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 140150.666667,
           "tot_pas": 97646.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.43528857544,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.43528857544
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 186916.666667,
           "tot_pas": 133146.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.40384389106,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40384389106
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 366973.666667,
           "tot_pas": 236376.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.55249750045,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.55249750045
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1084500.33333,
           "tot_pas": 726058,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.493682782,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.493682782
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 1778541.33333,
           "tot_pas": 1192435,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.49152057205,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.49152057205
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00335662673865,
-          "menn": 0.00460891103043,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00460891103043
         },
         {
           "alder": 1,
           "kvinner": 0.00842547174624,
-          "menn": 0.0103629795286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0103629795286
         },
         {
           "alder": 2,
           "kvinner": 0.0116004830575,
-          "menn": 0.0129651411463,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0129651411463
         },
         {
           "alder": 3,
           "kvinner": 0.0158976428353,
-          "menn": 0.0174319504904,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0174319504904
         },
         {
           "alder": 4,
           "kvinner": 0.0185370912391,
-          "menn": 0.0207148895529,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0207148895529
         },
         {
           "alder": 5,
           "kvinner": 0.0212422460108,
-          "menn": 0.0225990493295,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0225990493295
         },
         {
           "alder": 6,
           "kvinner": 0.0254939114073,
-          "menn": 0.0246350364964,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0246350364964
         },
         {
           "alder": 7,
           "kvinner": 0.028740798645,
-          "menn": 0.0280770041279,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0280770041279
         },
         {
           "alder": 8,
           "kvinner": 0.0317739552081,
-          "menn": 0.032336400818,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.032336400818
         },
         {
           "alder": 9,
           "kvinner": 0.0364152565951,
-          "menn": 0.0365061013233,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0365061013233
         },
         {
           "alder": 10,
           "kvinner": 0.041183068063,
-          "menn": 0.0398795907519,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0398795907519
         },
         {
           "alder": 11,
           "kvinner": 0.0441539514928,
-          "menn": 0.0429003165217,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0429003165217
         },
         {
           "alder": 12,
           "kvinner": 0.0526245847176,
-          "menn": 0.0445559427953,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0445559427953
         },
         {
           "alder": 13,
           "kvinner": 0.0699194367601,
-          "menn": 0.0526277434322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0526277434322
         },
         {
           "alder": 14,
           "kvinner": 0.093177511055,
-          "menn": 0.0656018359433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0656018359433
         },
         {
           "alder": 15,
           "kvinner": 0.113285787523,
-          "menn": 0.0757805395574,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0757805395574
         },
         {
           "alder": 16,
           "kvinner": 0.131429799875,
-          "menn": 0.0819946660051,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0819946660051
         },
         {
           "alder": 17,
           "kvinner": 0.144713113959,
-          "menn": 0.0873709827325,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0873709827325
         },
         {
           "alder": 18,
           "kvinner": 0.148871747271,
-          "menn": 0.0871238354481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0871238354481
         },
         {
           "alder": 19,
           "kvinner": 0.143083471721,
-          "menn": 0.0831794297425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0831794297425
         },
         {
           "alder": 20,
           "kvinner": 0.146381589275,
-          "menn": 0.0814926577659,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0814926577659
         },
         {
           "alder": 21,
           "kvinner": 0.146567637816,
-          "menn": 0.0819117528805,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0819117528805
         },
         {
           "alder": 22,
           "kvinner": 0.147562235906,
-          "menn": 0.0844374067281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0844374067281
         },
         {
           "alder": 23,
           "kvinner": 0.147691416643,
-          "menn": 0.0864313787406,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0864313787406
         },
         {
           "alder": 24,
           "kvinner": 0.148630505628,
-          "menn": 0.0889493256369,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0889493256369
         },
         {
           "alder": 25,
           "kvinner": 0.151550580527,
-          "menn": 0.091457960644,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.091457960644
         },
         {
           "alder": 26,
           "kvinner": 0.153410025117,
-          "menn": 0.0925347334063,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0925347334063
         },
         {
           "alder": 27,
           "kvinner": 0.151797801858,
-          "menn": 0.0958021535813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0958021535813
         },
         {
           "alder": 28,
           "kvinner": 0.153400868307,
-          "menn": 0.0971735490781,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0971735490781
         },
         {
           "alder": 29,
           "kvinner": 0.155469736195,
-          "menn": 0.100130172826,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.100130172826
         },
         {
           "alder": 30,
           "kvinner": 0.161901203597,
-          "menn": 0.103632158749,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103632158749
         },
         {
           "alder": 31,
           "kvinner": 0.166460422675,
-          "menn": 0.105368226199,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.105368226199
         },
         {
           "alder": 32,
           "kvinner": 0.172017469926,
-          "menn": 0.107741512649,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107741512649
         },
         {
           "alder": 33,
           "kvinner": 0.174868004224,
-          "menn": 0.109563233031,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.109563233031
         },
         {
           "alder": 34,
           "kvinner": 0.177409405013,
-          "menn": 0.112019321079,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112019321079
         },
         {
           "alder": 35,
           "kvinner": 0.176397685801,
-          "menn": 0.110237110738,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.110237110738
         },
         {
           "alder": 36,
           "kvinner": 0.176807683882,
-          "menn": 0.113139480471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113139480471
         },
         {
           "alder": 37,
           "kvinner": 0.175663778324,
-          "menn": 0.116594893543,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.116594893543
         },
         {
           "alder": 38,
           "kvinner": 0.178060404092,
-          "menn": 0.11673476103,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11673476103
         },
         {
           "alder": 39,
           "kvinner": 0.179630875428,
-          "menn": 0.120154653959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.120154653959
         },
         {
           "alder": 40,
           "kvinner": 0.183645351656,
-          "menn": 0.126362580415,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126362580415
         },
         {
           "alder": 41,
           "kvinner": 0.185311029796,
-          "menn": 0.12774214473,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.12774214473
         },
         {
           "alder": 42,
           "kvinner": 0.185758587362,
-          "menn": 0.128844396863,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128844396863
         },
         {
           "alder": 43,
           "kvinner": 0.185570145936,
-          "menn": 0.129148280743,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129148280743
         },
         {
           "alder": 44,
           "kvinner": 0.184515116004,
-          "menn": 0.133478768479,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133478768479
         },
         {
           "alder": 45,
           "kvinner": 0.18632584618,
-          "menn": 0.133518396688,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133518396688
         },
         {
           "alder": 46,
           "kvinner": 0.189068535482,
-          "menn": 0.137588190828,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137588190828
         },
         {
           "alder": 47,
           "kvinner": 0.195320425416,
-          "menn": 0.144323906468,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.144323906468
         },
         {
           "alder": 48,
           "kvinner": 0.203415257634,
-          "menn": 0.150789075449,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.150789075449
         },
         {
           "alder": 49,
           "kvinner": 0.211078996518,
-          "menn": 0.158426246316,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.158426246316
         },
         {
           "alder": 50,
           "kvinner": 0.219524729124,
-          "menn": 0.168573568532,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.168573568532
         },
         {
           "alder": 51,
           "kvinner": 0.228621062637,
-          "menn": 0.177922530269,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.177922530269
         },
         {
           "alder": 52,
           "kvinner": 0.235539196751,
-          "menn": 0.182980084193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.182980084193
         },
         {
           "alder": 53,
           "kvinner": 0.240651410922,
-          "menn": 0.18984361684,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.18984361684
         },
         {
           "alder": 54,
           "kvinner": 0.246506286961,
-          "menn": 0.200652617564,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.200652617564
         },
         {
           "alder": 55,
           "kvinner": 0.252355620867,
-          "menn": 0.208694341476,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.208694341476
         },
         {
           "alder": 56,
           "kvinner": 0.255656054173,
-          "menn": 0.216311486704,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.216311486704
         },
         {
           "alder": 57,
           "kvinner": 0.259184050212,
-          "menn": 0.22436744713,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.22436744713
         },
         {
           "alder": 58,
           "kvinner": 0.261609284916,
-          "menn": 0.229353308968,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.229353308968
         },
         {
           "alder": 59,
           "kvinner": 0.262396075558,
-          "menn": 0.23388102331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.23388102331
         },
         {
           "alder": 60,
           "kvinner": 0.266441071256,
-          "menn": 0.24141297206,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.24141297206
         },
         {
           "alder": 61,
           "kvinner": 0.267716024551,
-          "menn": 0.247085315572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.247085315572
         },
         {
           "alder": 62,
           "kvinner": 0.269840957663,
-          "menn": 0.250543383619,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.250543383619
         },
         {
           "alder": 63,
           "kvinner": 0.273014395425,
-          "menn": 0.260819895136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.260819895136
         },
         {
           "alder": 64,
           "kvinner": 0.283791544766,
-          "menn": 0.268200839649,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.268200839649
         },
         {
           "alder": 65,
           "kvinner": 0.291574226075,
-          "menn": 0.278468780629,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.278468780629
         },
         {
           "alder": 66,
           "kvinner": 0.300271152362,
-          "menn": 0.283758870801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.283758870801
         },
         {
           "alder": 67,
           "kvinner": 0.30463154544,
-          "menn": 0.291170461179,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.291170461179
         },
         {
           "alder": 68,
           "kvinner": 0.310545882873,
-          "menn": 0.293998184875,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.293998184875
         },
         {
           "alder": 69,
           "kvinner": 0.314278882438,
-          "menn": 0.298393422839,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.298393422839
         },
         {
           "alder": 70,
           "kvinner": 0.314482934743,
-          "menn": 0.305607690547,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.305607690547
         },
         {
           "alder": 71,
           "kvinner": 0.311980490996,
-          "menn": 0.29957095282,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.29957095282
         },
         {
           "alder": 72,
           "kvinner": 0.320013010196,
-          "menn": 0.310127326151,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.310127326151
         },
         {
           "alder": 73,
           "kvinner": 0.338745944432,
-          "menn": 0.326354048934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.326354048934
         },
         {
           "alder": 74,
           "kvinner": 0.362322403028,
-          "menn": 0.35434206525,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.35434206525
         },
         {
           "alder": 75,
           "kvinner": 0.383809061631,
-          "menn": 0.378392514122,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.378392514122
         },
         {
           "alder": 76,
           "kvinner": 0.418076146382,
-          "menn": 0.414763122535,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414763122535
         },
         {
           "alder": 77,
           "kvinner": 0.426713668508,
-          "menn": 0.42670868718,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.42670868718
         },
         {
           "alder": 78,
           "kvinner": 0.41850421884,
-          "menn": 0.416148648649,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.416148648649
         },
         {
           "alder": 79,
           "kvinner": 0.410414772153,
-          "menn": 0.424934060664,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.424934060664
         },
         {
           "alder": 80,
           "kvinner": 0.394923154276,
-          "menn": 0.396006103629,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.396006103629
         },
         {
           "alder": 81,
           "kvinner": 0.393827782174,
-          "menn": 0.395054816046,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.395054816046
         },
         {
           "alder": 82,
           "kvinner": 0.400624446619,
-          "menn": 0.408233796156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.408233796156
         },
         {
           "alder": 83,
           "kvinner": 0.415633423181,
-          "menn": 0.417187109668,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.417187109668
         },
         {
           "alder": 84,
           "kvinner": 0.412860863505,
-          "menn": 0.418808231801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.418808231801
         },
         {
           "alder": 85,
           "kvinner": 0.399761359858,
-          "menn": 0.407181513616,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.407181513616
         },
         {
           "alder": 86,
           "kvinner": 0.387224172518,
-          "menn": 0.402952768624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.402952768624
         },
         {
           "alder": 87,
           "kvinner": 0.375584857507,
-          "menn": 0.394049478694,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.394049478694
         },
         {
           "alder": 88,
           "kvinner": 0.380486372755,
-          "menn": 0.398105457289,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.398105457289
         },
         {
           "alder": 89,
           "kvinner": 0.380693350654,
-          "menn": 0.407827287066,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.407827287066
         },
         {
           "alder": 90,
           "kvinner": 0.389302787608,
-          "menn": 0.409927024908,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.409927024908
         },
         {
           "alder": 91,
           "kvinner": 0.390003229395,
-          "menn": 0.417035072207,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.417035072207
         },
         {
           "alder": 92,
           "kvinner": 0.391428938027,
-          "menn": 0.414661548544,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414661548544
         },
         {
           "alder": 93,
           "kvinner": 0.37722675702,
-          "menn": 0.413357619915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.413357619915
         },
         {
           "alder": 94,
           "kvinner": 0.379206845903,
-          "menn": 0.41976725127,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.41976725127
         },
         {
           "alder": 95,
           "kvinner": 0.369970798183,
-          "menn": 0.406111603189,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.406111603189
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/glukose_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/glukose_rb1.json
@@ -72,17 +72,23 @@
       "type": "linechart",
       "data": "datasett_3",
       "linevars": [
-        "kvinner",
-        "menn"
+        "kvinner_s",
+        "menn_s",
+        "kvinner_l",
+        "menn_l"
       ],
       "linevarsLabels": {
         "nb": [
-          "Kvinner",
-          "Menn"
+          "Kvinner i spes",
+          "Menn i spes",
+          "Kvinner hos lege",
+          "Menn hos lege"
         ],
         "en": [
-          "Women",
-          "Men"
+          "Women at specialist",
+          "Men at specialist",
+          "Women at GP",
+          "Men at GP"
         ]
       },
       "x": [
@@ -200,8 +206,7 @@
           "tot_events": 14376.3333333,
           "tot_pas": 11029.3333333,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.3034634913,
-          "borhf": null
+          "prove_pr_pas": 1.3034634913
         },
         {
           "bohf": "UNN",
@@ -213,8 +218,7 @@
           "tot_events": 33242.3333333,
           "tot_pas": 25866.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.2851583139,
-          "borhf": null
+          "prove_pr_pas": 1.2851583139
         },
         {
           "bohf": "Nordland",
@@ -226,8 +230,7 @@
           "tot_events": 16683.6666667,
           "tot_pas": 13516.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.23433376902,
-          "borhf": null
+          "prove_pr_pas": 1.23433376902
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +242,7 @@
           "tot_events": 16356,
           "tot_pas": 12266.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.33340579907,
-          "borhf": null
+          "prove_pr_pas": 1.33340579907
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +254,7 @@
           "tot_events": 21957.6666667,
           "tot_pas": 16596.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.32301667001,
-          "borhf": null
+          "prove_pr_pas": 1.32301667001
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +266,7 @@
           "tot_events": 45341,
           "tot_pas": 34259,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.32347704253,
-          "borhf": null
+          "prove_pr_pas": 1.32347704253
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +278,7 @@
           "tot_events": 53094.3333333,
           "tot_pas": 38554.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.37711820445,
-          "borhf": null
+          "prove_pr_pas": 1.37711820445
         },
         {
           "bohf": "Førde",
@@ -291,8 +290,7 @@
           "tot_events": 17434,
           "tot_pas": 13167.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.32400070881,
-          "borhf": null
+          "prove_pr_pas": 1.32400070881
         },
         {
           "bohf": "Bergen",
@@ -304,8 +302,7 @@
           "tot_events": 97467.6666667,
           "tot_pas": 68777.6666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.41714122317,
-          "borhf": null
+          "prove_pr_pas": 1.41714122317
         },
         {
           "bohf": "Fonna",
@@ -317,8 +314,7 @@
           "tot_events": 42362.6666667,
           "tot_pas": 29700,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.42635241302,
-          "borhf": null
+          "prove_pr_pas": 1.42635241302
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +326,7 @@
           "tot_events": 66854,
           "tot_pas": 48167.6666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.3879435029,
-          "borhf": null
+          "prove_pr_pas": 1.3879435029
         },
         {
           "bohf": "Østfold",
@@ -343,8 +338,7 @@
           "tot_events": 93999.6666667,
           "tot_pas": 66345.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.41681697373,
-          "borhf": null
+          "prove_pr_pas": 1.41681697373
         },
         {
           "bohf": "Akershus",
@@ -356,8 +350,7 @@
           "tot_events": 149242.666667,
           "tot_pas": 106722,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.39842456726,
-          "borhf": null
+          "prove_pr_pas": 1.39842456726
         },
         {
           "bohf": "OUS",
@@ -369,8 +362,7 @@
           "tot_events": 64413.6666667,
           "tot_pas": 46876.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.37411913617,
-          "borhf": null
+          "prove_pr_pas": 1.37411913617
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +374,7 @@
           "tot_events": 26002.3333333,
           "tot_pas": 20355.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.27740023253,
-          "borhf": null
+          "prove_pr_pas": 1.27740023253
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +386,7 @@
           "tot_events": 26197.3333333,
           "tot_pas": 20320,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.28923884514,
-          "borhf": null
+          "prove_pr_pas": 1.28923884514
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +398,7 @@
           "tot_events": 93920.3333333,
           "tot_pas": 66155.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.41969405339,
-          "borhf": null
+          "prove_pr_pas": 1.41969405339
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +410,7 @@
           "tot_events": 120082,
           "tot_pas": 86193,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.39317577994,
-          "borhf": null
+          "prove_pr_pas": 1.39317577994
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +422,7 @@
           "tot_events": 80419.3333333,
           "tot_pas": 56571.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.42154788911,
-          "borhf": null
+          "prove_pr_pas": 1.42154788911
         },
         {
           "bohf": "Telemark",
@@ -447,8 +434,7 @@
           "tot_events": 24752.6666667,
           "tot_pas": 19311.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.28176890945,
-          "borhf": null
+          "prove_pr_pas": 1.28176890945
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +446,7 @@
           "tot_events": 54500.3333333,
           "tot_pas": 38398,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.41935343855,
-          "borhf": null
+          "prove_pr_pas": 1.41935343855
         },
         {
           "bohf": "Norge",
@@ -473,8 +458,7 @@
           "tot_events": 1158712.33333,
           "tot_pas": 839161.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38079805075,
-          "borhf": null
+          "prove_pr_pas": 1.38079805075
         }
       ]
     },
@@ -493,9 +477,7 @@
           "tot_events": 80658.3333333,
           "tot_pas": 62661.6666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.28720376626,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.28720376626
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +489,7 @@
           "tot_events": 120393,
           "tot_pas": 89387,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.34687370647,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.34687370647
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +501,7 @@
           "tot_events": 224118.333333,
           "tot_pas": 159765,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.40279994575,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40279994575
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +513,7 @@
           "tot_events": 733542.666667,
           "tot_pas": 526313.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.39373757078,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39373757078
         },
         {
           "borhf": "Norge",
@@ -549,9 +525,7 @@
           "tot_events": 1158712.33333,
           "tot_pas": 837840.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38297511738,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.38297511738
         }
       ]
     },
@@ -562,675 +536,675 @@
       "data": [
         {
           "alder": 0,
-          "kvinner": 0.0210606049354,
-          "menn": 0.0243603816601,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00437334415049,
+          "menn_s": 0.00494582567476,
+          "kvinner_l": 0.0315768124026,
+          "menn_l": 0.0369183515527
         },
         {
           "alder": 1,
-          "kvinner": 0.0421638010831,
-          "menn": 0.0478995355238,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0113143364228,
+          "menn_s": 0.0131606752917,
+          "kvinner_l": 0.0599857030172,
+          "menn_l": 0.0685623048205
         },
         {
           "alder": 2,
-          "kvinner": 0.038701427861,
-          "menn": 0.0423639328486,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0149250046293,
+          "menn_s": 0.0161820628327,
+          "kvinner_l": 0.0523301030801,
+          "menn_l": 0.0579886503247
         },
         {
           "alder": 3,
-          "kvinner": 0.0363245484652,
-          "menn": 0.0386925053758,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0199553328907,
+          "menn_s": 0.0215376909592,
+          "kvinner_l": 0.0430735800085,
+          "menn_l": 0.0456480659336
         },
         {
           "alder": 4,
-          "kvinner": 0.0354162828936,
-          "menn": 0.0378611392544,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0228742036345,
+          "menn_s": 0.0233832985893,
+          "kvinner_l": 0.0381432635118,
+          "menn_l": 0.0413288772708
         },
         {
           "alder": 5,
-          "kvinner": 0.0345328849529,
-          "menn": 0.0365417933275,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0244873672647,
+          "menn_s": 0.0245831091985,
+          "kvinner_l": 0.0344997253753,
+          "menn_l": 0.0373641742873
         },
         {
           "alder": 6,
-          "kvinner": 0.0354251414488,
-          "menn": 0.0362761137679,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0278877293991,
+          "menn_s": 0.027071413435,
+          "kvinner_l": 0.0322395645916,
+          "menn_l": 0.0340114431024
         },
         {
           "alder": 7,
-          "kvinner": 0.0351117191062,
-          "menn": 0.0357625416816,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0304452774781,
+          "menn_s": 0.0301021758696,
+          "kvinner_l": 0.0295108955606,
+          "menn_l": 0.0309915824025
         },
         {
           "alder": 8,
-          "kvinner": 0.0354778247603,
-          "menn": 0.0361159801344,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0329446319758,
+          "menn_s": 0.0332445280259,
+          "kvinner_l": 0.0278374468458,
+          "menn_l": 0.0287520242386
         },
         {
           "alder": 9,
-          "kvinner": 0.0374901990541,
-          "menn": 0.037704201137,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0363728623251,
+          "menn_s": 0.0360615966611,
+          "kvinner_l": 0.0276386249784,
+          "menn_l": 0.0286395690701
         },
         {
           "alder": 10,
-          "kvinner": 0.0393305861152,
-          "menn": 0.038607409708,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.038582693812,
+          "menn_s": 0.0368735705974,
+          "kvinner_l": 0.027398997907,
+          "menn_l": 0.0279661356979
         },
         {
           "alder": 11,
-          "kvinner": 0.041748066812,
-          "menn": 0.0386859878041,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0409013464096,
+          "menn_s": 0.0376363654249,
+          "kvinner_l": 0.028143700133,
+          "menn_l": 0.0262057703847
         },
         {
           "alder": 12,
-          "kvinner": 0.0465179560196,
-          "menn": 0.0390097344069,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.046749324595,
+          "menn_s": 0.037124256785,
+          "kvinner_l": 0.0287624937082,
+          "menn_l": 0.0260502320874
         },
         {
           "alder": 13,
-          "kvinner": 0.0565859330578,
-          "menn": 0.0416783063899,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.059805889535,
+          "menn_s": 0.0422536589184,
+          "kvinner_l": 0.0318378411936,
+          "menn_l": 0.0248884714722
         },
         {
           "alder": 14,
-          "kvinner": 0.0718797942424,
-          "menn": 0.0497705070934,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0757151221144,
+          "menn_s": 0.050436862497,
+          "kvinner_l": 0.040868601539,
+          "menn_l": 0.0297303708389
         },
         {
           "alder": 15,
-          "kvinner": 0.0817407217532,
-          "menn": 0.0501698102703,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0850724009181,
+          "menn_s": 0.0520096939956,
+          "kvinner_l": 0.0481579810245,
+          "menn_l": 0.0295445632171
         },
         {
           "alder": 16,
-          "kvinner": 0.0870661350844,
-          "menn": 0.0507721887986,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0921325161715,
+          "menn_s": 0.0525545086396,
+          "kvinner_l": 0.0498263354116,
+          "menn_l": 0.0301148241282
         },
         {
           "alder": 17,
-          "kvinner": 0.0922094458772,
-          "menn": 0.051735312821,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0993608616057,
+          "menn_s": 0.0547668995295,
+          "kvinner_l": 0.0533685912191,
+          "menn_l": 0.031395751441
         },
         {
           "alder": 18,
-          "kvinner": 0.0928848061966,
-          "menn": 0.0507856020138,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.099081681972,
+          "menn_s": 0.0541497043962,
+          "kvinner_l": 0.0567638687503,
+          "menn_l": 0.0321072765583
         },
         {
           "alder": 19,
-          "kvinner": 0.0930793359929,
-          "menn": 0.0507286093867,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0962820402546,
+          "menn_s": 0.0521870008601,
+          "kvinner_l": 0.0610055049028,
+          "menn_l": 0.0349961092681
         },
         {
           "alder": 20,
-          "kvinner": 0.0946469498603,
-          "menn": 0.0496733860828,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.099046447247,
+          "menn_s": 0.0520055713098,
+          "kvinner_l": 0.0608300894155,
+          "menn_l": 0.0331072076315
         },
         {
           "alder": 21,
-          "kvinner": 0.0969050397288,
-          "menn": 0.0513779278814,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.100707505392,
+          "menn_s": 0.0525375337464,
+          "kvinner_l": 0.0628419001573,
+          "menn_l": 0.0343290539359
         },
         {
           "alder": 22,
-          "kvinner": 0.0983789006366,
-          "menn": 0.0536790421617,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.10243160782,
+          "menn_s": 0.0548307120909,
+          "kvinner_l": 0.0628396494869,
+          "menn_l": 0.0353795935559
         },
         {
           "alder": 23,
-          "kvinner": 0.100421716913,
-          "menn": 0.0546398786532,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.105281339538,
+          "menn_s": 0.0566910183159,
+          "kvinner_l": 0.0638373534372,
+          "menn_l": 0.0351251219951
         },
         {
           "alder": 24,
-          "kvinner": 0.103816604269,
-          "menn": 0.0554920353,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.107300983568,
+          "menn_s": 0.0580763937963,
+          "kvinner_l": 0.0665616735506,
+          "menn_l": 0.0348867482426
         },
         {
           "alder": 25,
-          "kvinner": 0.108314908493,
-          "menn": 0.0569396570531,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.111724497984,
+          "menn_s": 0.0597816213074,
+          "kvinner_l": 0.0692042191564,
+          "menn_l": 0.0350550488718
         },
         {
           "alder": 26,
-          "kvinner": 0.114397001877,
-          "menn": 0.0580321673216,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.116198483256,
+          "menn_s": 0.0604391174653,
+          "kvinner_l": 0.074833603166,
+          "menn_l": 0.0363960477637
         },
         {
           "alder": 27,
-          "kvinner": 0.11707953208,
-          "menn": 0.0598440000211,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.120585484474,
+          "menn_s": 0.0626488253901,
+          "kvinner_l": 0.077581369248,
+          "menn_l": 0.0380371041689
         },
         {
           "alder": 28,
-          "kvinner": 0.11916182919,
-          "menn": 0.0611513783888,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.122095211862,
+          "menn_s": 0.0639087890966,
+          "kvinner_l": 0.0797594454391,
+          "menn_l": 0.0388432640224
         },
         {
           "alder": 29,
-          "kvinner": 0.124162904641,
-          "menn": 0.0621433753351,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.124554072876,
+          "menn_s": 0.0648137055229,
+          "kvinner_l": 0.0840364829043,
+          "menn_l": 0.0385425045782
         },
         {
           "alder": 30,
-          "kvinner": 0.128686183982,
-          "menn": 0.0644919830265,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.128834032691,
+          "menn_s": 0.065108976727,
+          "kvinner_l": 0.0828168618431,
+          "menn_l": 0.039779024079
         },
         {
           "alder": 31,
-          "kvinner": 0.134221796582,
-          "menn": 0.0654059743748,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.130066000017,
+          "menn_s": 0.0656089516095,
+          "kvinner_l": 0.0862943722193,
+          "menn_l": 0.0397227673166
         },
         {
           "alder": 32,
-          "kvinner": 0.135452127368,
-          "menn": 0.0681452352864,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.129118996609,
+          "menn_s": 0.0670741380894,
+          "kvinner_l": 0.0855502259539,
+          "menn_l": 0.0414485275085
         },
         {
           "alder": 33,
-          "kvinner": 0.135191463347,
-          "menn": 0.0685984185109,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.130590134719,
+          "menn_s": 0.0679030199915,
+          "kvinner_l": 0.0840163392062,
+          "menn_l": 0.0420586984262
         },
         {
           "alder": 34,
-          "kvinner": 0.133802697334,
-          "menn": 0.0692660673554,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.128728442659,
+          "menn_s": 0.0691607144396,
+          "kvinner_l": 0.0837399908334,
+          "menn_l": 0.0420375141087
         },
         {
           "alder": 35,
-          "kvinner": 0.130593456049,
-          "menn": 0.0706163587027,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.130229438303,
+          "menn_s": 0.0711660101591,
+          "kvinner_l": 0.0798761382327,
+          "menn_l": 0.0438997429531
         },
         {
           "alder": 36,
-          "kvinner": 0.127532371695,
-          "menn": 0.0710896605761,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.128008354858,
+          "menn_s": 0.071252919114,
+          "kvinner_l": 0.0782615182343,
+          "menn_l": 0.0443174580709
         },
         {
           "alder": 37,
-          "kvinner": 0.124397618275,
-          "menn": 0.0739026362961,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.126803305035,
+          "menn_s": 0.0744104553662,
+          "kvinner_l": 0.0762351339598,
+          "menn_l": 0.0464752471707
         },
         {
           "alder": 38,
-          "kvinner": 0.12218894922,
-          "menn": 0.0749787490746,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.127057280778,
+          "menn_s": 0.0754474554342,
+          "kvinner_l": 0.0722376373104,
+          "menn_l": 0.047396132835
         },
         {
           "alder": 39,
-          "kvinner": 0.121676562637,
-          "menn": 0.0759039865864,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.126435022195,
+          "menn_s": 0.0766039171634,
+          "kvinner_l": 0.0725547221797,
+          "menn_l": 0.0480676897433
         },
         {
           "alder": 40,
-          "kvinner": 0.122840214293,
-          "menn": 0.0806770461044,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.128623119041,
+          "menn_s": 0.0813022900902,
+          "kvinner_l": 0.0702320327756,
+          "menn_l": 0.0499350490085
         },
         {
           "alder": 41,
-          "kvinner": 0.122172456399,
-          "menn": 0.0811613328934,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.129186787715,
+          "menn_s": 0.0820772977882,
+          "kvinner_l": 0.0694514197412,
+          "menn_l": 0.0510701147633
         },
         {
           "alder": 42,
-          "kvinner": 0.120297185278,
-          "menn": 0.083504755926,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.128144562386,
+          "menn_s": 0.0847756586925,
+          "kvinner_l": 0.0690637272056,
+          "menn_l": 0.0520890750744
         },
         {
           "alder": 43,
-          "kvinner": 0.119193987073,
-          "menn": 0.0845225210224,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.130110167569,
+          "menn_s": 0.0867839388861,
+          "kvinner_l": 0.0708741407028,
+          "menn_l": 0.0557776383909
         },
         {
           "alder": 44,
-          "kvinner": 0.117839597753,
-          "menn": 0.0860826239716,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.131536975581,
+          "menn_s": 0.0902741219824,
+          "kvinner_l": 0.0706820545842,
+          "menn_l": 0.0573625629841
         },
         {
           "alder": 45,
-          "kvinner": 0.118980920441,
-          "menn": 0.0886806480427,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.13557809251,
+          "menn_s": 0.093936246854,
+          "kvinner_l": 0.0714621993801,
+          "menn_l": 0.0611895472535
         },
         {
           "alder": 46,
-          "kvinner": 0.119804657323,
-          "menn": 0.0906423231984,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.134505038586,
+          "menn_s": 0.0950150095515,
+          "kvinner_l": 0.0720912750145,
+          "menn_l": 0.0620576730647
         },
         {
           "alder": 47,
-          "kvinner": 0.123719661849,
-          "menn": 0.0962920304856,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.138547652532,
+          "menn_s": 0.0991410387645,
+          "kvinner_l": 0.0727198219258,
+          "menn_l": 0.066064355334
         },
         {
           "alder": 48,
-          "kvinner": 0.128573130707,
-          "menn": 0.101426821359,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.139897364847,
+          "menn_s": 0.102925714484,
+          "kvinner_l": 0.0764932685559,
+          "menn_l": 0.0682985323636
         },
         {
           "alder": 49,
-          "kvinner": 0.132658388637,
-          "menn": 0.106728181469,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.143538551877,
+          "menn_s": 0.107485439482,
+          "kvinner_l": 0.0791182980261,
+          "menn_l": 0.0716282831064
         },
         {
           "alder": 50,
-          "kvinner": 0.137371999805,
-          "menn": 0.114863503706,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.144861823004,
+          "menn_s": 0.112830266269,
+          "kvinner_l": 0.0827000967777,
+          "menn_l": 0.0776789691923
         },
         {
           "alder": 51,
-          "kvinner": 0.143799097534,
-          "menn": 0.121902276473,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.150130524961,
+          "menn_s": 0.119295841007,
+          "kvinner_l": 0.0851988270634,
+          "menn_l": 0.081577932925
         },
         {
           "alder": 52,
-          "kvinner": 0.146511858907,
-          "menn": 0.125104192332,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.150256327526,
+          "menn_s": 0.118718129217,
+          "kvinner_l": 0.0876980712698,
+          "menn_l": 0.0861476915681
         },
         {
           "alder": 53,
-          "kvinner": 0.151582198512,
-          "menn": 0.131061445372,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.15303820541,
+          "menn_s": 0.12369795049,
+          "kvinner_l": 0.090532565736,
+          "menn_l": 0.0893576122815
         },
         {
           "alder": 54,
-          "kvinner": 0.156157776885,
-          "menn": 0.139854416082,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.156095316956,
+          "menn_s": 0.128787214259,
+          "kvinner_l": 0.0941392952434,
+          "menn_l": 0.0960334029228
         },
         {
           "alder": 55,
-          "kvinner": 0.16,
-          "menn": 0.147938904024,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.157184447784,
+          "menn_s": 0.136825938262,
+          "kvinner_l": 0.0984504132231,
+          "menn_l": 0.0998044450794
         },
         {
           "alder": 56,
-          "kvinner": 0.162398816468,
-          "menn": 0.153096725302,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.159268005851,
+          "menn_s": 0.137379757613,
+          "kvinner_l": 0.0989186450077,
+          "menn_l": 0.104164779624
         },
         {
           "alder": 57,
-          "kvinner": 0.163989908313,
-          "menn": 0.162038566843,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.159841918886,
+          "menn_s": 0.144597264224,
+          "kvinner_l": 0.100854968403,
+          "menn_l": 0.112511352252
         },
         {
           "alder": 58,
-          "kvinner": 0.166009320086,
-          "menn": 0.165294348627,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.1603699529,
+          "menn_s": 0.14790408732,
+          "kvinner_l": 0.105651946379,
+          "menn_l": 0.116862130361
         },
         {
           "alder": 59,
-          "kvinner": 0.168445194789,
-          "menn": 0.166702496852,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.16592021018,
+          "menn_s": 0.149770162138,
+          "kvinner_l": 0.107562138624,
+          "menn_l": 0.122029383193
         },
         {
           "alder": 60,
-          "kvinner": 0.16977021496,
-          "menn": 0.173542755233,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.166975213956,
+          "menn_s": 0.155903164214,
+          "kvinner_l": 0.111658856012,
+          "menn_l": 0.127262888124
         },
         {
           "alder": 61,
-          "kvinner": 0.171729623814,
-          "menn": 0.177887725975,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.169055238625,
+          "menn_s": 0.159657506557,
+          "kvinner_l": 0.114234033672,
+          "menn_l": 0.131047279437
         },
         {
           "alder": 62,
-          "kvinner": 0.17406154532,
-          "menn": 0.183731384677,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.169403919199,
+          "menn_s": 0.163591027691,
+          "kvinner_l": 0.117101174033,
+          "menn_l": 0.136120696911
         },
         {
           "alder": 63,
-          "kvinner": 0.175205292729,
-          "menn": 0.188940396476,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.16969425541,
+          "menn_s": 0.168702265476,
+          "kvinner_l": 0.118136039411,
+          "menn_l": 0.138646299937
         },
         {
           "alder": 64,
-          "kvinner": 0.181286865807,
-          "menn": 0.196053245357,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.172946222369,
+          "menn_s": 0.173349534224,
+          "kvinner_l": 0.122126910811,
+          "menn_l": 0.144100357952
         },
         {
           "alder": 65,
-          "kvinner": 0.187637802306,
-          "menn": 0.202777509353,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.178608561495,
+          "menn_s": 0.178983885407,
+          "kvinner_l": 0.126801346048,
+          "menn_l": 0.149776186213
         },
         {
           "alder": 66,
-          "kvinner": 0.194564209304,
-          "menn": 0.207603442262,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.180195413125,
+          "menn_s": 0.178917581285,
+          "kvinner_l": 0.131671224793,
+          "menn_l": 0.155225351145
         },
         {
           "alder": 67,
-          "kvinner": 0.198869966576,
-          "menn": 0.214149153532,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.18325952273,
+          "menn_s": 0.185631150643,
+          "kvinner_l": 0.136264834769,
+          "menn_l": 0.161489875095
         },
         {
           "alder": 68,
-          "kvinner": 0.202760702323,
-          "menn": 0.216230491125,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.1878800114,
+          "menn_s": 0.188770923933,
+          "kvinner_l": 0.139191050732,
+          "menn_l": 0.164318165254
         },
         {
           "alder": 69,
-          "kvinner": 0.207125617402,
-          "menn": 0.220915673556,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.194657615112,
+          "menn_s": 0.197266629051,
+          "kvinner_l": 0.146239177489,
+          "menn_l": 0.169970534763
         },
         {
           "alder": 70,
-          "kvinner": 0.206473080159,
-          "menn": 0.224223697261,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.198012810814,
+          "menn_s": 0.203721992074,
+          "kvinner_l": 0.148597871589,
+          "menn_l": 0.173209865459
         },
         {
           "alder": 71,
-          "kvinner": 0.207625165425,
-          "menn": 0.222807325047,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.203251928021,
+          "menn_s": 0.205174583202,
+          "kvinner_l": 0.155694087404,
+          "menn_l": 0.17803030303
         },
         {
           "alder": 72,
-          "kvinner": 0.214108498986,
-          "menn": 0.230942213516,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.205344530909,
+          "menn_s": 0.20738067643,
+          "kvinner_l": 0.158140072425,
+          "menn_l": 0.180802865873
         },
         {
           "alder": 73,
-          "kvinner": 0.229982805169,
-          "menn": 0.244326451623,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.215873382328,
+          "menn_s": 0.21269365052,
+          "kvinner_l": 0.163248553875,
+          "menn_l": 0.186196551129
         },
         {
           "alder": 74,
-          "kvinner": 0.247177293807,
-          "menn": 0.268100264998,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.214828439145,
+          "menn_s": 0.216831827649,
+          "kvinner_l": 0.167831546902,
+          "menn_l": 0.192515355328
         },
         {
           "alder": 75,
-          "kvinner": 0.265787267834,
-          "menn": 0.287700412712,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.221429504769,
+          "menn_s": 0.222313749581,
+          "kvinner_l": 0.172180844113,
+          "menn_l": 0.200086563163
         },
         {
           "alder": 76,
-          "kvinner": 0.290735359307,
-          "menn": 0.315786051753,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.228631089846,
+          "menn_s": 0.232655869113,
+          "kvinner_l": 0.179511291192,
+          "menn_l": 0.203164490705
         },
         {
           "alder": 77,
-          "kvinner": 0.299518517722,
-          "menn": 0.323886737075,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.240056818182,
+          "menn_s": 0.240778410632,
+          "kvinner_l": 0.190232831028,
+          "menn_l": 0.215656360184
         },
         {
           "alder": 78,
-          "kvinner": 0.298745496579,
-          "menn": 0.320418918919,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.238571842657,
+          "menn_s": 0.232612540652,
+          "kvinner_l": 0.195485004007,
+          "menn_l": 0.218329814952
         },
         {
           "alder": 79,
-          "kvinner": 0.289595331919,
-          "menn": 0.324646325381,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.246862657354,
+          "menn_s": 0.257055529527,
+          "kvinner_l": 0.199252874681,
+          "menn_l": 0.226245454343
         },
         {
           "alder": 80,
-          "kvinner": 0.28550462705,
-          "menn": 0.313308564984,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.243918446849,
+          "menn_s": 0.242164741336,
+          "kvinner_l": 0.200897677471,
+          "menn_l": 0.232219989955
         },
         {
           "alder": 81,
-          "kvinner": 0.284180994173,
-          "menn": 0.306536384489,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.246413232203,
+          "menn_s": 0.249873829417,
+          "kvinner_l": 0.204834140546,
+          "menn_l": 0.22598553244
         },
         {
           "alder": 82,
-          "kvinner": 0.292542367616,
-          "menn": 0.314396006387,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.247408547584,
+          "menn_s": 0.248211036992,
+          "kvinner_l": 0.205536448688,
+          "menn_l": 0.223468768951
         },
         {
           "alder": 83,
-          "kvinner": 0.302644878706,
-          "menn": 0.321554288829,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.262970338539,
+          "menn_s": 0.254697357204,
+          "kvinner_l": 0.20776124096,
+          "menn_l": 0.228132992327
         },
         {
           "alder": 84,
-          "kvinner": 0.305729797146,
-          "menn": 0.325074229548,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.26674934387,
+          "menn_s": 0.261579110973,
+          "kvinner_l": 0.213999365501,
+          "menn_l": 0.231893068076
         },
         {
           "alder": 85,
-          "kvinner": 0.298104571328,
-          "menn": 0.315494086991,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.266344368317,
+          "menn_s": 0.261472448058,
+          "kvinner_l": 0.221585451751,
+          "menn_l": 0.236178861789
         },
         {
           "alder": 86,
-          "kvinner": 0.293380140421,
-          "menn": 0.315209665956,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.27410327713,
+          "menn_s": 0.267293450286,
+          "kvinner_l": 0.22010630434,
+          "menn_l": 0.245180944377
         },
         {
           "alder": 87,
-          "kvinner": 0.28514182095,
-          "menn": 0.307334616922,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.274781595807,
+          "menn_s": 0.273558454224,
+          "kvinner_l": 0.219763152786,
+          "menn_l": 0.242106546385
         },
         {
           "alder": 88,
-          "kvinner": 0.28631893135,
-          "menn": 0.313144437924,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.280228792531,
+          "menn_s": 0.272583310383,
+          "kvinner_l": 0.211969550406,
+          "menn_l": 0.241806664831
         },
         {
           "alder": 89,
-          "kvinner": 0.285838001678,
-          "menn": 0.326843454259,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.278372787865,
+          "menn_s": 0.280601576323,
+          "kvinner_l": 0.207124798897,
+          "menn_l": 0.252694225511
         },
         {
           "alder": 90,
-          "kvinner": 0.287080151487,
-          "menn": 0.322960014474,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.274689940285,
+          "menn_s": 0.271657652529,
+          "kvinner_l": 0.197315367733,
+          "menn_l": 0.236455071639
         },
         {
           "alder": 91,
-          "kvinner": 0.2878467114,
-          "menn": 0.326849395815,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.280462496294,
+          "menn_s": 0.282626865672,
+          "kvinner_l": 0.195197153869,
+          "menn_l": 0.247044776119
         },
         {
           "alder": 92,
-          "kvinner": 0.292759077884,
-          "menn": 0.321599101208,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.287340781328,
+          "menn_s": 0.290167865707,
+          "kvinner_l": 0.199743826941,
+          "menn_l": 0.224670263789
         },
         {
           "alder": 93,
-          "kvinner": 0.284306175882,
-          "menn": 0.321554341226,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.296065889775,
+          "menn_s": 0.290527150218,
+          "kvinner_l": 0.189170244458,
+          "menn_l": 0.234244946492
         },
         {
           "alder": 94,
-          "kvinner": 0.276135129957,
-          "menn": 0.339288641206,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.287711313394,
+          "menn_s": 0.305452620434,
+          "kvinner_l": 0.180862592111,
+          "menn_l": 0.242456326098
         },
         {
           "alder": 95,
-          "kvinner": 0.270927968851,
-          "menn": 0.316873339238,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.282699250208,
+          "menn_s": 0.265191429575,
+          "kvinner_l": 0.18106081644,
+          "menn_l": 0.237442922374
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/hba1c_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/hba1c_rb1.json
@@ -106,17 +106,23 @@
       "type": "linechart",
       "data": "datasett_3",
       "linevars": [
-        "kvinner",
-        "menn"
+        "kvinner_s",
+        "menn_s",
+        "kvinner_l",
+        "menn_l"
       ],
       "linevarsLabels": {
         "nb": [
-          "Kvinner",
-          "Menn"
+          "Kvinner i spes",
+          "Menn i spes",
+          "Kvinner hos lege",
+          "Menn hos lege"
         ],
         "en": [
-          "Women",
-          "Men"
+          "Women at specialist",
+          "Men at specialist",
+          "Women at GP",
+          "Men at GP"
         ]
       },
       "x": [
@@ -253,8 +259,7 @@
           "tot_events": 31093,
           "tot_pas": 22507.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.38144039809,
-          "borhf": null
+          "prove_pr_pas": 1.38144039809
         },
         {
           "bohf": "UNN",
@@ -271,8 +276,7 @@
           "tot_events": 78156,
           "tot_pas": 56855,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.37465482367,
-          "borhf": null
+          "prove_pr_pas": 1.37465482367
         },
         {
           "bohf": "Nordland",
@@ -289,8 +293,7 @@
           "tot_events": 62195.3333333,
           "tot_pas": 44033,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.41247094982,
-          "borhf": null
+          "prove_pr_pas": 1.41247094982
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +310,7 @@
           "tot_events": 42254,
           "tot_pas": 28481,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.48358554826,
-          "borhf": null
+          "prove_pr_pas": 1.48358554826
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +327,7 @@
           "tot_events": 64787,
           "tot_pas": 45819.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.41395616147,
-          "borhf": null
+          "prove_pr_pas": 1.41395616147
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +344,7 @@
           "tot_events": 151966,
           "tot_pas": 108118,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.40555689154,
-          "borhf": null
+          "prove_pr_pas": 1.40555689154
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +361,7 @@
           "tot_events": 120969.333333,
           "tot_pas": 83608,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.44686313909,
-          "borhf": null
+          "prove_pr_pas": 1.44686313909
         },
         {
           "bohf": "Førde",
@@ -379,8 +378,7 @@
           "tot_events": 47110,
           "tot_pas": 32672.3333333,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.44189273289,
-          "borhf": null
+          "prove_pr_pas": 1.44189273289
         },
         {
           "bohf": "Bergen",
@@ -397,8 +395,7 @@
           "tot_events": 217608,
           "tot_pas": 149886,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.45182338577,
-          "borhf": null
+          "prove_pr_pas": 1.45182338577
         },
         {
           "bohf": "Fonna",
@@ -415,8 +412,7 @@
           "tot_events": 86279.6666667,
           "tot_pas": 58393.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.47755178929,
-          "borhf": null
+          "prove_pr_pas": 1.47755178929
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +429,7 @@
           "tot_events": 149843,
           "tot_pas": 106034.666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.41315104494,
-          "borhf": null
+          "prove_pr_pas": 1.41315104494
         },
         {
           "bohf": "Østfold",
@@ -451,8 +446,7 @@
           "tot_events": 205625.666667,
           "tot_pas": 132201.333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.55539782756,
-          "borhf": null
+          "prove_pr_pas": 1.55539782756
         },
         {
           "bohf": "Akershus",
@@ -469,8 +463,7 @@
           "tot_events": 321168,
           "tot_pas": 214883.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.49461336444,
-          "borhf": null
+          "prove_pr_pas": 1.49461336444
         },
         {
           "bohf": "OUS",
@@ -487,8 +480,7 @@
           "tot_events": 142448,
           "tot_pas": 98367,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.44812792908,
-          "borhf": null
+          "prove_pr_pas": 1.44812792908
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +497,7 @@
           "tot_events": 66464.6666667,
           "tot_pas": 48211,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.37862037018,
-          "borhf": null
+          "prove_pr_pas": 1.37862037018
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +514,7 @@
           "tot_events": 66750.3333333,
           "tot_pas": 47653.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.40073866299,
-          "borhf": null
+          "prove_pr_pas": 1.40073866299
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +531,7 @@
           "tot_events": 186012,
           "tot_pas": 123210.333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.50971103614,
-          "borhf": null
+          "prove_pr_pas": 1.50971103614
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +548,7 @@
           "tot_events": 262828.666667,
           "tot_pas": 175267,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.49959014912,
-          "borhf": null
+          "prove_pr_pas": 1.49959014912
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +565,7 @@
           "tot_events": 140520,
           "tot_pas": 93256,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.50681993652,
-          "borhf": null
+          "prove_pr_pas": 1.50681993652
         },
         {
           "bohf": "Telemark",
@@ -595,8 +582,7 @@
           "tot_events": 86833,
           "tot_pas": 58512,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.48402037189,
-          "borhf": null
+          "prove_pr_pas": 1.48402037189
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +599,7 @@
           "tot_events": 171195.666667,
           "tot_pas": 113099.333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.51367529428,
-          "borhf": null
+          "prove_pr_pas": 1.51367529428
         },
         {
           "bohf": "Norge",
@@ -631,8 +616,7 @@
           "tot_events": 2702149.33333,
           "tot_pas": 1841104,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.467678813,
-          "borhf": null
+          "prove_pr_pas": 1.467678813
         }
       ]
     },
@@ -651,9 +635,7 @@
           "tot_events": 213698.333333,
           "tot_pas": 151816.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.40760786036,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40760786036
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +647,7 @@
           "tot_events": 337722.333333,
           "tot_pas": 237436,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.42237206377,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.42237206377
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +659,7 @@
           "tot_events": 500840.666667,
           "tot_pas": 346849.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.44397183023,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44397183023
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +671,7 @@
           "tot_events": 1649888,
           "tot_pas": 1101578.66667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.49774868552,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.49774868552
         },
         {
           "borhf": "Norge",
@@ -707,9 +683,7 @@
           "tot_events": 2702149.33333,
           "tot_pas": 1836535.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.47132962478,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.47132962478
         }
       ]
     },
@@ -720,675 +694,675 @@
       "data": [
         {
           "alder": 0,
-          "kvinner": 0.00231696358951,
-          "menn": 0.00303977032846,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00357473347953,
+          "menn_s": 0.00448631130889,
+          "kvinner_l": 0.000380290795695,
+          "menn_l": 0.000737641482055
         },
         {
           "alder": 1,
-          "kvinner": 0.0109472824938,
-          "menn": 0.0132805780148,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0143832577401,
+          "menn_s": 0.0167766324638,
+          "kvinner_l": 0.00412887004536,
+          "menn_l": 0.00588180046491
         },
         {
           "alder": 2,
-          "kvinner": 0.0172266818214,
-          "menn": 0.0197284003422,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.022060366644,
+          "menn_s": 0.0248873807992,
+          "kvinner_l": 0.00787605703352,
+          "menn_l": 0.00965307435792
         },
         {
           "alder": 3,
-          "kvinner": 0.0222497425765,
-          "menn": 0.0253579482876,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0299511076236,
+          "menn_s": 0.033740864695,
+          "kvinner_l": 0.00865576145349,
+          "menn_l": 0.0102907360608
         },
         {
           "alder": 4,
-          "kvinner": 0.0273314639322,
-          "menn": 0.0299817373404,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0362272844817,
+          "menn_s": 0.0384390545206,
+          "kvinner_l": 0.010861132661,
+          "menn_l": 0.012805664935
         },
         {
           "alder": 5,
-          "kvinner": 0.0310092578947,
-          "menn": 0.0334892399079,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0418001647748,
+          "menn_s": 0.0432275416891,
+          "kvinner_l": 0.0111680703039,
+          "menn_l": 0.0135449166218
         },
         {
           "alder": 6,
-          "kvinner": 0.0357895294757,
-          "menn": 0.0373647118047,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0486910759266,
+          "menn_s": 0.0489616444162,
+          "kvinner_l": 0.0120546959338,
+          "menn_l": 0.0139542275906
         },
         {
           "alder": 7,
-          "kvinner": 0.0402123640154,
-          "menn": 0.041607269031,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0554733645536,
+          "menn_s": 0.0569114299328,
+          "kvinner_l": 0.0131925827874,
+          "menn_l": 0.0141669754884
         },
         {
           "alder": 8,
-          "kvinner": 0.0447215061123,
-          "menn": 0.04794770669,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0640699662444,
+          "menn_s": 0.0673144230267,
+          "kvinner_l": 0.0125487703301,
+          "menn_l": 0.0149924254297
         },
         {
           "alder": 9,
-          "kvinner": 0.0498393909502,
-          "menn": 0.0534172801936,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0702733632752,
+          "menn_s": 0.074569789675,
+          "kvinner_l": 0.0148233719122,
+          "menn_l": 0.0170953350192
         },
         {
           "alder": 10,
-          "kvinner": 0.0565006994064,
-          "menn": 0.0579588960097,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0784444303503,
+          "menn_s": 0.0801468523051,
+          "kvinner_l": 0.0163421492146,
+          "menn_l": 0.0171929542992
         },
         {
           "alder": 11,
-          "kvinner": 0.0629047759638,
-          "menn": 0.0599483789439,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0869660073138,
+          "menn_s": 0.0819618914585,
+          "kvinner_l": 0.0170690658245,
+          "menn_l": 0.0169688265442
         },
         {
           "alder": 12,
-          "kvinner": 0.0740072773295,
-          "menn": 0.0627388535032,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.100093478105,
+          "menn_s": 0.0834541615173,
+          "kvinner_l": 0.0200412947231,
+          "menn_l": 0.0181485554139
         },
         {
           "alder": 13,
-          "kvinner": 0.0948167361985,
-          "menn": 0.0704517022336,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.130238188854,
+          "menn_s": 0.0951514440009,
+          "kvinner_l": 0.0233222275107,
+          "menn_l": 0.0183435078657
         },
         {
           "alder": 14,
-          "kvinner": 0.124531050576,
-          "menn": 0.0832249275931,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.168733271997,
+          "menn_s": 0.111597612082,
+          "kvinner_l": 0.0332469053195,
+          "menn_l": 0.0224559183996
         },
         {
           "alder": 15,
-          "kvinner": 0.140645178037,
-          "menn": 0.0900953288257,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.189532805179,
+          "menn_s": 0.121406232716,
+          "kvinner_l": 0.0397068000804,
+          "menn_l": 0.025049525859
         },
         {
           "alder": 16,
-          "kvinner": 0.152764748801,
-          "menn": 0.0877876325746,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.205487163691,
+          "menn_s": 0.118308237647,
+          "kvinner_l": 0.0435914049306,
+          "menn_l": 0.0246311388493
         },
         {
           "alder": 17,
-          "kvinner": 0.164608016133,
-          "menn": 0.0911497823216,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.224319376492,
+          "menn_s": 0.124921077822,
+          "kvinner_l": 0.0483261425803,
+          "menn_l": 0.0268844579319
         },
         {
           "alder": 18,
-          "kvinner": 0.166942995231,
-          "menn": 0.0890148207478,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.229719134311,
+          "menn_s": 0.123928564122,
+          "kvinner_l": 0.0503839750819,
+          "menn_l": 0.0272589652845
         },
         {
           "alder": 19,
-          "kvinner": 0.164614709195,
-          "menn": 0.0899353009163,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.224744108034,
+          "menn_s": 0.124912970471,
+          "kvinner_l": 0.0534255117839,
+          "menn_l": 0.0296514723348
         },
         {
           "alder": 20,
-          "kvinner": 0.173533013092,
-          "menn": 0.0895688228448,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.235481920682,
+          "menn_s": 0.124031784523,
+          "kvinner_l": 0.0576480446335,
+          "menn_l": 0.0294397627183
         },
         {
           "alder": 21,
-          "kvinner": 0.183018157347,
-          "menn": 0.0946226924447,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.246553646414,
+          "menn_s": 0.127546759376,
+          "kvinner_l": 0.0623313292557,
+          "menn_l": 0.0324353720357
         },
         {
           "alder": 22,
-          "kvinner": 0.190080168286,
-          "menn": 0.0986773903236,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.254204205747,
+          "menn_s": 0.13161093934,
+          "kvinner_l": 0.0651202449072,
+          "menn_l": 0.0342213330525
         },
         {
           "alder": 23,
-          "kvinner": 0.200958063601,
-          "menn": 0.10440784243,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.268293674179,
+          "menn_s": 0.138624368705,
+          "kvinner_l": 0.0701367580419,
+          "menn_l": 0.0368212096232
         },
         {
           "alder": 24,
-          "kvinner": 0.211087256102,
-          "menn": 0.110068268857,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.278509097753,
+          "menn_s": 0.144800461189,
+          "kvinner_l": 0.0750007428758,
+          "menn_l": 0.039591624205
         },
         {
           "alder": 25,
-          "kvinner": 0.22501070763,
-          "menn": 0.115144639818,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.294403140197,
+          "menn_s": 0.150884778896,
+          "kvinner_l": 0.0814536946622,
+          "menn_l": 0.0408960430217
         },
         {
           "alder": 26,
-          "kvinner": 0.238494815084,
-          "menn": 0.11947325474,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.307789170714,
+          "menn_s": 0.155312497201,
+          "kvinner_l": 0.0904744321678,
+          "menn_l": 0.044046115396
         },
         {
           "alder": 27,
-          "kvinner": 0.247481640705,
-          "menn": 0.1234269298,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.322886270108,
+          "menn_s": 0.161868713793,
+          "kvinner_l": 0.0959970071081,
+          "menn_l": 0.0457937946476
         },
         {
           "alder": 28,
-          "kvinner": 0.256665420034,
-          "menn": 0.126462360783,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.331451131616,
+          "menn_s": 0.164930980255,
+          "kvinner_l": 0.103328283524,
+          "menn_l": 0.0475624672375
         },
         {
           "alder": 29,
-          "kvinner": 0.26717516421,
-          "menn": 0.130733649933,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.340962393854,
+          "menn_s": 0.169872837119,
+          "kvinner_l": 0.107885159725,
+          "menn_l": 0.0475619983228
         },
         {
           "alder": 30,
-          "kvinner": 0.280061914547,
-          "menn": 0.136975128282,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.348578752392,
+          "menn_s": 0.172137891661,
+          "kvinner_l": 0.112040662254,
+          "menn_l": 0.050634718071
         },
         {
           "alder": 31,
-          "kvinner": 0.292342788275,
-          "menn": 0.141892697698,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.355099173482,
+          "menn_s": 0.174706692831,
+          "kvinner_l": 0.116146154046,
+          "menn_l": 0.0538015114191
         },
         {
           "alder": 32,
-          "kvinner": 0.297995774817,
-          "menn": 0.14663520776,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.353537631517,
+          "menn_s": 0.178285447091,
+          "kvinner_l": 0.118736392891,
+          "menn_l": 0.0552340873225
         },
         {
           "alder": 33,
-          "kvinner": 0.297832490413,
-          "menn": 0.148123971767,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.353480903773,
+          "menn_s": 0.181633347512,
+          "kvinner_l": 0.119306201311,
+          "menn_l": 0.055806039983
         },
         {
           "alder": 34,
-          "kvinner": 0.295648384486,
-          "menn": 0.151745605796,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.352071032506,
+          "menn_s": 0.18552854915,
+          "kvinner_l": 0.117395954095,
+          "menn_l": 0.058080525232
         },
         {
           "alder": 35,
-          "kvinner": 0.290691232659,
-          "menn": 0.153362837576,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.349835984232,
+          "menn_s": 0.190398905138,
+          "kvinner_l": 0.117843261571,
+          "menn_l": 0.0594980129313
         },
         {
           "alder": 36,
-          "kvinner": 0.282991455948,
-          "menn": 0.156288428682,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.343379055043,
+          "menn_s": 0.193103814309,
+          "kvinner_l": 0.114329140363,
+          "menn_l": 0.0609740994976
         },
         {
           "alder": 37,
-          "kvinner": 0.274969880914,
-          "menn": 0.161008612775,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.337546559776,
+          "menn_s": 0.19789748449,
+          "kvinner_l": 0.111251867118,
+          "menn_l": 0.0654711887437
         },
         {
           "alder": 38,
-          "kvinner": 0.27356039244,
-          "menn": 0.163420987688,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.337698126117,
+          "menn_s": 0.200276739505,
+          "kvinner_l": 0.108489490288,
+          "menn_l": 0.0674687320299
         },
         {
           "alder": 39,
-          "kvinner": 0.27056070666,
-          "menn": 0.169303064399,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.33428363692,
+          "menn_s": 0.207779972098,
+          "kvinner_l": 0.108191106689,
+          "menn_l": 0.0702987697715
         },
         {
           "alder": 40,
-          "kvinner": 0.27487966697,
-          "menn": 0.18145773767,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.335901902975,
+          "menn_s": 0.219843209215,
+          "kvinner_l": 0.109076463606,
+          "menn_l": 0.0753340661138
         },
         {
           "alder": 41,
-          "kvinner": 0.272323337927,
-          "menn": 0.184103249473,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.334943017191,
+          "menn_s": 0.223279238948,
+          "kvinner_l": 0.10782306355,
+          "menn_l": 0.078747236416
         },
         {
           "alder": 42,
-          "kvinner": 0.269387900314,
-          "menn": 0.188516274403,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.333867957541,
+          "menn_s": 0.228337559255,
+          "kvinner_l": 0.107751078969,
+          "menn_l": 0.0806416051152
         },
         {
           "alder": 43,
-          "kvinner": 0.268885444389,
-          "menn": 0.191002691977,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.340907970135,
+          "menn_s": 0.234569403747,
+          "kvinner_l": 0.112485329073,
+          "menn_l": 0.0875890541768
         },
         {
           "alder": 44,
-          "kvinner": 0.26734285071,
-          "menn": 0.197548796597,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.345009658725,
+          "menn_s": 0.244792058359,
+          "kvinner_l": 0.113764921492,
+          "menn_l": 0.0940155674212
         },
         {
           "alder": 45,
-          "kvinner": 0.269436067976,
-          "menn": 0.199814936645,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.35185766409,
+          "menn_s": 0.250399977545,
+          "kvinner_l": 0.116991643454,
+          "menn_l": 0.0991289377906
         },
         {
           "alder": 46,
-          "kvinner": 0.272425780819,
-          "menn": 0.206455778599,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.350464844085,
+          "menn_s": 0.256062949149,
+          "kvinner_l": 0.119317911485,
+          "menn_l": 0.101701082507
         },
         {
           "alder": 47,
-          "kvinner": 0.283266975729,
-          "menn": 0.22011237529,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.358607072673,
+          "menn_s": 0.268627887311,
+          "kvinner_l": 0.125108269458,
+          "menn_l": 0.109012417108
         },
         {
           "alder": 48,
-          "kvinner": 0.295165780267,
-          "menn": 0.230772398316,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.367754696515,
+          "menn_s": 0.274775596743,
+          "kvinner_l": 0.12901402802,
+          "menn_l": 0.114804097912
         },
         {
           "alder": 49,
-          "kvinner": 0.306884543551,
-          "menn": 0.246607714981,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.378734360179,
+          "menn_s": 0.290160789408,
+          "kvinner_l": 0.136347621844,
+          "menn_l": 0.123702027719
         },
         {
           "alder": 50,
-          "kvinner": 0.321124292043,
-          "menn": 0.264893204886,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.386259364135,
+          "menn_s": 0.306089578836,
+          "kvinner_l": 0.145695186207,
+          "menn_l": 0.133254514924
         },
         {
           "alder": 51,
-          "kvinner": 0.333988877599,
-          "menn": 0.280049282851,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.394319482191,
+          "menn_s": 0.317171371054,
+          "kvinner_l": 0.152258260621,
+          "menn_l": 0.144301195014
         },
         {
           "alder": 52,
-          "kvinner": 0.343185405101,
-          "menn": 0.290412208458,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.398248727325,
+          "menn_s": 0.325395326477,
+          "kvinner_l": 0.159129203413,
+          "menn_l": 0.150172552925
         },
         {
           "alder": 53,
-          "kvinner": 0.352885020357,
-          "menn": 0.303876555309,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.403160022378,
+          "menn_s": 0.335835692825,
+          "kvinner_l": 0.163875403801,
+          "menn_l": 0.158150851582
         },
         {
           "alder": 54,
-          "kvinner": 0.362697364644,
-          "menn": 0.320486516572,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.409623700432,
+          "menn_s": 0.34724829389,
+          "kvinner_l": 0.171579722146,
+          "menn_l": 0.167944422028
         },
         {
           "alder": 55,
-          "kvinner": 0.369786921381,
-          "menn": 0.336865258363,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.415796393689,
+          "menn_s": 0.362106992651,
+          "kvinner_l": 0.17501878287,
+          "menn_l": 0.17671378439
         },
         {
           "alder": 56,
-          "kvinner": 0.377449152644,
-          "menn": 0.351961144537,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.418276907191,
+          "menn_s": 0.368770493288,
+          "kvinner_l": 0.181803405647,
+          "menn_l": 0.186527417982
         },
         {
           "alder": 57,
-          "kvinner": 0.384468648083,
-          "menn": 0.369571374622,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.424774519203,
+          "menn_s": 0.386594511596,
+          "kvinner_l": 0.186420284468,
+          "menn_l": 0.199809001283
         },
         {
           "alder": 58,
-          "kvinner": 0.389258035748,
-          "menn": 0.378789983991,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.42929028622,
+          "menn_s": 0.397381560613,
+          "kvinner_l": 0.194476872912,
+          "menn_l": 0.209359033906
         },
         {
           "alder": 59,
-          "kvinner": 0.394368171248,
-          "menn": 0.385927950616,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.43883366605,
+          "menn_s": 0.408390333791,
+          "kvinner_l": 0.201450159807,
+          "menn_l": 0.220844641623
         },
         {
           "alder": 60,
-          "kvinner": 0.3980856618,
-          "menn": 0.3997872407,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.445672756509,
+          "menn_s": 0.420884428062,
+          "kvinner_l": 0.207682298554,
+          "menn_l": 0.231439977945
         },
         {
           "alder": 61,
-          "kvinner": 0.402183927436,
-          "menn": 0.409850935617,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.448395072299,
+          "menn_s": 0.430697944417,
+          "kvinner_l": 0.215057100962,
+          "menn_l": 0.239081984886
         },
         {
           "alder": 62,
-          "kvinner": 0.405774298863,
-          "menn": 0.419511502964,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.447913069751,
+          "menn_s": 0.43627430351,
+          "kvinner_l": 0.219990935773,
+          "menn_l": 0.248053615016
         },
         {
           "alder": 63,
-          "kvinner": 0.411376708002,
-          "menn": 0.432267522485,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.45234688193,
+          "menn_s": 0.44735909252,
+          "kvinner_l": 0.22346991163,
+          "menn_l": 0.255808707422
         },
         {
           "alder": 64,
-          "kvinner": 0.425768396587,
-          "menn": 0.449516289321,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.461288903552,
+          "menn_s": 0.461845806925,
+          "kvinner_l": 0.231716705158,
+          "menn_l": 0.266012063096
         },
         {
           "alder": 65,
-          "kvinner": 0.438934260143,
-          "menn": 0.46448736178,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.47151944727,
+          "menn_s": 0.47448522829,
+          "kvinner_l": 0.242914798708,
+          "menn_l": 0.278581020591
         },
         {
           "alder": 66,
-          "kvinner": 0.452583735106,
-          "menn": 0.477432396842,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.47884159281,
+          "menn_s": 0.480695644204,
+          "kvinner_l": 0.246604101179,
+          "menn_l": 0.287743738973
         },
         {
           "alder": 67,
-          "kvinner": 0.466077293707,
-          "menn": 0.48901780502,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.488161244203,
+          "menn_s": 0.491602006056,
+          "kvinner_l": 0.260685101882,
+          "menn_l": 0.301062168812
         },
         {
           "alder": 68,
-          "kvinner": 0.473464129274,
-          "menn": 0.496533408716,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.498408702261,
+          "menn_s": 0.505599961128,
+          "kvinner_l": 0.265331084933,
+          "menn_l": 0.3052039552
         },
         {
           "alder": 69,
-          "kvinner": 0.483355376718,
-          "menn": 0.501780057324,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.517611176702,
+          "menn_s": 0.518751175475,
+          "kvinner_l": 0.277917158599,
+          "menn_l": 0.315378346185
         },
         {
           "alder": 70,
-          "kvinner": 0.481785542603,
-          "menn": 0.507515068284,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.527399505725,
+          "menn_s": 0.532121740692,
+          "kvinner_l": 0.281383971352,
+          "menn_l": 0.321037848376
         },
         {
           "alder": 71,
-          "kvinner": 0.479338597196,
-          "menn": 0.505460254075,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.536259640103,
+          "menn_s": 0.537800146797,
+          "kvinner_l": 0.292429305913,
+          "menn_l": 0.331537695292
         },
         {
           "alder": 72,
-          "kvinner": 0.493441953345,
-          "menn": 0.524575905975,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.54124611552,
+          "menn_s": 0.54555631651,
+          "kvinner_l": 0.296453244985,
+          "menn_l": 0.336186913918
         },
         {
           "alder": 73,
-          "kvinner": 0.523135216725,
-          "menn": 0.549596285665,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.556184026575,
+          "menn_s": 0.552934460832,
+          "kvinner_l": 0.30619364603,
+          "menn_l": 0.34434281618
         },
         {
           "alder": 74,
-          "kvinner": 0.559903642889,
-          "menn": 0.596828706721,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.558952242024,
+          "menn_s": 0.562674944615,
+          "kvinner_l": 0.307845500095,
+          "menn_l": 0.348589167031
         },
         {
           "alder": 75,
-          "kvinner": 0.598138262673,
-          "menn": 0.641044903859,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.569632823729,
+          "menn_s": 0.581885960013,
+          "kvinner_l": 0.316163595975,
+          "menn_l": 0.359292974422
         },
         {
           "alder": 76,
-          "kvinner": 0.64827857952,
-          "menn": 0.69747735252,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.586505884143,
+          "menn_s": 0.594867423393,
+          "kvinner_l": 0.323565610609,
+          "menn_l": 0.367729971436
         },
         {
           "alder": 77,
-          "kvinner": 0.666046901533,
-          "menn": 0.719970168643,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.618067564229,
+          "menn_s": 0.629797260646,
+          "kvinner_l": 0.338778409091,
+          "menn_l": 0.384814890155
         },
         {
           "alder": 78,
-          "kvinner": 0.656202692077,
-          "menn": 0.712581081081,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.611246568569,
+          "menn_s": 0.616515471368,
+          "kvinner_l": 0.342171222016,
+          "menn_l": 0.386337270117
         },
         {
           "alder": 79,
-          "kvinner": 0.638867838739,
-          "menn": 0.711994964633,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.636535206335,
+          "menn_s": 0.666421256944,
+          "kvinner_l": 0.347627293422,
+          "menn_l": 0.393525645316
         },
         {
           "alder": 80,
-          "kvinner": 0.617089510661,
-          "menn": 0.673621707689,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.614930239451,
+          "menn_s": 0.628101456554,
+          "kvinner_l": 0.346495035251,
+          "menn_l": 0.391838272225
         },
         {
           "alder": 81,
-          "kvinner": 0.609941730811,
-          "menn": 0.653132732494,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.627501599196,
+          "menn_s": 0.634806258061,
+          "kvinner_l": 0.34101708855,
+          "menn_l": 0.379100543935
         },
         {
           "alder": 82,
-          "kvinner": 0.617534212529,
-          "menn": 0.666868772611,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.624570095481,
+          "menn_s": 0.63359611886,
+          "kvinner_l": 0.331561605618,
+          "menn_l": 0.366889023651
         },
         {
           "alder": 83,
-          "kvinner": 0.632580862534,
-          "menn": 0.675130016124,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.650403521643,
+          "menn_s": 0.64378516624,
+          "kvinner_l": 0.333508018027,
+          "menn_l": 0.369957374254
         },
         {
           "alder": 84,
-          "kvinner": 0.630552804373,
-          "menn": 0.680070646053,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.656187811842,
+          "menn_s": 0.660087037613,
+          "kvinner_l": 0.335332968015,
+          "menn_l": 0.372280074604
         },
         {
           "alder": 85,
-          "kvinner": 0.601451401522,
-          "menn": 0.644245912436,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.656368060447,
+          "menn_s": 0.654426377597,
+          "kvinner_l": 0.32807197285,
+          "menn_l": 0.361788617886
         },
         {
           "alder": 86,
-          "kvinner": 0.577649615513,
-          "menn": 0.63342379014,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.655637298039,
+          "menn_s": 0.675823310048,
+          "kvinner_l": 0.317434615791,
+          "menn_l": 0.354010189611
         },
         {
           "alder": 87,
-          "kvinner": 0.55810517361,
-          "menn": 0.611327060704,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.660376625898,
+          "menn_s": 0.673899792759,
+          "kvinner_l": 0.307590759076,
+          "menn_l": 0.351822503962
         },
         {
           "alder": 88,
-          "kvinner": 0.556784263835,
-          "menn": 0.609145779194,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.661900155613,
+          "menn_s": 0.658565133572,
+          "kvinner_l": 0.295243302351,
+          "menn_l": 0.342054530432
         },
         {
           "alder": 89,
-          "kvinner": 0.552136613353,
-          "menn": 0.606023264984,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.658607216732,
+          "menn_s": 0.658114846389,
+          "kvinner_l": 0.279200183866,
+          "menn_l": 0.330706128358
         },
         {
           "alder": 90,
-          "kvinner": 0.557428447259,
-          "menn": 0.602376213739,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.653090389425,
+          "menn_s": 0.64047822374,
+          "kvinner_l": 0.263410401674,
+          "menn_l": 0.30723977607
         },
         {
           "alder": 91,
-          "kvinner": 0.552334134702,
-          "menn": 0.597332743884,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.66178476134,
+          "menn_s": 0.662208955224,
+          "kvinner_l": 0.250933886748,
+          "menn_l": 0.305791044776
         },
         {
           "alder": 92,
-          "kvinner": 0.548180146273,
-          "menn": 0.585900196611,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.671102255746,
+          "menn_s": 0.656474820144,
+          "kvinner_l": 0.240944993951,
+          "menn_l": 0.281474820144
         },
         {
           "alder": 93,
-          "kvinner": 0.520817290415,
-          "menn": 0.574620522162,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.667747305704,
+          "menn_s": 0.665081252477,
+          "kvinner_l": 0.221151318672,
+          "menn_l": 0.272691240587
         },
         {
           "alder": 94,
-          "kvinner": 0.509802669391,
-          "menn": 0.576135059826,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.663849154746,
+          "menn_s": 0.664637374272,
+          "kvinner_l": 0.201235370611,
+          "menn_l": 0.265749073584
         },
         {
           "alder": 95,
-          "kvinner": 0.497647631408,
-          "menn": 0.548051372896,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.661344071091,
+          "menn_s": 0.631190727081,
+          "kvinner_l": 0.190502638156,
+          "menn_l": 0.238145416228
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/hdl_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/hdl_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 21283,
           "tot_pas": 15211.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.39912347979,
-          "borhf": null
+          "prove_pr_pas": 1.39912347979
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 58214,
           "tot_pas": 41635.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.39817624312,
-          "borhf": null
+          "prove_pr_pas": 1.39817624312
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 42372.3333333,
           "tot_pas": 30109.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.40726676925,
-          "borhf": null
+          "prove_pr_pas": 1.40726676925
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 27900.6666667,
           "tot_pas": 19561.6666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.42629291983,
-          "borhf": null
+          "prove_pr_pas": 1.42629291983
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 39667.3333333,
           "tot_pas": 29417.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.34841875064,
-          "borhf": null
+          "prove_pr_pas": 1.34841875064
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 94224.6666667,
           "tot_pas": 69868,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.34860975936,
-          "borhf": null
+          "prove_pr_pas": 1.34860975936
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 87985,
           "tot_pas": 64197.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.37053267772,
-          "borhf": null
+          "prove_pr_pas": 1.37053267772
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 33744,
           "tot_pas": 23849,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.41490209233,
-          "borhf": null
+          "prove_pr_pas": 1.41490209233
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 153351.666667,
           "tot_pas": 104225,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.47135204286,
-          "borhf": null
+          "prove_pr_pas": 1.47135204286
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 66208.6666667,
           "tot_pas": 44989,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.47166344366,
-          "borhf": null
+          "prove_pr_pas": 1.47166344366
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 105686,
           "tot_pas": 77796,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.35850172245,
-          "borhf": null
+          "prove_pr_pas": 1.35850172245
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 152494.333333,
           "tot_pas": 103786.666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.46930562693,
-          "borhf": null
+          "prove_pr_pas": 1.46930562693
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 246330.666667,
           "tot_pas": 171272.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.43823688543,
-          "borhf": null
+          "prove_pr_pas": 1.43823688543
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 105096.333333,
           "tot_pas": 73608.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.42777765199,
-          "borhf": null
+          "prove_pr_pas": 1.42777765199
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 48210.3333333,
           "tot_pas": 35321,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.36491983051,
-          "borhf": null
+          "prove_pr_pas": 1.36491983051
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 51598.6666667,
           "tot_pas": 36965.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.39585381029,
-          "borhf": null
+          "prove_pr_pas": 1.39585381029
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 135563,
           "tot_pas": 95820.6666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.41475742881,
-          "borhf": null
+          "prove_pr_pas": 1.41475742881
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 211457,
           "tot_pas": 144584.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.462513314,
-          "borhf": null
+          "prove_pr_pas": 1.462513314
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 112646.333333,
           "tot_pas": 77328,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.45673408511,
-          "borhf": null
+          "prove_pr_pas": 1.45673408511
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 63801,
           "tot_pas": 44635.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.42937262428,
-          "borhf": null
+          "prove_pr_pas": 1.42937262428
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 116588.666667,
           "tot_pas": 79311,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.47001887086,
-          "borhf": null
+          "prove_pr_pas": 1.47001887086
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 1974457,
           "tot_pas": 1383520.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.42712504957,
-          "borhf": null
+          "prove_pr_pas": 1.42712504957
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 149770,
           "tot_pas": 106472.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.4066520985,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.4066520985
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 221877,
           "tot_pas": 163423.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.35768250148,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.35768250148
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 358990.333333,
           "tot_pas": 250751.666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.4316568185,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.4316568185
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 1243819.66667,
           "tot_pas": 860269.666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.44584856919,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44584856919
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 1974457,
           "tot_pas": 1380050.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.43071341342,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.43071341342
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 0.000653502550888,
-          "menn": 0.000802161614456,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000802161614456
         },
         {
           "alder": 1,
           "kvinner": 0.00183669453292,
-          "menn": 0.00218819886461,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00218819886461
         },
         {
           "alder": 2,
           "kvinner": 0.00287703345883,
-          "menn": 0.00284030153978,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00284030153978
         },
         {
           "alder": 3,
           "kvinner": 0.00392396961011,
-          "menn": 0.00422195416164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00422195416164
         },
         {
           "alder": 4,
           "kvinner": 0.00526024929897,
-          "menn": 0.00557559644039,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00557559644039
         },
         {
           "alder": 5,
           "kvinner": 0.00694007154437,
-          "menn": 0.00720935693298,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00720935693298
         },
         {
           "alder": 6,
           "kvinner": 0.00924220540884,
-          "menn": 0.00909262522024,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00909262522024
         },
         {
           "alder": 7,
           "kvinner": 0.0109048270471,
-          "menn": 0.010710168462,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.010710168462
         },
         {
           "alder": 8,
           "kvinner": 0.0136384281264,
-          "menn": 0.0140836498198,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0140836498198
         },
         {
           "alder": 9,
           "kvinner": 0.0156182816096,
-          "menn": 0.016797359388,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.016797359388
         },
         {
           "alder": 10,
           "kvinner": 0.0177245976838,
-          "menn": 0.0190050708061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0190050708061
         },
         {
           "alder": 11,
           "kvinner": 0.0203463720138,
-          "menn": 0.0209643480904,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0209643480904
         },
         {
           "alder": 12,
           "kvinner": 0.0255592469546,
-          "menn": 0.0235007811561,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0235007811561
         },
         {
           "alder": 13,
           "kvinner": 0.0354644365365,
-          "menn": 0.028566917275,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.028566917275
         },
         {
           "alder": 14,
           "kvinner": 0.0477071435017,
-          "menn": 0.0362954690491,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0362954690491
         },
         {
           "alder": 15,
           "kvinner": 0.0584696652109,
-          "menn": 0.0439465267768,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0439465267768
         },
         {
           "alder": 16,
           "kvinner": 0.068343495935,
-          "menn": 0.0484339142839,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0484339142839
         },
         {
           "alder": 17,
           "kvinner": 0.076380136123,
-          "menn": 0.0536919728024,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0536919728024
         },
         {
           "alder": 18,
           "kvinner": 0.0802995871075,
-          "menn": 0.0558322443105,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0558322443105
         },
         {
           "alder": 19,
           "kvinner": 0.0824218824562,
-          "menn": 0.0571270270592,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0571270270592
         },
         {
           "alder": 20,
           "kvinner": 0.0900631063389,
-          "menn": 0.0600595332082,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0600595332082
         },
         {
           "alder": 21,
           "kvinner": 0.0946083606527,
-          "menn": 0.0641290737614,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0641290737614
         },
         {
           "alder": 22,
           "kvinner": 0.0988742195669,
-          "menn": 0.0689044326221,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0689044326221
         },
         {
           "alder": 23,
           "kvinner": 0.103589118618,
-          "menn": 0.0734959936394,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0734959936394
         },
         {
           "alder": 24,
           "kvinner": 0.107844354939,
-          "menn": 0.0786534939224,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0786534939224
         },
         {
           "alder": 25,
           "kvinner": 0.114629516015,
-          "menn": 0.0847822767136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0847822767136
         },
         {
           "alder": 26,
           "kvinner": 0.116959694291,
-          "menn": 0.0892814962743,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0892814962743
         },
         {
           "alder": 27,
           "kvinner": 0.119969497875,
-          "menn": 0.0946033724301,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0946033724301
         },
         {
           "alder": 28,
           "kvinner": 0.122397654162,
-          "menn": 0.0987386000853,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0987386000853
         },
         {
           "alder": 29,
           "kvinner": 0.125478722266,
-          "menn": 0.103016613757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103016613757
         },
         {
           "alder": 30,
           "kvinner": 0.131456326226,
-          "menn": 0.110146917621,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.110146917621
         },
         {
           "alder": 31,
           "kvinner": 0.137864244824,
-          "menn": 0.114862307305,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114862307305
         },
         {
           "alder": 32,
           "kvinner": 0.144017426141,
-          "menn": 0.118851749902,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118851749902
         },
         {
           "alder": 33,
           "kvinner": 0.147824153838,
-          "menn": 0.122554794884,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.122554794884
         },
         {
           "alder": 34,
           "kvinner": 0.150600193556,
-          "menn": 0.125318663625,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125318663625
         },
         {
           "alder": 35,
           "kvinner": 0.15479773606,
-          "menn": 0.127864280484,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127864280484
         },
         {
           "alder": 36,
           "kvinner": 0.15629504076,
-          "menn": 0.132428638278,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132428638278
         },
         {
           "alder": 37,
           "kvinner": 0.160471016172,
-          "menn": 0.138766230927,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.138766230927
         },
         {
           "alder": 38,
           "kvinner": 0.165977255249,
-          "menn": 0.141479064411,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141479064411
         },
         {
           "alder": 39,
           "kvinner": 0.173418350932,
-          "menn": 0.146882652724,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146882652724
         },
         {
           "alder": 40,
           "kvinner": 0.181132253983,
-          "menn": 0.158774124375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.158774124375
         },
         {
           "alder": 41,
           "kvinner": 0.186071377655,
-          "menn": 0.162853899535,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162853899535
         },
         {
           "alder": 42,
           "kvinner": 0.189956655539,
-          "menn": 0.167390658543,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167390658543
         },
         {
           "alder": 43,
           "kvinner": 0.19416254789,
-          "menn": 0.169416923376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.169416923376
         },
         {
           "alder": 44,
           "kvinner": 0.199316503778,
-          "menn": 0.176078841927,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.176078841927
         },
         {
           "alder": 45,
           "kvinner": 0.204543020601,
-          "menn": 0.178891010521,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.178891010521
         },
         {
           "alder": 46,
           "kvinner": 0.20917117316,
-          "menn": 0.187321518562,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.187321518562
         },
         {
           "alder": 47,
           "kvinner": 0.22133624216,
-          "menn": 0.198436292134,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.198436292134
         },
         {
           "alder": 48,
           "kvinner": 0.232568971307,
-          "menn": 0.208963444137,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.208963444137
         },
         {
           "alder": 49,
           "kvinner": 0.246753106952,
-          "menn": 0.224682814302,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.224682814302
         },
         {
           "alder": 50,
           "kvinner": 0.261436847828,
-          "menn": 0.242346134972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.242346134972
         },
         {
           "alder": 51,
           "kvinner": 0.272679100156,
-          "menn": 0.252891728487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.252891728487
         },
         {
           "alder": 52,
           "kvinner": 0.282621651749,
-          "menn": 0.261888410667,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.261888410667
         },
         {
           "alder": 53,
           "kvinner": 0.291938789836,
-          "menn": 0.273484106017,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.273484106017
         },
         {
           "alder": 54,
           "kvinner": 0.302457369237,
-          "menn": 0.288477698595,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.288477698595
         },
         {
           "alder": 55,
           "kvinner": 0.31158853784,
-          "menn": 0.302777901836,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.302777901836
         },
         {
           "alder": 56,
           "kvinner": 0.3184229201,
-          "menn": 0.313036788683,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.313036788683
         },
         {
           "alder": 57,
           "kvinner": 0.327333702541,
-          "menn": 0.327564435423,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.327564435423
         },
         {
           "alder": 58,
           "kvinner": 0.332345220002,
-          "menn": 0.335475881234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.335475881234
         },
         {
           "alder": 59,
           "kvinner": 0.336661039085,
-          "menn": 0.34055465127,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.34055465127
         },
         {
           "alder": 60,
           "kvinner": 0.343317541655,
-          "menn": 0.354669753762,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.354669753762
         },
         {
           "alder": 61,
           "kvinner": 0.348928798516,
-          "menn": 0.365112591183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.365112591183
         },
         {
           "alder": 62,
           "kvinner": 0.353734807064,
-          "menn": 0.371345462989,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.371345462989
         },
         {
           "alder": 63,
           "kvinner": 0.361361747399,
-          "menn": 0.382932498646,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.382932498646
         },
         {
           "alder": 64,
           "kvinner": 0.373431619629,
-          "menn": 0.396250650694,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.396250650694
         },
         {
           "alder": 65,
           "kvinner": 0.385427470482,
-          "menn": 0.410386670164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.410386670164
         },
         {
           "alder": 66,
           "kvinner": 0.398707247485,
-          "menn": 0.418509634206,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.418509634206
         },
         {
           "alder": 67,
           "kvinner": 0.406479244136,
-          "menn": 0.427838587274,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.427838587274
         },
         {
           "alder": 68,
           "kvinner": 0.414480803917,
-          "menn": 0.434372814783,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.434372814783
         },
         {
           "alder": 69,
           "kvinner": 0.419661204391,
-          "menn": 0.434032282396,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.434032282396
         },
         {
           "alder": 70,
           "kvinner": 0.417250030044,
-          "menn": 0.444686045624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.444686045624
         },
         {
           "alder": 71,
           "kvinner": 0.411971569196,
-          "menn": 0.4341987944,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.4341987944
         },
         {
           "alder": 72,
           "kvinner": 0.419019091707,
-          "menn": 0.446001958864,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.446001958864
         },
         {
           "alder": 73,
           "kvinner": 0.440670053763,
-          "menn": 0.465169982843,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.465169982843
         },
         {
           "alder": 74,
           "kvinner": 0.462079871524,
-          "menn": 0.500916634085,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.500916634085
         },
         {
           "alder": 75,
           "kvinner": 0.485578153262,
-          "menn": 0.52985982997,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.52985982997
         },
         {
           "alder": 76,
           "kvinner": 0.518406146875,
-          "menn": 0.568690130467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.568690130467
         },
         {
           "alder": 77,
           "kvinner": 0.521247554973,
-          "menn": 0.578896720957,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.578896720957
         },
         {
           "alder": 78,
           "kvinner": 0.50235292737,
-          "menn": 0.556756756757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.556756756757
         },
         {
           "alder": 79,
           "kvinner": 0.481370617359,
-          "menn": 0.560319506054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.560319506054
         },
         {
           "alder": 80,
           "kvinner": 0.448803489652,
-          "menn": 0.498291647316,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.498291647316
         },
         {
           "alder": 81,
           "kvinner": 0.433191856701,
-          "menn": 0.486824281612,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.486824281612
         },
         {
           "alder": 82,
           "kvinner": 0.422635413269,
-          "menn": 0.485155318418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.485155318418
         },
         {
           "alder": 83,
           "kvinner": 0.423888140162,
-          "menn": 0.477119433152,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.477119433152
         },
         {
           "alder": 84,
           "kvinner": 0.401397600968,
-          "menn": 0.464523395106,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.464523395106
         },
         {
           "alder": 85,
           "kvinner": 0.367447137296,
-          "menn": 0.433181570885,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.433181570885
         },
         {
           "alder": 86,
           "kvinner": 0.339727515881,
-          "menn": 0.407540220973,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.407540220973
         },
         {
           "alder": 87,
           "kvinner": 0.310819584052,
-          "menn": 0.380717114106,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.380717114106
         },
         {
           "alder": 88,
           "kvinner": 0.293046924695,
-          "menn": 0.358244613966,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.358244613966
         },
         {
           "alder": 89,
           "kvinner": 0.275364672133,
-          "menn": 0.348432570978,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.348432570978
         },
         {
           "alder": 90,
           "kvinner": 0.258738436705,
-          "menn": 0.324045594355,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.324045594355
         },
         {
           "alder": 91,
           "kvinner": 0.245756934228,
-          "menn": 0.306808134394,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.306808134394
         },
         {
           "alder": 92,
           "kvinner": 0.223258201103,
-          "menn": 0.280778953282,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.280778953282
         },
         {
           "alder": 93,
           "kvinner": 0.203398531752,
-          "menn": 0.262295081967,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.262295081967
         },
         {
           "alder": 94,
           "kvinner": 0.183408902229,
-          "menn": 0.256515325356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.256515325356
         },
         {
           "alder": 95,
           "kvinner": 0.169613887086,
-          "menn": 0.233170947741,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.233170947741
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/homocystein_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/homocystein_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 1296.66666667,
           "tot_pas": 1101.66666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.17700453858,
-          "borhf": null
+          "prove_pr_pas": 1.17700453858
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 4394,
           "tot_pas": 3765.33333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.16696175637,
-          "borhf": null
+          "prove_pr_pas": 1.16696175637
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 5343,
           "tot_pas": 4642,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.15101249461,
-          "borhf": null
+          "prove_pr_pas": 1.15101249461
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 2541.66666667,
           "tot_pas": 2175.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.16822429907,
-          "borhf": null
+          "prove_pr_pas": 1.16822429907
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 5719.33333333,
           "tot_pas": 4657.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.22802748354,
-          "borhf": null
+          "prove_pr_pas": 1.22802748354
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 12919.6666667,
           "tot_pas": 10949.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.17995007306,
-          "borhf": null
+          "prove_pr_pas": 1.17995007306
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 5598.66666667,
           "tot_pas": 4814.33333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.16291629163,
-          "borhf": null
+          "prove_pr_pas": 1.16291629163
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 7616.66666667,
           "tot_pas": 6156.66666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.23714131023,
-          "borhf": null
+          "prove_pr_pas": 1.23714131023
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 72240.3333333,
           "tot_pas": 56547,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.27752724872,
-          "borhf": null
+          "prove_pr_pas": 1.27752724872
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 9396.66666667,
           "tot_pas": 7751.33333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.21226455664,
-          "borhf": null
+          "prove_pr_pas": 1.21226455664
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 33062.6666667,
           "tot_pas": 27599.6666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.19793717315,
-          "borhf": null
+          "prove_pr_pas": 1.19793717315
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 17127.3333333,
           "tot_pas": 13791.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.24186102719,
-          "borhf": null
+          "prove_pr_pas": 1.24186102719
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 48504.6666667,
           "tot_pas": 38519.6666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.25921823484,
-          "borhf": null
+          "prove_pr_pas": 1.25921823484
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 13859.3333333,
           "tot_pas": 11334.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.22277446108,
-          "borhf": null
+          "prove_pr_pas": 1.22277446108
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 8045,
           "tot_pas": 6786.33333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.18547079916,
-          "borhf": null
+          "prove_pr_pas": 1.18547079916
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 8041,
           "tot_pas": 6502.33333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.23663300354,
-          "borhf": null
+          "prove_pr_pas": 1.23663300354
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 17652.6666667,
           "tot_pas": 14022,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.25892644891,
-          "borhf": null
+          "prove_pr_pas": 1.25892644891
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 22110.6666667,
           "tot_pas": 18273,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.21001842427,
-          "borhf": null
+          "prove_pr_pas": 1.21001842427
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 19261.3333333,
           "tot_pas": 15913.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.21036425714,
-          "borhf": null
+          "prove_pr_pas": 1.21036425714
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 4350,
           "tot_pas": 3815,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.14023591088,
-          "borhf": null
+          "prove_pr_pas": 1.14023591088
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 4307,
           "tot_pas": 3555.66666667,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.21130589669,
-          "borhf": null
+          "prove_pr_pas": 1.21130589669
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 323390.333333,
           "tot_pas": 262676,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.23113772607,
-          "borhf": null
+          "prove_pr_pas": 1.23113772607
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 13575.3333333,
           "tot_pas": 11683.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.16194008559,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.16194008559
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 24237.6666667,
           "tot_pas": 20416,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.18718978579,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.18718978579
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 122316.333333,
           "tot_pas": 98020.6666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.24786269562,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.24786269562
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 163261,
           "tot_pas": 132263,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.23436637608,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.23436637608
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 323390.333333,
           "tot_pas": 262290.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.23294796733,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.23294796733
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00740388685494,
-          "menn": 0.00864082861887,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00864082861887
         },
         {
           "alder": 1,
           "kvinner": 0.00666895038738,
-          "menn": 0.00809908825047,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00809908825047
         },
         {
           "alder": 2,
           "kvinner": 0.00574696313135,
-          "menn": 0.00712414456801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00712414456801
         },
         {
           "alder": 3,
           "kvinner": 0.00592074137979,
-          "menn": 0.00830623590497,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00830623590497
         },
         {
           "alder": 4,
           "kvinner": 0.00638598358475,
-          "menn": 0.00902807803254,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00902807803254
         },
         {
           "alder": 5,
           "kvinner": 0.00685298570452,
-          "menn": 0.00892919472245,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00892919472245
         },
         {
           "alder": 6,
           "kvinner": 0.00755939524838,
-          "menn": 0.00854517996476,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00854517996476
         },
         {
           "alder": 7,
           "kvinner": 0.00802553579571,
-          "menn": 0.00943957555999,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00943957555999
         },
         {
           "alder": 8,
           "kvinner": 0.00951235582736,
-          "menn": 0.0104197098062,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0104197098062
         },
         {
           "alder": 9,
           "kvinner": 0.0109264739358,
-          "menn": 0.0113340242376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0113340242376
         },
         {
           "alder": 10,
           "kvinner": 0.0125263065038,
-          "menn": 0.0129129362297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0129129362297
         },
         {
           "alder": 11,
           "kvinner": 0.0142405759047,
-          "menn": 0.0135430761619,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0135430761619
         },
         {
           "alder": 12,
           "kvinner": 0.018073089701,
-          "menn": 0.014217041221,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.014217041221
         },
         {
           "alder": 13,
           "kvinner": 0.0243734147697,
-          "menn": 0.0169069510403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0169069510403
         },
         {
           "alder": 14,
           "kvinner": 0.0334291644643,
-          "menn": 0.0191203180993,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0191203180993
         },
         {
           "alder": 15,
           "kvinner": 0.0395335405621,
-          "menn": 0.0205999344266,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0205999344266
         },
         {
           "alder": 16,
           "kvinner": 0.0416601521784,
-          "menn": 0.0199776716492,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0199776716492
         },
         {
           "alder": 17,
           "kvinner": 0.0443207745955,
-          "menn": 0.0205449298048,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0205449298048
         },
         {
           "alder": 18,
           "kvinner": 0.0422174567103,
-          "menn": 0.0185304514878,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185304514878
         },
         {
           "alder": 19,
           "kvinner": 0.0404092462158,
-          "menn": 0.0170445744516,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0170445744516
         },
         {
           "alder": 20,
           "kvinner": 0.0413048255942,
-          "menn": 0.0168131604648,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0168131604648
         },
         {
           "alder": 21,
           "kvinner": 0.0419823056929,
-          "menn": 0.0172944595697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0172944595697
         },
         {
           "alder": 22,
           "kvinner": 0.0430927469409,
-          "menn": 0.0175550517766,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0175550517766
         },
         {
           "alder": 23,
           "kvinner": 0.0440721322948,
-          "menn": 0.0181569049807,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0181569049807
         },
         {
           "alder": 24,
           "kvinner": 0.0450504799588,
-          "menn": 0.0192984403619,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0192984403619
         },
         {
           "alder": 25,
           "kvinner": 0.0465289916307,
-          "menn": 0.0195416466687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0195416466687
         },
         {
           "alder": 26,
           "kvinner": 0.0468711906881,
-          "menn": 0.0199542614185,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0199542614185
         },
         {
           "alder": 27,
           "kvinner": 0.0467146669908,
-          "menn": 0.0196927529191,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0196927529191
         },
         {
           "alder": 28,
           "kvinner": 0.0462934356656,
-          "menn": 0.0192485675364,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0192485675364
         },
         {
           "alder": 29,
           "kvinner": 0.0480808318535,
-          "menn": 0.020503506434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.020503506434
         },
         {
           "alder": 30,
           "kvinner": 0.0503696191722,
-          "menn": 0.0211239249615,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0211239249615
         },
         {
           "alder": 31,
           "kvinner": 0.0517206129213,
-          "menn": 0.0211400156593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0211400156593
         },
         {
           "alder": 32,
           "kvinner": 0.0524261961317,
-          "menn": 0.0219321011928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0219321011928
         },
         {
           "alder": 33,
           "kvinner": 0.0532651586728,
-          "menn": 0.021769357321,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.021769357321
         },
         {
           "alder": 34,
           "kvinner": 0.0544447148444,
-          "menn": 0.0220635985509,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0220635985509
         },
         {
           "alder": 35,
           "kvinner": 0.0536800443193,
-          "menn": 0.0219235904725,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0219235904725
         },
         {
           "alder": 36,
           "kvinner": 0.0535415729819,
-          "menn": 0.0221512444091,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0221512444091
         },
         {
           "alder": 37,
           "kvinner": 0.0518801260368,
-          "menn": 0.0233299086259,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0233299086259
         },
         {
           "alder": 38,
           "kvinner": 0.0522651534572,
-          "menn": 0.0231539115413,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0231539115413
         },
         {
           "alder": 39,
           "kvinner": 0.051934832841,
-          "menn": 0.0234573212434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0234573212434
         },
         {
           "alder": 40,
           "kvinner": 0.0528874013979,
-          "menn": 0.0248112491065,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0248112491065
         },
         {
           "alder": 41,
           "kvinner": 0.053871833864,
-          "menn": 0.0248617394271,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0248617394271
         },
         {
           "alder": 42,
           "kvinner": 0.0516279373136,
-          "menn": 0.0244662545051,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0244662545051
         },
         {
           "alder": 43,
           "kvinner": 0.0515310151201,
-          "menn": 0.0250992146088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0250992146088
         },
         {
           "alder": 44,
           "kvinner": 0.0520357680962,
-          "menn": 0.0246271397328,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0246271397328
         },
         {
           "alder": 45,
           "kvinner": 0.0498774060818,
-          "menn": 0.0240742820772,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0240742820772
         },
         {
           "alder": 46,
           "kvinner": 0.0494371482176,
-          "menn": 0.0247459264237,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0247459264237
         },
         {
           "alder": 47,
           "kvinner": 0.0506135805836,
-          "menn": 0.0263402283823,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0263402283823
         },
         {
           "alder": 48,
           "kvinner": 0.0526965695779,
-          "menn": 0.0272547586448,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0272547586448
         },
         {
           "alder": 49,
           "kvinner": 0.0536995473457,
-          "menn": 0.0284659746251,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0284659746251
         },
         {
           "alder": 50,
           "kvinner": 0.0535531718083,
-          "menn": 0.0292776156409,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0292776156409
         },
         {
           "alder": 51,
           "kvinner": 0.0550821069193,
-          "menn": 0.0308381723756,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0308381723756
         },
         {
           "alder": 52,
           "kvinner": 0.0547750173828,
-          "menn": 0.0310034442447,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0310034442447
         },
         {
           "alder": 53,
           "kvinner": 0.055257616173,
-          "menn": 0.0327041077212,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0327041077212
         },
         {
           "alder": 54,
           "kvinner": 0.0555549176092,
-          "menn": 0.0340823520424,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0340823520424
         },
         {
           "alder": 55,
           "kvinner": 0.0545422483468,
-          "menn": 0.035148050556,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.035148050556
         },
         {
           "alder": 56,
           "kvinner": 0.0548405720403,
-          "menn": 0.0365360767924,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0365360767924
         },
         {
           "alder": 57,
           "kvinner": 0.0551781428835,
-          "menn": 0.0374575151057,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0374575151057
         },
         {
           "alder": 58,
           "kvinner": 0.0540992049037,
-          "menn": 0.0383302624823,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0383302624823
         },
         {
           "alder": 59,
           "kvinner": 0.0534577772115,
-          "menn": 0.0388440158472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0388440158472
         },
         {
           "alder": 60,
           "kvinner": 0.052344580876,
-          "menn": 0.0397922468008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0397922468008
         },
         {
           "alder": 61,
           "kvinner": 0.0532745935144,
-          "menn": 0.04013320647,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.04013320647
         },
         {
           "alder": 62,
           "kvinner": 0.0527540678388,
-          "menn": 0.0405038472205,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0405038472205
         },
         {
           "alder": 63,
           "kvinner": 0.0518634263107,
-          "menn": 0.0417871812143,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0417871812143
         },
         {
           "alder": 64,
           "kvinner": 0.0524921792126,
-          "menn": 0.0434088927048,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0434088927048
         },
         {
           "alder": 65,
           "kvinner": 0.0528748737885,
-          "menn": 0.0445340217286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0445340217286
         },
         {
           "alder": 66,
           "kvinner": 0.0530269240844,
-          "menn": 0.0462100235606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0462100235606
         },
         {
           "alder": 67,
           "kvinner": 0.0543457815462,
-          "menn": 0.0472270869819,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0472270869819
         },
         {
           "alder": 68,
           "kvinner": 0.0551183421062,
-          "menn": 0.0478627646437,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0478627646437
         },
         {
           "alder": 69,
           "kvinner": 0.0558482219582,
-          "menn": 0.048054005129,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.048054005129
         },
         {
           "alder": 70,
           "kvinner": 0.0574825742098,
-          "menn": 0.0501792935073,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0501792935073
         },
         {
           "alder": 71,
           "kvinner": 0.0565047359891,
-          "menn": 0.0494661677628,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0494661677628
         },
         {
           "alder": 72,
           "kvinner": 0.0587803697316,
-          "menn": 0.053124387855,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.053124387855
         },
         {
           "alder": 73,
           "kvinner": 0.0624071206828,
-          "menn": 0.0562679394713,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0562679394713
         },
         {
           "alder": 74,
           "kvinner": 0.0677531422578,
-          "menn": 0.0625222642165,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0625222642165
         },
         {
           "alder": 75,
           "kvinner": 0.0719901177924,
-          "menn": 0.0682211529318,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0682211529318
         },
         {
           "alder": 76,
           "kvinner": 0.0799684775649,
-          "menn": 0.0753868492913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0753868492913
         },
         {
           "alder": 77,
           "kvinner": 0.0804870709112,
-          "menn": 0.0789688935935,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0789688935935
         },
         {
           "alder": 78,
           "kvinner": 0.0788025301304,
-          "menn": 0.0783243243243,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0783243243243
         },
         {
           "alder": 79,
           "kvinner": 0.0792285541073,
-          "menn": 0.0800713343724,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0800713343724
         },
         {
           "alder": 80,
           "kvinner": 0.0767913682751,
-          "menn": 0.0767265972268,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0767265972268
         },
         {
           "alder": 81,
           "kvinner": 0.0792173224948,
-          "menn": 0.0753517438185,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0753517438185
         },
         {
           "alder": 82,
           "kvinner": 0.081752799913,
-          "menn": 0.0799935326098,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0799935326098
         },
         {
           "alder": 83,
           "kvinner": 0.0847203504043,
-          "menn": 0.0833011604933,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0833011604933
         },
         {
           "alder": 84,
           "kvinner": 0.0844062947067,
-          "menn": 0.0862854510085,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0862854510085
         },
         {
           "alder": 85,
           "kvinner": 0.0791033390059,
-          "menn": 0.0830684649085,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0830684649085
         },
         {
           "alder": 86,
           "kvinner": 0.0801780341023,
-          "menn": 0.0803773341087,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0803773341087
         },
         {
           "alder": 87,
           "kvinner": 0.0783317289395,
-          "menn": 0.078868020489,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.078868020489
         },
         {
           "alder": 88,
           "kvinner": 0.0741302539512,
-          "menn": 0.0801408332635,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0801408332635
         },
         {
           "alder": 89,
           "kvinner": 0.0771021081973,
-          "menn": 0.0796037066246,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0796037066246
         },
         {
           "alder": 90,
           "kvinner": 0.077357670578,
-          "menn": 0.0806947711236,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0806947711236
         },
         {
           "alder": 91,
           "kvinner": 0.0791201693638,
-          "menn": 0.0833333333333,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0833333333333
         },
         {
           "alder": 92,
           "kvinner": 0.0734356956503,
-          "menn": 0.0798614361951,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0798614361951
         },
         {
           "alder": 93,
           "kvinner": 0.0670465629652,
-          "menn": 0.0790528233151,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0790528233151
         },
         {
           "alder": 94,
           "kvinner": 0.0713966409094,
-          "menn": 0.0791673496148,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0791673496148
         },
         {
           "alder": 95,
           "kvinner": 0.0674886437378,
-          "menn": 0.0750664304694,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0750664304694
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/inr_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/inr_rb1.json
@@ -72,17 +72,23 @@
       "type": "linechart",
       "data": "datasett_3",
       "linevars": [
-        "kvinner",
-        "menn"
+        "kvinner_s",
+        "menn_s",
+        "kvinner_l",
+        "menn_l"
       ],
       "linevarsLabels": {
         "nb": [
-          "Kvinner",
-          "Menn"
+          "Kvinner i spes",
+          "Menn i spes",
+          "Kvinner hos lege",
+          "Menn hos lege"
         ],
         "en": [
-          "Women",
-          "Men"
+          "Women at specialist",
+          "Men at specialist",
+          "Women at GP",
+          "Men at GP"
         ]
       },
       "x": [
@@ -200,8 +206,7 @@
           "tot_events": 5057,
           "tot_pas": 1175,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 4.30382978723,
-          "borhf": null
+          "prove_pr_pas": 4.30382978723
         },
         {
           "bohf": "UNN",
@@ -213,8 +218,7 @@
           "tot_events": 12470.6666667,
           "tot_pas": 2913,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 4.28103902048,
-          "borhf": null
+          "prove_pr_pas": 4.28103902048
         },
         {
           "bohf": "Nordland",
@@ -226,8 +230,7 @@
           "tot_events": 8058,
           "tot_pas": 2075.66666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 3.88212622451,
-          "borhf": null
+          "prove_pr_pas": 3.88212622451
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +242,7 @@
           "tot_events": 5627.33333333,
           "tot_pas": 1253.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 4.48869981388,
-          "borhf": null
+          "prove_pr_pas": 4.48869981388
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +254,7 @@
           "tot_events": 11971.3333333,
           "tot_pas": 1907.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 6.27647675638,
-          "borhf": null
+          "prove_pr_pas": 6.27647675638
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +266,7 @@
           "tot_events": 19618,
           "tot_pas": 3643.33333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 5.3846294602,
-          "borhf": null
+          "prove_pr_pas": 5.3846294602
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +278,7 @@
           "tot_events": 17919.3333333,
           "tot_pas": 2860.33333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 6.26477100571,
-          "borhf": null
+          "prove_pr_pas": 6.26477100571
         },
         {
           "bohf": "Førde",
@@ -291,8 +290,7 @@
           "tot_events": 6728,
           "tot_pas": 1420.66666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 4.73580478649,
-          "borhf": null
+          "prove_pr_pas": 4.73580478649
         },
         {
           "bohf": "Bergen",
@@ -304,8 +302,7 @@
           "tot_events": 20489.6666667,
           "tot_pas": 5354,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 3.8269829411,
-          "borhf": null
+          "prove_pr_pas": 3.8269829411
         },
         {
           "bohf": "Fonna",
@@ -317,8 +314,7 @@
           "tot_events": 9803,
           "tot_pas": 2169,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 4.51959428308,
-          "borhf": null
+          "prove_pr_pas": 4.51959428308
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +326,7 @@
           "tot_events": 18282.3333333,
           "tot_pas": 3744.33333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 4.88266714146,
-          "borhf": null
+          "prove_pr_pas": 4.88266714146
         },
         {
           "bohf": "Østfold",
@@ -343,8 +338,7 @@
           "tot_events": 17230.6666667,
           "tot_pas": 3209.33333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 5.36892397175,
-          "borhf": null
+          "prove_pr_pas": 5.36892397175
         },
         {
           "bohf": "Akershus",
@@ -356,8 +350,7 @@
           "tot_events": 27783.3333333,
           "tot_pas": 5581.33333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 4.97790253225,
-          "borhf": null
+          "prove_pr_pas": 4.97790253225
         },
         {
           "bohf": "OUS",
@@ -369,8 +362,7 @@
           "tot_events": 9444.66666667,
           "tot_pas": 2476,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 3.81448572967,
-          "borhf": null
+          "prove_pr_pas": 3.81448572967
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +374,7 @@
           "tot_events": 3858,
           "tot_pas": 1142,
           "tot_pop": 163625,
-          "prove_pr_pas": 3.37828371278,
-          "borhf": null
+          "prove_pr_pas": 3.37828371278
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +386,7 @@
           "tot_events": 4091,
           "tot_pas": 1023.66666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 3.99641810485,
-          "borhf": null
+          "prove_pr_pas": 3.99641810485
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +398,7 @@
           "tot_events": 24337.6666667,
           "tot_pas": 4530.33333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 5.37215804577,
-          "borhf": null
+          "prove_pr_pas": 5.37215804577
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +410,7 @@
           "tot_events": 31233,
           "tot_pas": 6062.33333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 5.15197668664,
-          "borhf": null
+          "prove_pr_pas": 5.15197668664
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +422,7 @@
           "tot_events": 13627.3333333,
           "tot_pas": 2270.66666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 6.00146799765,
-          "borhf": null
+          "prove_pr_pas": 6.00146799765
         },
         {
           "bohf": "Telemark",
@@ -447,8 +434,7 @@
           "tot_events": 7425.66666667,
           "tot_pas": 1867.66666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 3.97590576477,
-          "borhf": null
+          "prove_pr_pas": 3.97590576477
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +446,7 @@
           "tot_events": 14685.6666667,
           "tot_pas": 2619.33333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 5.60664291168,
-          "borhf": null
+          "prove_pr_pas": 5.60664291168
         },
         {
           "bohf": "Norge",
@@ -473,8 +458,7 @@
           "tot_events": 289741.666667,
           "tot_pas": 59299,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 4.88611387488,
-          "borhf": null
+          "prove_pr_pas": 4.88611387488
         }
       ]
     },
@@ -493,9 +477,7 @@
           "tot_events": 31213,
           "tot_pas": 7414.66666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 4.20962956303,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 4.20962956303
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +489,7 @@
           "tot_events": 49508.6666667,
           "tot_pas": 8407.66666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 5.8885144511,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 5.8885144511
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +501,7 @@
           "tot_events": 55303,
           "tot_pas": 12685,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 4.35971620024,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 4.35971620024
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +513,7 @@
           "tot_events": 153717,
           "tot_pas": 30707.6666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 5.00581830813,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 5.00581830813
         },
         {
           "borhf": "Norge",
@@ -549,9 +525,7 @@
           "tot_events": 289741.666667,
           "tot_pas": 59180.6666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 4.89588379088,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 4.89588379088
         }
       ]
     },
@@ -562,675 +536,675 @@
       "data": [
         {
           "alder": 0,
-          "kvinner": 0.000237637291232,
-          "menn": 0.000436263334178,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000380290795695,
+          "menn_s": 0.000665086582181,
+          "kvinner_l": 2.5352719713e-05,
+          "menn_l": 8.46473831866e-05
         },
         {
           "alder": 1,
-          "kvinner": 0.000371711988805,
-          "menn": 0.000516084637881,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000566949319661,
+          "menn_s": 0.00068092699993,
+          "kvinner_l": 6.16249260501e-05,
+          "menn_l": 0.000199582051703
         },
         {
           "alder": 2,
-          "kvinner": 0.00037650067486,
-          "menn": 0.000514595808383,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000530831430159,
+          "menn_s": 0.000643538290528,
+          "kvinner_l": 0.000123449169804,
+          "menn_l": 0.000257415316211
         },
         {
           "alder": 3,
-          "kvinner": 0.000438315754321,
-          "menn": 0.000603136308806,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000543248626788,
+          "menn_s": 0.000842383261617,
+          "kvinner_l": 0.000217299450715,
+          "menn_l": 0.00020490403661
         },
         {
           "alder": 4,
-          "kvinner": 0.000470761610414,
-          "menn": 0.000638870425462,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000658250464302,
+          "menn_s": 0.000948567772961,
+          "kvinner_l": 0.000152808143499,
+          "menn_l": 0.000143388151727
         },
         {
           "alder": 5,
-          "kvinner": 0.000643095432683,
-          "menn": 0.000583856371333,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000926858293665,
+          "menn_s": 0.000817643894567,
+          "kvinner_l": 0.000171640424753,
+          "menn_l": 0.000172135556751
         },
         {
           "alder": 6,
-          "kvinner": 0.00047701705336,
-          "menn": 0.00044047319406,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000708438287154,
+          "menn_s": 0.000625132443314,
+          "kvinner_l": 0.000101205469593,
+          "menn_l": 0.00011655011655
         },
         {
           "alder": 7,
-          "kvinner": 0.00046902481923,
-          "menn": 0.00061360340147,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000678539249602,
+          "menn_s": 0.000868230186881,
+          "kvinner_l": 0.000122359536814,
+          "menn_l": 0.000179998941183
         },
         {
           "alder": 8,
-          "kvinner": 0.00060771607505,
-          "menn": 0.000572110234687,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000909648853623,
+          "menn_s": 0.000762680875516,
+          "kvinner_l": 0.000131515496909,
+          "menn_l": 0.000219401347751
         },
         {
           "alder": 9,
-          "kvinner": 0.000613349520702,
-          "menn": 0.000664945396601,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.000809725341164,
+          "menn_s": 0.00104854129402,
+          "kvinner_l": 0.000237519433408,
+          "menn_l": 9.25183494726e-05
         },
         {
           "alder": 10,
-          "kvinner": 0.000775017957733,
-          "menn": 0.000740612438705,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00104648950339,
+          "menn_s": 0.00105324399149,
+          "kvinner_l": 0.000253694425065,
+          "menn_l": 0.000190587007985
         },
         {
           "alder": 11,
-          "kvinner": 0.00106160446753,
-          "menn": 0.000858363982094,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00141289893617,
+          "menn_s": 0.00123946211279,
+          "kvinner_l": 0.000342835771277,
+          "menn_l": 0.000177066016113
         },
         {
           "alder": 12,
-          "kvinner": 0.00120234140168,
-          "menn": 0.000919360653768,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00162302643068,
+          "menn_s": 0.00119692885572,
+          "kvinner_l": 0.000328714213808,
+          "menn_l": 0.000291933867248
         },
         {
           "alder": 13,
-          "kvinner": 0.00169304191716,
-          "menn": 0.000989882550132,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00220391945864,
+          "menn_s": 0.00128159974955,
+          "kvinner_l": 0.000538046065021,
+          "menn_l": 0.000313062534241
         },
         {
           "alder": 14,
-          "kvinner": 0.0023205744711,
-          "menn": 0.00132541357813,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00308422549348,
+          "menn_s": 0.00165058907251,
+          "kvinner_l": 0.000679575108732,
+          "menn_l": 0.000484304578161
         },
         {
           "alder": 15,
-          "kvinner": 0.00317332589213,
-          "menn": 0.00137332896178,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00431549665232,
+          "menn_s": 0.00171957804974,
+          "kvinner_l": 0.000856753011857,
+          "menn_l": 0.000512856611325
         },
         {
           "alder": 16,
-          "kvinner": 0.00368068584532,
-          "menn": 0.00161880543323,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00486473281145,
+          "menn_s": 0.00183799396088,
+          "kvinner_l": 0.00113652054765,
+          "menn_l": 0.000797810565436
         },
         {
           "alder": 17,
-          "kvinner": 0.00422071836239,
-          "menn": 0.0019688891063,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00558844626206,
+          "menn_s": 0.00245422513697,
+          "kvinner_l": 0.00140246448339,
+          "menn_l": 0.000824864050184
         },
         {
           "alder": 18,
-          "kvinner": 0.0048330826105,
-          "menn": 0.00193916326912,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00617582299554,
+          "menn_s": 0.00237301311294,
+          "kvinner_l": 0.00193330111165,
+          "menn_l": 0.000920565431745
         },
         {
           "alder": 19,
-          "kvinner": 0.00496923654457,
-          "menn": 0.00203748495717,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00627902976088,
+          "menn_s": 0.002436826801,
+          "kvinner_l": 0.00211809736797,
+          "menn_l": 0.00106483187943
         },
         {
           "alder": 20,
-          "kvinner": 0.00480361684092,
-          "menn": 0.00188892202787,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00606709871764,
+          "menn_s": 0.00234475986252,
+          "kvinner_l": 0.00204711547641,
+          "menn_l": 0.000891810375061
         },
         {
           "alder": 21,
-          "kvinner": 0.00509961536799,
-          "menn": 0.00209647218297,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00632482729158,
+          "menn_s": 0.00257346514654,
+          "kvinner_l": 0.00228193933584,
+          "menn_l": 0.000971118923223
         },
         {
           "alder": 22,
-          "kvinner": 0.00535066745755,
-          "menn": 0.00223852542122,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00667741902345,
+          "menn_s": 0.00265155503652,
+          "kvinner_l": 0.00231141427735,
+          "menn_l": 0.00111039849905
         },
         {
           "alder": 23,
-          "kvinner": 0.00554446127022,
-          "menn": 0.00209199122604,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00708175001524,
+          "menn_s": 0.00250149236761,
+          "kvinner_l": 0.00225559326167,
+          "menn_l": 0.00101386243687
         },
         {
           "alder": 24,
-          "kvinner": 0.00524613046127,
-          "menn": 0.00240328578565,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00650759219089,
+          "menn_s": 0.00275225945624,
+          "kvinner_l": 0.00227815251736,
+          "menn_l": 0.0012738498159
         },
         {
           "alder": 25,
-          "kvinner": 0.00563742229734,
-          "menn": 0.00244338758236,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00690301934586,
+          "menn_s": 0.00285236728317,
+          "kvinner_l": 0.0025137045237,
+          "menn_l": 0.00121725228008
         },
         {
           "alder": 26,
-          "kvinner": 0.00547690458506,
-          "menn": 0.00249629581911,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00654225958853,
+          "menn_s": 0.0028127883332,
+          "kvinner_l": 0.00260364889558,
+          "menn_l": 0.00135264661883
         },
         {
           "alder": 27,
-          "kvinner": 0.00569151963574,
-          "menn": 0.00287284998336,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00679947624392,
+          "menn_s": 0.00333191171767,
+          "kvinner_l": 0.00283389450056,
+          "menn_l": 0.00150158154743
         },
         {
           "alder": 28,
-          "kvinner": 0.00596215656623,
-          "menn": 0.00279733369383,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00709727769361,
+          "menn_s": 0.00314520356456,
+          "kvinner_l": 0.00300234127531,
+          "menn_l": 0.00155512842915
         },
         {
           "alder": 29,
-          "kvinner": 0.00583559768074,
-          "menn": 0.00305108640286,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00716179179584,
+          "menn_s": 0.00334594122781,
+          "kvinner_l": 0.00264186548052,
+          "menn_l": 0.0017285936778
         },
         {
           "alder": 30,
-          "kvinner": 0.00589789437165,
-          "menn": 0.00317994569314,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0067594852257,
+          "menn_s": 0.00328273499681,
+          "kvinner_l": 0.00294081500079,
+          "menn_l": 0.00188904187796
         },
         {
           "alder": 31,
-          "kvinner": 0.00625726337537,
-          "menn": 0.00344815070233,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00701629619351,
+          "menn_s": 0.00379107344161,
+          "kvinner_l": 0.00307017163474,
+          "menn_l": 0.00176193060833
         },
         {
           "alder": 32,
-          "kvinner": 0.00666068281577,
-          "menn": 0.00367544894482,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00723399457017,
+          "menn_s": 0.00381586967594,
+          "kvinner_l": 0.00332208623546,
+          "menn_l": 0.00203735711363
         },
         {
           "alder": 33,
-          "kvinner": 0.00653031734563,
-          "menn": 0.00368837233986,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00726088912808,
+          "menn_s": 0.00393024245002,
+          "kvinner_l": 0.00310550786523,
+          "menn_l": 0.00198213526159
         },
         {
           "alder": 34,
-          "kvinner": 0.00671220704838,
-          "menn": 0.00358513350329,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00754001419931,
+          "menn_s": 0.00369626840595,
+          "kvinner_l": 0.00311845640901,
+          "menn_l": 0.0020592264546
         },
         {
           "alder": 35,
-          "kvinner": 0.00623097439646,
-          "menn": 0.00357496661929,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.007020058623,
+          "menn_s": 0.00372849535473,
+          "kvinner_l": 0.00300465859911,
+          "menn_l": 0.0020967303289
         },
         {
           "alder": 36,
-          "kvinner": 0.00609383467663,
-          "menn": 0.00374900697566,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00704008653245,
+          "menn_s": 0.00392753520628,
+          "kvinner_l": 0.00281603461298,
+          "menn_l": 0.00216722100347
         },
         {
           "alder": 37,
-          "kvinner": 0.00612807562207,
-          "menn": 0.00390744545971,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0069579685757,
+          "menn_s": 0.00449645111115,
+          "kvinner_l": 0.00304411125187,
+          "menn_l": 0.00189512452398
         },
         {
           "alder": 38,
-          "kvinner": 0.00601244436159,
-          "menn": 0.00406372535578,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0069843019499,
+          "menn_s": 0.00448353939045,
+          "kvinner_l": 0.00282222813486,
+          "menn_l": 0.00217438182864
         },
         {
           "alder": 39,
-          "kvinner": 0.00643481821639,
-          "menn": 0.00385531802237,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00746211541405,
+          "menn_s": 0.00429402279275,
+          "kvinner_l": 0.00306138068269,
+          "menn_l": 0.00203830195858
         },
         {
           "alder": 40,
-          "kvinner": 0.00620291637594,
-          "menn": 0.00440046461758,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0070165026611,
+          "menn_s": 0.00482363307686,
+          "kvinner_l": 0.00302484971475,
+          "menn_l": 0.00233460207298
         },
         {
           "alder": 41,
-          "kvinner": 0.00602338069667,
-          "menn": 0.00445117961852,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00677998841028,
+          "menn_s": 0.00457768767143,
+          "kvinner_l": 0.00301332818234,
+          "menn_l": 0.00272459566817
         },
         {
           "alder": 42,
-          "kvinner": 0.00660543495663,
-          "menn": 0.00451210420999,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00741669582799,
+          "menn_s": 0.0044923382207,
+          "kvinner_l": 0.00341187448968,
+          "menn_l": 0.00290302428986
         },
         {
           "alder": 43,
-          "kvinner": 0.00663293656596,
-          "menn": 0.00475675075625,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00773244173546,
+          "menn_s": 0.00489622438376,
+          "kvinner_l": 0.00345198291762,
+          "menn_l": 0.0031268431055
         },
         {
           "alder": 44,
-          "kvinner": 0.00611336569934,
-          "menn": 0.00476866493825,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00706325226609,
+          "menn_s": 0.00502932992404,
+          "kvinner_l": 0.00342760909406,
+          "menn_l": 0.00314920658795
         },
         {
           "alder": 45,
-          "kvinner": 0.00586759856833,
-          "menn": 0.00484052994443,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0069539801483,
+          "menn_s": 0.00511784133756,
+          "kvinner_l": 0.00325630664208,
+          "menn_l": 0.00334951955914
         },
         {
           "alder": 46,
-          "kvinner": 0.0063238053195,
-          "menn": 0.00497123299177,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00730809123695,
+          "menn_s": 0.00525789138543,
+          "kvinner_l": 0.00359695115569,
+          "menn_l": 0.00335668152461
         },
         {
           "alder": 47,
-          "kvinner": 0.00649577311154,
-          "menn": 0.00513107856413,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00736697991078,
+          "menn_s": 0.00550091236815,
+          "kvinner_l": 0.00372540071341,
+          "menn_l": 0.00330232765143
         },
         {
           "alder": 48,
-          "kvinner": 0.00660738076927,
-          "menn": 0.00563110594097,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0073558231321,
+          "menn_s": 0.00560465055655,
+          "kvinner_l": 0.0037645042795,
+          "menn_l": 0.00390153193782
         },
         {
           "alder": 49,
-          "kvinner": 0.00701856367032,
-          "menn": 0.00629501473792,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00755228330096,
+          "menn_s": 0.00603928113628,
+          "kvinner_l": 0.00422783323547,
+          "menn_l": 0.00452515936992
         },
         {
           "alder": 50,
-          "kvinner": 0.00722156407718,
-          "menn": 0.00678219995351,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00784078282376,
+          "menn_s": 0.00585141016415,
+          "kvinner_l": 0.00412201154163,
+          "menn_l": 0.00539734758918
         },
         {
           "alder": 51,
-          "kvinner": 0.00833087504234,
-          "menn": 0.00755878331661,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00870762408811,
+          "menn_s": 0.00655330449308,
+          "kvinner_l": 0.00492597625519,
+          "menn_l": 0.00590225724933
         },
         {
           "alder": 52,
-          "kvinner": 0.00807884600528,
-          "menn": 0.00809947943152,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00824550082455,
+          "menn_s": 0.00675617670793,
+          "kvinner_l": 0.00487560048756,
+          "menn_l": 0.00650721975173
         },
         {
           "alder": 53,
-          "kvinner": 0.00827741120314,
-          "menn": 0.00857550707346,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00861742253343,
+          "menn_s": 0.00672779697119,
+          "kvinner_l": 0.00468318564906,
+          "menn_l": 0.00721268323939
         },
         {
           "alder": 54,
-          "kvinner": 0.00893954182695,
-          "menn": 0.00907443987297,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00898886742111,
+          "menn_s": 0.00707882317854,
+          "kvinner_l": 0.00533627748643,
+          "menn_l": 0.00750864019929
         },
         {
           "alder": 55,
-          "kvinner": 0.009005143277,
-          "menn": 0.0098309588674,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00893125469572,
+          "menn_s": 0.00774183178705,
+          "kvinner_l": 0.00545642374155,
+          "menn_l": 0.00798292689461
         },
         {
           "alder": 56,
-          "kvinner": 0.0098627632576,
-          "menn": 0.0100009185689,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00980963945273,
+          "menn_s": 0.0076538468506,
+          "kvinner_l": 0.00587048598828,
+          "menn_l": 0.00812485281064
         },
         {
           "alder": 57,
-          "kvinner": 0.00978401329149,
-          "menn": 0.0110814765861,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00928335257175,
+          "menn_s": 0.00842641399908,
+          "kvinner_l": 0.00627042044098,
+          "menn_l": 0.00915670321234
         },
         {
           "alder": 58,
-          "kvinner": 0.00972203032168,
-          "menn": 0.011127556106,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00960106275915,
+          "menn_s": 0.00820560458275,
+          "kvinner_l": 0.00597802020853,
+          "menn_l": 0.00961836197554
         },
         {
           "alder": 59,
-          "kvinner": 0.0104418182397,
-          "menn": 0.0115168453057,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0102917903578,
+          "menn_s": 0.00867274894094,
+          "kvinner_l": 0.00666121908584,
+          "menn_l": 0.0101048541356
         },
         {
           "alder": 60,
-          "kvinner": 0.0103064874795,
-          "menn": 0.012196114014,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0101556136212,
+          "menn_s": 0.00865845066827,
+          "kvinner_l": 0.00675983031662,
+          "menn_l": 0.0112416912568
         },
         {
           "alder": 61,
-          "kvinner": 0.0102967701751,
-          "menn": 0.0134665398034,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00979332341514,
+          "menn_s": 0.00989955322435,
+          "kvinner_l": 0.00719247359014,
+          "menn_l": 0.0121075164042
         },
         {
           "alder": 62,
-          "kvinner": 0.0102072926091,
-          "menn": 0.0138474140099,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00956060082873,
+          "menn_s": 0.00988973992088,
+          "kvinner_l": 0.00724059046961,
+          "menn_l": 0.0126988468984
         },
         {
           "alder": 63,
-          "kvinner": 0.0104657734632,
-          "menn": 0.01477871548,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.00968901220138,
+          "menn_s": 0.0103337522692,
+          "kvinner_l": 0.00750434203196,
+          "menn_l": 0.0137067233841
         },
         {
           "alder": 64,
-          "kvinner": 0.0113916609798,
-          "menn": 0.016211575254,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0105245793468,
+          "menn_s": 0.0110779065822,
+          "kvinner_l": 0.00801715605411,
+          "menn_l": 0.0151719155364
         },
         {
           "alder": 65,
-          "kvinner": 0.0113744857098,
-          "menn": 0.016372396085,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0105537357318,
+          "menn_s": 0.0110340196956,
+          "kvinner_l": 0.00796002101803,
+          "menn_l": 0.0155102954342
         },
         {
           "alder": 66,
-          "kvinner": 0.011780614376,
-          "menn": 0.0172469018927,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0103380578977,
+          "menn_s": 0.0110441537016,
+          "kvinner_l": 0.00854506871234,
+          "menn_l": 0.0167151662351
         },
         {
           "alder": 67,
-          "kvinner": 0.0125085005715,
-          "menn": 0.0189652656159,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0108681754251,
+          "menn_s": 0.0118754731264,
+          "kvinner_l": 0.00922923132359,
+          "menn_l": 0.0188659159727
         },
         {
           "alder": 68,
-          "kvinner": 0.0127875731586,
-          "menn": 0.0199068632556,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.010794698841,
+          "menn_s": 0.0124268117879,
+          "kvinner_l": 0.00983279498385,
+          "menn_l": 0.0200796870824
         },
         {
           "alder": 69,
-          "kvinner": 0.0130317499458,
-          "menn": 0.0202670085986,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0109700905155,
+          "menn_s": 0.012087016488,
+          "kvinner_l": 0.0104781582054,
+          "menn_l": 0.0216036612125
         },
         {
           "alder": 70,
-          "kvinner": 0.0131744982574,
-          "menn": 0.021858548867,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0114364250769,
+          "menn_s": 0.0132103784838,
+          "kvinner_l": 0.0106798809704,
+          "menn_l": 0.0235349946774
         },
         {
           "alder": 71,
-          "kvinner": 0.0135537018037,
-          "menn": 0.0222296736041,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0117480719794,
+          "menn_s": 0.0131199538639,
+          "kvinner_l": 0.0116838046272,
+          "menn_l": 0.0251127188843
         },
         {
           "alder": 72,
-          "kvinner": 0.0144549332849,
-          "menn": 0.0242977473066,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0119552096977,
+          "menn_s": 0.0135918238331,
+          "kvinner_l": 0.0125844312608,
+          "menn_l": 0.0272494995259
         },
         {
           "alder": 73,
-          "kvinner": 0.0167435636092,
-          "menn": 0.0266134343771,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.01344158426,
+          "menn_s": 0.0141512564882,
+          "kvinner_l": 0.0141598368541,
+          "menn_l": 0.0292981454685
         },
         {
           "alder": 74,
-          "kvinner": 0.0177719876112,
-          "menn": 0.0311394934619,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0123802879432,
+          "menn_s": 0.0156007481991,
+          "kvinner_l": 0.0151328724551,
+          "menn_l": 0.0319443891697
         },
         {
           "alder": 75,
-          "kvinner": 0.0200644108175,
-          "menn": 0.0349093744651,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0133150398537,
+          "menn_s": 0.0159443761868,
+          "kvinner_l": 0.016398797857,
+          "menn_l": 0.0353093934994
         },
         {
           "alder": 76,
-          "kvinner": 0.0230113776289,
-          "menn": 0.0407871353647,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0135936830169,
+          "menn_s": 0.0170039032707,
+          "kvinner_l": 0.0187103287099,
+          "menn_l": 0.0392869427371
         },
         {
           "alder": 77,
-          "kvinner": 0.0254390301571,
-          "menn": 0.0444703731325,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0151154891304,
+          "menn_s": 0.0184601301871,
+          "kvinner_l": 0.0214303359684,
+          "menn_l": 0.0442093843233
         },
         {
           "alder": 78,
-          "kvinner": 0.0267564808187,
-          "menn": 0.0468108108108,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0155842384354,
+          "menn_s": 0.0190753313935,
+          "kvinner_l": 0.0232911047077,
+          "menn_l": 0.0468039786235
         },
         {
           "alder": 79,
-          "kvinner": 0.0262705870466,
-          "menn": 0.0487951085002,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0153705469191,
+          "menn_s": 0.0211052361511,
+          "kvinner_l": 0.0250987411717,
+          "menn_l": 0.0515360417643
         },
         {
           "alder": 80,
-          "kvinner": 0.0260229110329,
-          "menn": 0.049475884031,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0153917811699,
+          "menn_s": 0.0200401808137,
+          "kvinner_l": 0.025151906506,
+          "menn_l": 0.0548719236565
         },
         {
           "alder": 81,
-          "kvinner": 0.0268182145169,
-          "menn": 0.051023172648,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0160833409486,
+          "menn_s": 0.0208041271799,
+          "kvinner_l": 0.0265009595175,
+          "menn_l": 0.058402960803
         },
         {
           "alder": 82,
-          "kvinner": 0.0282864998369,
-          "menn": 0.056124820631,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0153683349768,
+          "menn_s": 0.0228623408126,
+          "kvinner_l": 0.0284278121167,
+          "menn_l": 0.0613402061856
         },
         {
           "alder": 83,
-          "kvinner": 0.0308119946092,
-          "menn": 0.0614766198079,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0170317576774,
+          "menn_s": 0.0234271099744,
+          "kvinner_l": 0.0308929881564,
+          "menn_l": 0.0688832054561
         },
         {
           "alder": 84,
-          "kvinner": 0.0336194563662,
-          "menn": 0.0654499846422,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0184581662965,
+          "menn_s": 0.026616412807,
+          "kvinner_l": 0.0344071756121,
+          "menn_l": 0.0727385763133
         },
         {
           "alder": 85,
-          "kvinner": 0.0348375486572,
-          "menn": 0.0645992612319,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0194979829673,
+          "menn_s": 0.0264227642276,
+          "kvinner_l": 0.0375232118845,
+          "menn_l": 0.0754742547425
         },
         {
           "alder": 86,
-          "kvinner": 0.0365889334671,
-          "menn": 0.0672934031143,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0217536696117,
+          "menn_s": 0.0279951678134,
+          "kvinner_l": 0.0398817276215,
+          "menn_l": 0.0814118388571
         },
         {
           "alder": 87,
-          "kvinner": 0.0342295551725,
-          "menn": 0.0703672757656,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0203455639682,
+          "menn_s": 0.0327319273437,
+          "kvinner_l": 0.0390215492137,
+          "menn_l": 0.0853346336706
         },
         {
           "alder": 88,
-          "kvinner": 0.0364534912169,
-          "menn": 0.0736440606924,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0217016444463,
+          "menn_s": 0.0332553015698,
+          "kvinner_l": 0.0409639567649,
+          "menn_l": 0.0877168824015
         },
         {
           "alder": 89,
-          "kvinner": 0.0356147330248,
-          "menn": 0.0746746845426,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0211445644679,
+          "menn_s": 0.0350651439601,
+          "kvinner_l": 0.0393472764882,
+          "menn_l": 0.0867781888371
         },
         {
           "alder": 90,
-          "kvinner": 0.0387719625008,
-          "menn": 0.0758096616609,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.022661154494,
+          "menn_s": 0.0333048676345,
+          "kvinner_l": 0.0410861021793,
+          "menn_l": 0.0859664104754
         },
         {
           "alder": 91,
-          "kvinner": 0.0405468441638,
-          "menn": 0.0803860890068,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.024785057812,
+          "menn_s": 0.0372537313433,
+          "kvinner_l": 0.0422176104358,
+          "menn_l": 0.0930149253731
         },
         {
           "alder": 92,
-          "kvinner": 0.0431974680296,
-          "menn": 0.080610429735,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0266135344766,
+          "menn_s": 0.0406175059952,
+          "kvinner_l": 0.0452572404469,
+          "menn_l": 0.0884292565947
         },
         {
           "alder": 93,
-          "kvinner": 0.0429693516094,
-          "menn": 0.0766241651488,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0286515377201,
+          "menn_s": 0.0368608799049,
+          "kvinner_l": 0.0446858845177,
+          "menn_l": 0.0881886642885
         },
         {
           "alder": 94,
-          "kvinner": 0.0427868957149,
-          "menn": 0.0768726438289,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0286085825748,
+          "menn_s": 0.0386447856008,
+          "kvinner_l": 0.043996532293,
+          "menn_l": 0.0854949708841
         },
         {
           "alder": 95,
-          "kvinner": 0.0446950032446,
-          "menn": 0.0801594331267,
-          "bohf": null,
-          "borhf": null
+          "kvinner_s": 0.0320744237712,
+          "menn_s": 0.0407446434844,
+          "kvinner_l": 0.0444321021938,
+          "menn_l": 0.086406743941
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/kalium_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/kalium_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 32877.6666667,
           "tot_pas": 21075,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.56003163306,
-          "borhf": null
+          "prove_pr_pas": 1.56003163306
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 80132.6666667,
           "tot_pas": 52642.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.5222096285,
-          "borhf": null
+          "prove_pr_pas": 1.5222096285
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 58010.3333333,
           "tot_pas": 38912.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.49078277853,
-          "borhf": null
+          "prove_pr_pas": 1.49078277853
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 41969.3333333,
           "tot_pas": 25672.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.63480789955,
-          "borhf": null
+          "prove_pr_pas": 1.63480789955
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 62728,
           "tot_pas": 42258.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.48438190194,
-          "borhf": null
+          "prove_pr_pas": 1.48438190194
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 136799,
           "tot_pas": 92682.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.47599335367,
-          "borhf": null
+          "prove_pr_pas": 1.47599335367
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 128145,
           "tot_pas": 84425.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.51785009239,
-          "borhf": null
+          "prove_pr_pas": 1.51785009239
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 50309.3333333,
           "tot_pas": 31133,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.61594877889,
-          "borhf": null
+          "prove_pr_pas": 1.61594877889
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 195538.333333,
           "tot_pas": 116349.666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.68060931273,
-          "borhf": null
+          "prove_pr_pas": 1.68060931273
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 93115.3333333,
           "tot_pas": 55699.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.67173950772,
-          "borhf": null
+          "prove_pr_pas": 1.67173950772
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 152880,
           "tot_pas": 97114.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.57422694213,
-          "borhf": null
+          "prove_pr_pas": 1.57422694213
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 195260,
           "tot_pas": 120315.666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.62289754451,
-          "borhf": null
+          "prove_pr_pas": 1.62289754451
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 287189.666667,
           "tot_pas": 184452.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.55698300196,
-          "borhf": null
+          "prove_pr_pas": 1.55698300196
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 113706,
           "tot_pas": 75088.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.51428977298,
-          "borhf": null
+          "prove_pr_pas": 1.51428977298
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 48743.3333333,
           "tot_pas": 35350.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.37886488576,
-          "borhf": null
+          "prove_pr_pas": 1.37886488576
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 52312,
           "tot_pas": 34960.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.49631013901,
-          "borhf": null
+          "prove_pr_pas": 1.49631013901
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 200947.333333,
           "tot_pas": 123046.666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.63309855339,
-          "borhf": null
+          "prove_pr_pas": 1.63309855339
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 240402,
           "tot_pas": 152462.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.57679256998,
-          "borhf": null
+          "prove_pr_pas": 1.57679256998
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 139040.333333,
           "tot_pas": 86967.3333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.59876505355,
-          "borhf": null
+          "prove_pr_pas": 1.59876505355
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 84098.6666667,
           "tot_pas": 53362.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.57598320923,
-          "borhf": null
+          "prove_pr_pas": 1.57598320923
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 169647,
           "tot_pas": 103919,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.63249261444,
-          "borhf": null
+          "prove_pr_pas": 1.63249261444
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 2563857,
           "tot_pas": 1627896.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.57495102575,
-          "borhf": null
+          "prove_pr_pas": 1.57495102575
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 212990,
           "tot_pas": 138231,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.54082658738,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.54082658738
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 327672,
           "tot_pas": 219261.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.49443586344,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.49443586344
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 491843,
           "tot_pas": 300159,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.63860820432,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.63860820432
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1531352,
           "tot_pas": 967125.666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.58340539682,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.58340539682
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 2563857,
           "tot_pas": 1623568,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.57914974919,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57914974919
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.0044408468799,
-          "menn": 0.00545329167722,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00545329167722
         },
         {
           "alder": 1,
           "kvinner": 0.0131921313674,
-          "menn": 0.0155513504215,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0155513504215
         },
         {
           "alder": 2,
           "kvinner": 0.017439795411,
-          "menn": 0.0198219632164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0198219632164
         },
         {
           "alder": 3,
           "kvinner": 0.0229941836195,
-          "menn": 0.0257381863953,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0257381863953
         },
         {
           "alder": 4,
           "kvinner": 0.0263831180793,
-          "menn": 0.0301172553094,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0301172553094
         },
         {
           "alder": 5,
           "kvinner": 0.0305068395879,
-          "menn": 0.0324167211388,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0324167211388
         },
         {
           "alder": 6,
           "kvinner": 0.0354980190542,
-          "menn": 0.0362006040775,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0362006040775
         },
         {
           "alder": 7,
           "kvinner": 0.0402644778842,
-          "menn": 0.0397912508832,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0397912508832
         },
         {
           "alder": 8,
           "kvinner": 0.045604293674,
-          "menn": 0.0460792190087,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0460792190087
         },
         {
           "alder": 9,
           "kvinner": 0.0501808432607,
-          "menn": 0.0512007955383,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0512007955383
         },
         {
           "alder": 10,
           "kvinner": 0.0566267185866,
-          "menn": 0.0561909824463,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0561909824463
         },
         {
           "alder": 11,
           "kvinner": 0.0626346635845,
-          "menn": 0.0581660815088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0581660815088
         },
         {
           "alder": 12,
           "kvinner": 0.0744755576649,
-          "menn": 0.0594399711573,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0594399711573
         },
         {
           "alder": 13,
           "kvinner": 0.100521968017,
-          "menn": 0.0696075692614,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0696075692614
         },
         {
           "alder": 14,
           "kvinner": 0.129797465417,
-          "menn": 0.0836667321192,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0836667321192
         },
         {
           "alder": 15,
           "kvinner": 0.149451319623,
-          "menn": 0.0896622971711,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0896622971711
         },
         {
           "alder": 16,
           "kvinner": 0.16335730665,
-          "menn": 0.0890405011474,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0890405011474
         },
         {
           "alder": 17,
           "kvinner": 0.17367642021,
-          "menn": 0.0929230054297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0929230054297
         },
         {
           "alder": 18,
           "kvinner": 0.178100694556,
-          "menn": 0.0924715900537,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0924715900537
         },
         {
           "alder": 19,
           "kvinner": 0.172663472612,
-          "menn": 0.0921098097156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0921098097156
         },
         {
           "alder": 20,
           "kvinner": 0.176791937459,
-          "menn": 0.0928027977099,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0928027977099
         },
         {
           "alder": 21,
           "kvinner": 0.179134794071,
-          "menn": 0.0946112049258,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0946112049258
         },
         {
           "alder": 22,
           "kvinner": 0.181555790645,
-          "menn": 0.0990134539365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0990134539365
         },
         {
           "alder": 23,
           "kvinner": 0.184831464064,
-          "menn": 0.102845897498,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.102845897498
         },
         {
           "alder": 24,
           "kvinner": 0.186660515623,
-          "menn": 0.105439307321,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.105439307321
         },
         {
           "alder": 25,
           "kvinner": 0.193819671941,
-          "menn": 0.108976176971,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.108976176971
         },
         {
           "alder": 26,
           "kvinner": 0.197253610165,
-          "menn": 0.111377740557,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111377740557
         },
         {
           "alder": 27,
           "kvinner": 0.198998734604,
-          "menn": 0.114391182885,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114391182885
         },
         {
           "alder": 28,
           "kvinner": 0.202469416847,
-          "menn": 0.11674968543,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11674968543
         },
         {
           "alder": 29,
           "kvinner": 0.205962900362,
-          "menn": 0.119254773432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.119254773432
         },
         {
           "alder": 30,
           "kvinner": 0.214283045555,
-          "menn": 0.125308444408,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125308444408
         },
         {
           "alder": 31,
           "kvinner": 0.220661343778,
-          "menn": 0.127265279456,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127265279456
         },
         {
           "alder": 32,
           "kvinner": 0.227716540604,
-          "menn": 0.130659326255,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.130659326255
         },
         {
           "alder": 33,
           "kvinner": 0.229561496137,
-          "menn": 0.13131666932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13131666932
         },
         {
           "alder": 34,
           "kvinner": 0.233082238685,
-          "menn": 0.133245672883,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133245672883
         },
         {
           "alder": 35,
           "kvinner": 0.230820192698,
-          "menn": 0.133905112633,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133905112633
         },
         {
           "alder": 36,
           "kvinner": 0.230257013387,
-          "menn": 0.136607502367,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136607502367
         },
         {
           "alder": 37,
           "kvinner": 0.228980353088,
-          "menn": 0.140165260351,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140165260351
         },
         {
           "alder": 38,
           "kvinner": 0.231141199226,
-          "menn": 0.14149551674,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.14149551674
         },
         {
           "alder": 39,
           "kvinner": 0.233303109187,
-          "menn": 0.145520330046,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145520330046
         },
         {
           "alder": 40,
           "kvinner": 0.23757347115,
-          "menn": 0.152536409936,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.152536409936
         },
         {
           "alder": 41,
           "kvinner": 0.238933374519,
-          "menn": 0.154835065901,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.154835065901
         },
         {
           "alder": 42,
           "kvinner": 0.239372898742,
-          "menn": 0.158316004237,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.158316004237
         },
         {
           "alder": 43,
           "kvinner": 0.238750621472,
-          "menn": 0.159392778842,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.159392778842
         },
         {
           "alder": 44,
           "kvinner": 0.238969675628,
-          "menn": 0.16466693342,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16466693342
         },
         {
           "alder": 45,
           "kvinner": 0.240430628752,
-          "menn": 0.16500591026,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16500591026
         },
         {
           "alder": 46,
           "kvinner": 0.243825184858,
-          "menn": 0.170518016126,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170518016126
         },
         {
           "alder": 47,
           "kvinner": 0.25274065994,
-          "menn": 0.181408789761,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181408789761
         },
         {
           "alder": 48,
           "kvinner": 0.262708376209,
-          "menn": 0.190639187144,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.190639187144
         },
         {
           "alder": 49,
           "kvinner": 0.274380627903,
-          "menn": 0.201481481481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.201481481481
         },
         {
           "alder": 50,
           "kvinner": 0.282647149511,
-          "menn": 0.217846535293,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.217846535293
         },
         {
           "alder": 51,
           "kvinner": 0.294241043626,
-          "menn": 0.228401062596,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.228401062596
         },
         {
           "alder": 52,
           "kvinner": 0.302101382895,
-          "menn": 0.23813518005,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.23813518005
         },
         {
           "alder": 53,
           "kvinner": 0.309218026113,
-          "menn": 0.247581813533,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.247581813533
         },
         {
           "alder": 54,
           "kvinner": 0.31510018947,
-          "menn": 0.261789132499,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.261789132499
         },
         {
           "alder": 55,
           "kvinner": 0.323244673035,
-          "menn": 0.276310794516,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276310794516
         },
         {
           "alder": 56,
           "kvinner": 0.328237572317,
-          "menn": 0.287225003445,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.287225003445
         },
         {
           "alder": 57,
           "kvinner": 0.335400898406,
-          "menn": 0.301642749245,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.301642749245
         },
         {
           "alder": 58,
           "kvinner": 0.33775262834,
-          "menn": 0.308635635968,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.308635635968
         },
         {
           "alder": 59,
           "kvinner": 0.342713343739,
-          "menn": 0.315598415282,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.315598415282
         },
         {
           "alder": 60,
           "kvinner": 0.347758548455,
-          "menn": 0.328850786897,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.328850786897
         },
         {
           "alder": 61,
           "kvinner": 0.351115321231,
-          "menn": 0.339169045354,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.339169045354
         },
         {
           "alder": 62,
           "kvinner": 0.356691447377,
-          "menn": 0.346707772482,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.346707772482
         },
         {
           "alder": 63,
           "kvinner": 0.364972239769,
-          "menn": 0.360969135069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.360969135069
         },
         {
           "alder": 64,
           "kvinner": 0.379607170125,
-          "menn": 0.375387881205,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.375387881205
         },
         {
           "alder": 65,
           "kvinner": 0.391032289527,
-          "menn": 0.390038515164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.390038515164
         },
         {
           "alder": 66,
           "kvinner": 0.405949776636,
-          "menn": 0.403092057029,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.403092057029
         },
         {
           "alder": 67,
           "kvinner": 0.416846324136,
-          "menn": 0.414046993579,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414046993579
         },
         {
           "alder": 68,
           "kvinner": 0.425295395149,
-          "menn": 0.42328121048,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.42328121048
         },
         {
           "alder": 69,
           "kvinner": 0.435711777145,
-          "menn": 0.428865590587,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.428865590587
         },
         {
           "alder": 70,
           "kvinner": 0.439565557024,
-          "menn": 0.442725261311,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.442725261311
         },
         {
           "alder": 71,
           "kvinner": 0.438937710963,
-          "menn": 0.439213235686,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.439213235686
         },
         {
           "alder": 72,
           "kvinner": 0.45391213579,
-          "menn": 0.457308521058,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.457308521058
         },
         {
           "alder": 73,
           "kvinner": 0.48277793771,
-          "menn": 0.482416268915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.482416268915
         },
         {
           "alder": 74,
           "kvinner": 0.520934729528,
-          "menn": 0.528094183066,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.528094183066
         },
         {
           "alder": 75,
           "kvinner": 0.55667710769,
-          "menn": 0.565938872934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.565938872934
         },
         {
           "alder": 76,
           "kvinner": 0.607043294094,
-          "menn": 0.620389233237,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.620389233237
         },
         {
           "alder": 77,
           "kvinner": 0.627818498377,
-          "menn": 0.642865734838,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.642865734838
         },
         {
           "alder": 78,
           "kvinner": 0.619107413188,
-          "menn": 0.633364864865,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.633364864865
         },
         {
           "alder": 79,
           "kvinner": 0.612559361423,
-          "menn": 0.646190504736,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.646190504736
         },
         {
           "alder": 80,
           "kvinner": 0.592670100151,
-          "menn": 0.605602733364,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.605602733364
         },
         {
           "alder": 81,
           "kvinner": 0.598949715848,
-          "menn": 0.608864486066,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.608864486066
         },
         {
           "alder": 82,
           "kvinner": 0.611476148314,
-          "menn": 0.628266537319,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.628266537319
         },
         {
           "alder": 83,
           "kvinner": 0.634720350404,
-          "menn": 0.647332682306,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.647332682306
         },
         {
           "alder": 84,
           "kvinner": 0.633817541543,
-          "menn": 0.654115900481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.654115900481
         },
         {
           "alder": 85,
           "kvinner": 0.622146587642,
-          "menn": 0.640838415944,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.640838415944
         },
         {
           "alder": 86,
           "kvinner": 0.607092109662,
-          "menn": 0.636686696388,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.636686696388
         },
         {
           "alder": 87,
           "kvinner": 0.600752199512,
-          "menn": 0.625858248265,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.625858248265
         },
         {
           "alder": 88,
           "kvinner": 0.610192298283,
-          "menn": 0.636683711962,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.636683711962
         },
         {
           "alder": 89,
           "kvinner": 0.622554193391,
-          "menn": 0.653933359621,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.653933359621
         },
         {
           "alder": 90,
           "kvinner": 0.638542248712,
-          "menn": 0.666666666667,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.666666666667
         },
         {
           "alder": 91,
           "kvinner": 0.6453765833,
-          "menn": 0.671455938697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.671455938697
         },
         {
           "alder": 92,
           "kvinner": 0.650528206664,
-          "menn": 0.681303248759,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.681303248759
         },
         {
           "alder": 93,
           "kvinner": 0.638790492325,
-          "menn": 0.688281724347,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.688281724347
         },
         {
           "alder": 94,
           "kvinner": 0.645251931796,
-          "menn": 0.708736272742,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.708736272742
         },
         {
           "alder": 95,
           "kvinner": 0.637167423751,
-          "menn": 0.689991142604,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.689991142604
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/karbamid_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/karbamid_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 5548.33333333,
           "tot_pas": 3905.66666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.4205854741,
-          "borhf": null
+          "prove_pr_pas": 1.4205854741
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 7031.33333333,
           "tot_pas": 4691.66666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.49868561279,
-          "borhf": null
+          "prove_pr_pas": 1.49868561279
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 6302.33333333,
           "tot_pas": 4713,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.33722328312,
-          "borhf": null
+          "prove_pr_pas": 1.33722328312
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 4854,
           "tot_pas": 3337.33333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.45445465441,
-          "borhf": null
+          "prove_pr_pas": 1.45445465441
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 5347.33333333,
           "tot_pas": 3852,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.38819660782,
-          "borhf": null
+          "prove_pr_pas": 1.38819660782
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 8778,
           "tot_pas": 6293,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.39488320356,
-          "borhf": null
+          "prove_pr_pas": 1.39488320356
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 10727.3333333,
           "tot_pas": 8071.33333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.32906582969,
-          "borhf": null
+          "prove_pr_pas": 1.32906582969
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 2923.33333333,
           "tot_pas": 2096.66666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.39427662957,
-          "borhf": null
+          "prove_pr_pas": 1.39427662957
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 8027.66666667,
           "tot_pas": 5489.66666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.46232315259,
-          "borhf": null
+          "prove_pr_pas": 1.46232315259
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 11194.6666667,
           "tot_pas": 7833.66666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.42904557253,
-          "borhf": null
+          "prove_pr_pas": 1.42904557253
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 34689.6666667,
           "tot_pas": 24498.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.41600108851,
-          "borhf": null
+          "prove_pr_pas": 1.41600108851
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 50589.3333333,
           "tot_pas": 33388.3333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.51517995308,
-          "borhf": null
+          "prove_pr_pas": 1.51517995308
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 39051.3333333,
           "tot_pas": 28707,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.36034184461,
-          "borhf": null
+          "prove_pr_pas": 1.36034184461
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 25324,
           "tot_pas": 18076.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.40094783234,
-          "borhf": null
+          "prove_pr_pas": 1.40094783234
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 8629.66666667,
           "tot_pas": 6651.33333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.29743409843,
-          "borhf": null
+          "prove_pr_pas": 1.29743409843
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 11027,
           "tot_pas": 7940,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.38879093199,
-          "borhf": null
+          "prove_pr_pas": 1.38879093199
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 33012,
           "tot_pas": 22533.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.4650295858,
-          "borhf": null
+          "prove_pr_pas": 1.4650295858
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 33475.6666667,
           "tot_pas": 23217.6666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.44181872999,
-          "borhf": null
+          "prove_pr_pas": 1.44181872999
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 47168.3333333,
           "tot_pas": 31139.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.51473468995,
-          "borhf": null
+          "prove_pr_pas": 1.51473468995
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 37300,
           "tot_pas": 24874.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.49953767605,
-          "borhf": null
+          "prove_pr_pas": 1.49953767605
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 24127.6666667,
           "tot_pas": 16710.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.44387704215,
-          "borhf": null
+          "prove_pr_pas": 1.44387704215
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 415130,
           "tot_pas": 288021.666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.44131517883,
-          "borhf": null
+          "prove_pr_pas": 1.44131517883
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 23736,
           "tot_pas": 16641.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.42632801859,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.42632801859
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 24852.6666667,
           "tot_pas": 18212.6666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.36458142685,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.36458142685
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 56835.3333333,
           "tot_pas": 39909.6666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.42409942453,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.42409942453
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 309706,
           "tot_pas": 212883,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.45481790467,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.45481790467
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 415130,
           "tot_pas": 287561.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.44362246199,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44362246199
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.000824304353961,
-          "menn": 0.000956964733035,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000956964733035
         },
         {
           "alder": 1,
           "kvinner": 0.00210636793656,
-          "menn": 0.00232582143472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00232582143472
         },
         {
           "alder": 2,
           "kvinner": 0.00257867443347,
-          "menn": 0.00282025235244,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00282025235244
         },
         {
           "alder": 3,
           "kvinner": 0.00339520774775,
-          "menn": 0.00392694183668,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00392694183668
         },
         {
           "alder": 4,
           "kvinner": 0.00338402548935,
-          "menn": 0.00429140235285,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00429140235285
         },
         {
           "alder": 5,
           "kvinner": 0.00402604536502,
-          "menn": 0.00472796735481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00472796735481
         },
         {
           "alder": 6,
           "kvinner": 0.0049358014549,
-          "menn": 0.00487037503146,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00487037503146
         },
         {
           "alder": 7,
           "kvinner": 0.00519835841313,
-          "menn": 0.00561540082558,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00561540082558
         },
         {
           "alder": 8,
           "kvinner": 0.00598760259207,
-          "menn": 0.00615322816243,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00615322816243
         },
         {
           "alder": 9,
           "kvinner": 0.00626628221666,
-          "menn": 0.00678723544458,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00678723544458
         },
         {
           "alder": 10,
           "kvinner": 0.00735952011896,
-          "menn": 0.00741209706801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00741209706801
         },
         {
           "alder": 11,
           "kvinner": 0.00872525802014,
-          "menn": 0.00804120147114,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00804120147114
         },
         {
           "alder": 12,
           "kvinner": 0.010118652112,
-          "menn": 0.0086227616873,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0086227616873
         },
         {
           "alder": 13,
           "kvinner": 0.0131673939293,
-          "menn": 0.0101903246572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0101903246572
         },
         {
           "alder": 14,
           "kvinner": 0.0181713873168,
-          "menn": 0.0124993863826,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0124993863826
         },
         {
           "alder": 15,
           "kvinner": 0.0222067918259,
-          "menn": 0.014562235928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.014562235928
         },
         {
           "alder": 16,
           "kvinner": 0.0248397435897,
-          "menn": 0.0156112386032,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0156112386032
         },
         {
           "alder": 17,
           "kvinner": 0.0271987486507,
-          "menn": 0.0160874137847,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160874137847
         },
         {
           "alder": 18,
           "kvinner": 0.027129276958,
-          "menn": 0.016500954526,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.016500954526
         },
         {
           "alder": 19,
           "kvinner": 0.0274166968893,
-          "menn": 0.0152930522954,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0152930522954
         },
         {
           "alder": 20,
           "kvinner": 0.0277667891118,
-          "menn": 0.0157605104183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0157605104183
         },
         {
           "alder": 21,
           "kvinner": 0.0284121427645,
-          "menn": 0.0160997576134,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160997576134
         },
         {
           "alder": 22,
           "kvinner": 0.0280130372835,
-          "menn": 0.0161139654367,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0161139654367
         },
         {
           "alder": 23,
           "kvinner": 0.0282170243317,
-          "menn": 0.0163524920634,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0163524920634
         },
         {
           "alder": 24,
           "kvinner": 0.0299331074008,
-          "menn": 0.0177943053783,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0177943053783
         },
         {
           "alder": 25,
           "kvinner": 0.030728003056,
-          "menn": 0.0185053885423,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185053885423
         },
         {
           "alder": 26,
           "kvinner": 0.0310244533017,
-          "menn": 0.0187839549915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0187839549915
         },
         {
           "alder": 27,
           "kvinner": 0.0314193986882,
-          "menn": 0.0191382506245,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0191382506245
         },
         {
           "alder": 28,
           "kvinner": 0.0318812772023,
-          "menn": 0.0200752888325,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0200752888325
         },
         {
           "alder": 29,
           "kvinner": 0.0327296262222,
-          "menn": 0.0199169569401,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0199169569401
         },
         {
           "alder": 30,
           "kvinner": 0.0347041712257,
-          "menn": 0.0214594711792,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0214594711792
         },
         {
           "alder": 31,
           "kvinner": 0.0356551026557,
-          "menn": 0.0221822386535,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0221822386535
         },
         {
           "alder": 32,
           "kvinner": 0.0368608864126,
-          "menn": 0.0225350635732,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0225350635732
         },
         {
           "alder": 33,
           "kvinner": 0.037809148002,
-          "menn": 0.0232606272886,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0232606272886
         },
         {
           "alder": 34,
           "kvinner": 0.0382188315327,
-          "menn": 0.02348047766,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.02348047766
         },
         {
           "alder": 35,
           "kvinner": 0.03826537897,
-          "menn": 0.0235872421071,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0235872421071
         },
         {
           "alder": 36,
           "kvinner": 0.0393072514903,
-          "menn": 0.0248936239675,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0248936239675
         },
         {
           "alder": 37,
           "kvinner": 0.0386045595663,
-          "menn": 0.0253628732567,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0253628732567
         },
         {
           "alder": 38,
           "kvinner": 0.0398557479434,
-          "menn": 0.0258137047904,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0258137047904
         },
         {
           "alder": 39,
           "kvinner": 0.0405101055895,
-          "menn": 0.0263143380325,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0263143380325
         },
         {
           "alder": 40,
           "kvinner": 0.0407594876829,
-          "menn": 0.027927314153,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.027927314153
         },
         {
           "alder": 41,
           "kvinner": 0.041819132253,
-          "menn": 0.0287872772313,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0287872772313
         },
         {
           "alder": 42,
           "kvinner": 0.0411505552953,
-          "menn": 0.0289391230263,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0289391230263
         },
         {
           "alder": 43,
           "kvinner": 0.0417044424297,
-          "menn": 0.028845780257,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.028845780257
         },
         {
           "alder": 44,
           "kvinner": 0.041361912404,
-          "menn": 0.0302837629699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0302837629699
         },
         {
           "alder": 45,
           "kvinner": 0.0421103063439,
-          "menn": 0.0306263806208,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0306263806208
         },
         {
           "alder": 46,
           "kvinner": 0.0431078247434,
-          "menn": 0.0313077439946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0313077439946
         },
         {
           "alder": 47,
           "kvinner": 0.0446468502863,
-          "menn": 0.0332197128879,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0332197128879
         },
         {
           "alder": 48,
           "kvinner": 0.0458617216018,
-          "menn": 0.034435190809,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.034435190809
         },
         {
           "alder": 49,
           "kvinner": 0.0486616826253,
-          "menn": 0.0367448417275,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0367448417275
         },
         {
           "alder": 50,
           "kvinner": 0.0498206780156,
-          "menn": 0.0396032955397,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0396032955397
         },
         {
           "alder": 51,
           "kvinner": 0.0526128901854,
-          "menn": 0.0411106316835,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0411106316835
         },
         {
           "alder": 52,
           "kvinner": 0.053307139625,
-          "menn": 0.0427096821544,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0427096821544
         },
         {
           "alder": 53,
           "kvinner": 0.0556338621367,
-          "menn": 0.0447311232316,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0447311232316
         },
         {
           "alder": 54,
           "kvinner": 0.0563013148074,
-          "menn": 0.0473038600474,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0473038600474
         },
         {
           "alder": 55,
           "kvinner": 0.0575988243938,
-          "menn": 0.0497577151534,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0497577151534
         },
         {
           "alder": 56,
           "kvinner": 0.0588879133039,
-          "menn": 0.0516178294218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0516178294218
         },
         {
           "alder": 57,
           "kvinner": 0.0596394068057,
-          "menn": 0.0547524074773,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0547524074773
         },
         {
           "alder": 58,
           "kvinner": 0.0603795862485,
-          "menn": 0.0552692784003,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0552692784003
         },
         {
           "alder": 59,
           "kvinner": 0.0610072309113,
-          "menn": 0.057006848684,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.057006848684
         },
         {
           "alder": 60,
           "kvinner": 0.0613361693899,
-          "menn": 0.0609117361785,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0609117361785
         },
         {
           "alder": 61,
           "kvinner": 0.0615924633092,
-          "menn": 0.0614272121789,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0614272121789
         },
         {
           "alder": 62,
           "kvinner": 0.0628433570651,
-          "menn": 0.0633485330255,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0633485330255
         },
         {
           "alder": 63,
           "kvinner": 0.0625419728049,
-          "menn": 0.0671645733455,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0671645733455
         },
         {
           "alder": 64,
           "kvinner": 0.0659648790903,
-          "menn": 0.0692270769813,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0692270769813
         },
         {
           "alder": 65,
           "kvinner": 0.0689131733854,
-          "menn": 0.0708527174588,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0708527174588
         },
         {
           "alder": 66,
           "kvinner": 0.0720571473072,
-          "menn": 0.0737709002128,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0737709002128
         },
         {
           "alder": 67,
           "kvinner": 0.0733436545946,
-          "menn": 0.0766783420899,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0766783420899
         },
         {
           "alder": 68,
           "kvinner": 0.0751499981595,
-          "menn": 0.0778792793061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0778792793061
         },
         {
           "alder": 69,
           "kvinner": 0.0774806279749,
-          "menn": 0.0799969829537,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0799969829537
         },
         {
           "alder": 70,
           "kvinner": 0.0787841004687,
-          "menn": 0.0831311512932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0831311512932
         },
         {
           "alder": 71,
           "kvinner": 0.079099195551,
-          "menn": 0.0829135580433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0829135580433
         },
         {
           "alder": 72,
           "kvinner": 0.0815330852319,
-          "menn": 0.0869108716944,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0869108716944
         },
         {
           "alder": 73,
           "kvinner": 0.089771020875,
-          "menn": 0.093378759666,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.093378759666
         },
         {
           "alder": 74,
           "kvinner": 0.0961358831916,
-          "menn": 0.103557930405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103557930405
         },
         {
           "alder": 75,
           "kvinner": 0.104371994529,
-          "menn": 0.112621008387,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112621008387
         },
         {
           "alder": 76,
           "kvinner": 0.116268531744,
-          "menn": 0.127443543843,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127443543843
         },
         {
           "alder": 77,
           "kvinner": 0.117930915891,
-          "menn": 0.131943609113,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131943609113
         },
         {
           "alder": 78,
           "kvinner": 0.119031133747,
-          "menn": 0.13,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13
         },
         {
           "alder": 79,
           "kvinner": 0.120238456098,
-          "menn": 0.135235583263,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.135235583263
         },
         {
           "alder": 80,
           "kvinner": 0.116077131093,
-          "menn": 0.129884561799,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129884561799
         },
         {
           "alder": 81,
           "kvinner": 0.120653190418,
-          "menn": 0.133310455687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133310455687
         },
         {
           "alder": 82,
           "kvinner": 0.124656321357,
-          "menn": 0.140362578063,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140362578063
         },
         {
           "alder": 83,
           "kvinner": 0.133692722372,
-          "menn": 0.147389457907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147389457907
         },
         {
           "alder": 84,
           "kvinner": 0.135596639888,
-          "menn": 0.150506808641,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.150506808641
         },
         {
           "alder": 85,
           "kvinner": 0.136279169845,
-          "menn": 0.151676545543,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151676545543
         },
         {
           "alder": 86,
           "kvinner": 0.134006185222,
-          "menn": 0.151062867481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151062867481
         },
         {
           "alder": 87,
           "kvinner": 0.134545210325,
-          "menn": 0.15337668471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.15337668471
         },
         {
           "alder": 88,
           "kvinner": 0.14177716886,
-          "menn": 0.162628887585,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162628887585
         },
         {
           "alder": 89,
           "kvinner": 0.147465562502,
-          "menn": 0.172318611987,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.172318611987
         },
         {
           "alder": 90,
           "kvinner": 0.150866083069,
-          "menn": 0.173511850914,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173511850914
         },
         {
           "alder": 91,
           "kvinner": 0.160644443647,
-          "menn": 0.173445328618,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173445328618
         },
         {
           "alder": 92,
           "kvinner": 0.164406997134,
-          "menn": 0.181630933433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181630933433
         },
         {
           "alder": 93,
           "kvinner": 0.16376610709,
-          "menn": 0.180813600486,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.180813600486
         },
         {
           "alder": 94,
           "kvinner": 0.168848585478,
-          "menn": 0.200786756269,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.200786756269
         },
         {
           "alder": 95,
           "kvinner": 0.169532770928,
-          "menn": 0.192648361382,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.192648361382
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/kol_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/kol_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 20524.3333333,
           "tot_pas": 15042,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.36446837743,
-          "borhf": null
+          "prove_pr_pas": 1.36446837743
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 55144.3333333,
           "tot_pas": 40618.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.35761062237,
-          "borhf": null
+          "prove_pr_pas": 1.35761062237
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 37366.3333333,
           "tot_pas": 28527,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.30985849663,
-          "borhf": null
+          "prove_pr_pas": 1.30985849663
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 25077.6666667,
           "tot_pas": 18439.6666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.35998481534,
-          "borhf": null
+          "prove_pr_pas": 1.35998481534
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 39083.6666667,
           "tot_pas": 29305.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.33367077665,
-          "borhf": null
+          "prove_pr_pas": 1.33367077665
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 96385.6666667,
           "tot_pas": 71839.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.34167753191,
-          "borhf": null
+          "prove_pr_pas": 1.34167753191
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 84379.3333333,
           "tot_pas": 63074.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.33777606316,
-          "borhf": null
+          "prove_pr_pas": 1.33777606316
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 33006.6666667,
           "tot_pas": 23723.6666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.39129701704,
-          "borhf": null
+          "prove_pr_pas": 1.39129701704
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 148558.666667,
           "tot_pas": 103010.666667,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.44216780139,
-          "borhf": null
+          "prove_pr_pas": 1.44216780139
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 64790,
           "tot_pas": 45304.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.43010602371,
-          "borhf": null
+          "prove_pr_pas": 1.43010602371
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 105672.333333,
           "tot_pas": 77510,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.36333806391,
-          "borhf": null
+          "prove_pr_pas": 1.36333806391
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 154963.333333,
           "tot_pas": 107296.666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.44425114169,
-          "borhf": null
+          "prove_pr_pas": 1.44425114169
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 245938.333333,
           "tot_pas": 174840,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.40664798292,
-          "borhf": null
+          "prove_pr_pas": 1.40664798292
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 104624,
           "tot_pas": 75908,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.37830004743,
-          "borhf": null
+          "prove_pr_pas": 1.37830004743
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 47112.6666667,
           "tot_pas": 35945.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.31067547016,
-          "borhf": null
+          "prove_pr_pas": 1.31067547016
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 51275.6666667,
           "tot_pas": 38019,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.34868530647,
-          "borhf": null
+          "prove_pr_pas": 1.34868530647
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 141206.333333,
           "tot_pas": 100610.666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.40349267142,
-          "borhf": null
+          "prove_pr_pas": 1.40349267142
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 204899.333333,
           "tot_pas": 145539,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.40786547478,
-          "borhf": null
+          "prove_pr_pas": 1.40786547478
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 112526,
           "tot_pas": 78718.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.42947035011,
-          "borhf": null
+          "prove_pr_pas": 1.42947035011
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 59241.6666667,
           "tot_pas": 42903.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.38080661327,
-          "borhf": null
+          "prove_pr_pas": 1.38080661327
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 116289.666667,
           "tot_pas": 80291,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.44835245129,
-          "borhf": null
+          "prove_pr_pas": 1.44835245129
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 1948070.33333,
           "tot_pas": 1396470.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.39499552682,
-          "borhf": null
+          "prove_pr_pas": 1.39499552682
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 138112.666667,
           "tot_pas": 102589.333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.34626731824,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.34626731824
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 219848.666667,
           "tot_pas": 164161.666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.33922048387,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.33922048387
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 352027.666667,
           "tot_pas": 249447.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.41123042673,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41123042673
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 1238081.33333,
           "tot_pas": 877735.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.41054061095,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41054061095
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 1948070.33333,
           "tot_pas": 1393101,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.39836977601,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39836977601
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 0.000623797889484,
-          "menn": 0.000724760055166,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000724760055166
         },
         {
           "alder": 1,
           "kvinner": 0.00187313688476,
-          "menn": 0.00225701014966,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00225701014966
         },
         {
           "alder": 2,
           "kvinner": 0.00280599559565,
-          "menn": 0.00280688622754,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00280688622754
         },
         {
           "alder": 3,
           "kvinner": 0.00363871650015,
-          "menn": 0.00395316515446,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00395316515446
         },
         {
           "alder": 4,
           "kvinner": 0.0046598576799,
-          "menn": 0.00508515045721,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00508515045721
         },
         {
           "alder": 5,
           "kvinner": 0.00610270769973,
-          "menn": 0.00611779936918,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00611779936918
         },
         {
           "alder": 6,
           "kvinner": 0.00780452901191,
-          "menn": 0.00756984646363,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00756984646363
         },
         {
           "alder": 7,
           "kvinner": 0.00921112631099,
-          "menn": 0.00865242776215,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00865242776215
         },
         {
           "alder": 8,
           "kvinner": 0.011386680143,
-          "menn": 0.0113691693446,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0113691693446
         },
         {
           "alder": 9,
           "kvinner": 0.0127854920707,
-          "menn": 0.0133648034218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0133648034218
         },
         {
           "alder": 10,
           "kvinner": 0.014750545033,
-          "menn": 0.0148958663075,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0148958663075
         },
         {
           "alder": 11,
           "kvinner": 0.0168223477163,
-          "menn": 0.0164579371844,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0164579371844
         },
         {
           "alder": 12,
           "kvinner": 0.0220028476507,
-          "menn": 0.0182429996395,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0182429996395
         },
         {
           "alder": 13,
           "kvinner": 0.0337266727574,
-          "menn": 0.0244859290928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0244859290928
         },
         {
           "alder": 14,
           "kvinner": 0.0482937331597,
-          "menn": 0.0342337145943,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0342337145943
         },
         {
           "alder": 15,
           "kvinner": 0.0632328987586,
-          "menn": 0.0447445422546,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0447445422546
         },
         {
           "alder": 16,
           "kvinner": 0.0753400562852,
-          "menn": 0.0529554053216,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0529554053216
         },
         {
           "alder": 17,
           "kvinner": 0.0850930432478,
-          "menn": 0.0594641197476,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0594641197476
         },
         {
           "alder": 18,
           "kvinner": 0.0893064046346,
-          "menn": 0.0602706397432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0602706397432
         },
         {
           "alder": 19,
           "kvinner": 0.0913995940624,
-          "menn": 0.0602785754286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0602785754286
         },
         {
           "alder": 20,
           "kvinner": 0.100216633701,
-          "menn": 0.0628549038872,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0628549038872
         },
         {
           "alder": 21,
           "kvinner": 0.105628715897,
-          "menn": 0.067127316171,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.067127316171
         },
         {
           "alder": 22,
           "kvinner": 0.108315854486,
-          "menn": 0.0709151183058,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0709151183058
         },
         {
           "alder": 23,
           "kvinner": 0.112089821479,
-          "menn": 0.0747365275201,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0747365275201
         },
         {
           "alder": 24,
           "kvinner": 0.115284751918,
-          "menn": 0.0796136981739,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0796136981739
         },
         {
           "alder": 25,
           "kvinner": 0.121499762696,
-          "menn": 0.0852404118853,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0852404118853
         },
         {
           "alder": 26,
           "kvinner": 0.122663385816,
-          "menn": 0.0899901221843,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0899901221843
         },
         {
           "alder": 27,
           "kvinner": 0.124296157948,
-          "menn": 0.0947882065283,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0947882065283
         },
         {
           "alder": 28,
           "kvinner": 0.126836750733,
-          "menn": 0.0987957946404,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0987957946404
         },
         {
           "alder": 29,
           "kvinner": 0.128688033548,
-          "menn": 0.102944581363,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.102944581363
         },
         {
           "alder": 30,
           "kvinner": 0.134808251715,
-          "menn": 0.11015207987,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11015207987
         },
         {
           "alder": 31,
           "kvinner": 0.141404467783,
-          "menn": 0.113654158262,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113654158262
         },
         {
           "alder": 32,
           "kvinner": 0.146485764638,
-          "menn": 0.118364136846,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.118364136846
         },
         {
           "alder": 33,
           "kvinner": 0.150519646529,
-          "menn": 0.121673831131,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.121673831131
         },
         {
           "alder": 34,
           "kvinner": 0.153775192,
-          "menn": 0.124137931034,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124137931034
         },
         {
           "alder": 35,
           "kvinner": 0.157219306312,
-          "menn": 0.126410604299,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126410604299
         },
         {
           "alder": 36,
           "kvinner": 0.15835898855,
-          "menn": 0.131068330957,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131068330957
         },
         {
           "alder": 37,
           "kvinner": 0.162359251193,
-          "menn": 0.136290604643,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136290604643
         },
         {
           "alder": 38,
           "kvinner": 0.16733471604,
-          "menn": 0.139203158847,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.139203158847
         },
         {
           "alder": 39,
           "kvinner": 0.174067682588,
-          "menn": 0.145316257418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145316257418
         },
         {
           "alder": 40,
           "kvinner": 0.183119079438,
-          "menn": 0.156506879914,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.156506879914
         },
         {
           "alder": 41,
           "kvinner": 0.187063394003,
-          "menn": 0.160399040424,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160399040424
         },
         {
           "alder": 42,
           "kvinner": 0.190383577727,
-          "menn": 0.164599319541,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.164599319541
         },
         {
           "alder": 43,
           "kvinner": 0.195221244114,
-          "menn": 0.167096827908,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167096827908
         },
         {
           "alder": 44,
           "kvinner": 0.199599369613,
-          "menn": 0.173650659665,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173650659665
         },
         {
           "alder": 45,
           "kvinner": 0.205546317955,
-          "menn": 0.176093665592,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.176093665592
         },
         {
           "alder": 46,
           "kvinner": 0.209943714822,
-          "menn": 0.184586552998,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.184586552998
         },
         {
           "alder": 47,
           "kvinner": 0.221892555222,
-          "menn": 0.195759207666,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.195759207666
         },
         {
           "alder": 48,
           "kvinner": 0.233711723227,
-          "menn": 0.205684637478,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.205684637478
         },
         {
           "alder": 49,
           "kvinner": 0.247689633086,
-          "menn": 0.221617326669,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.221617326669
         },
         {
           "alder": 50,
           "kvinner": 0.262134661885,
-          "menn": 0.239742761951,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.239742761951
         },
         {
           "alder": 51,
           "kvinner": 0.273913708523,
-          "menn": 0.250120867752,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.250120867752
         },
         {
           "alder": 52,
           "kvinner": 0.283923979383,
-          "menn": 0.259576520422,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.259576520422
         },
         {
           "alder": 53,
           "kvinner": 0.293140530675,
-          "menn": 0.27081557866,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.27081557866
         },
         {
           "alder": 54,
           "kvinner": 0.303875523913,
-          "menn": 0.286044024402,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.286044024402
         },
         {
           "alder": 55,
           "kvinner": 0.313146216018,
-          "menn": 0.300405296771,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.300405296771
         },
         {
           "alder": 56,
           "kvinner": 0.32028722291,
-          "menn": 0.310746107564,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.310746107564
         },
         {
           "alder": 57,
           "kvinner": 0.329450495354,
-          "menn": 0.326620326662,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.326620326662
         },
         {
           "alder": 58,
           "kvinner": 0.335114868175,
-          "menn": 0.333337360679,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.333337360679
         },
         {
           "alder": 59,
           "kvinner": 0.339992992068,
-          "menn": 0.339350757041,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.339350757041
         },
         {
           "alder": 60,
           "kvinner": 0.347146218054,
-          "menn": 0.354400675824,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.354400675824
         },
         {
           "alder": 61,
           "kvinner": 0.352503795596,
-          "menn": 0.364630510625,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.364630510625
         },
         {
           "alder": 62,
           "kvinner": 0.357451913622,
-          "menn": 0.371306765045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.371306765045
         },
         {
           "alder": 63,
           "kvinner": 0.365936367565,
-          "menn": 0.383256071952,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.383256071952
         },
         {
           "alder": 64,
           "kvinner": 0.378951778004,
-          "menn": 0.397068665959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.397068665959
         },
         {
           "alder": 65,
           "kvinner": 0.391307035559,
-          "menn": 0.410731788125,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.410731788125
         },
         {
           "alder": 66,
           "kvinner": 0.405553313652,
-          "menn": 0.419150253757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.419150253757
         },
         {
           "alder": 67,
           "kvinner": 0.414039326899,
-          "menn": 0.429378283713,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.429378283713
         },
         {
           "alder": 68,
           "kvinner": 0.421246365075,
-          "menn": 0.434075253299,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.434075253299
         },
         {
           "alder": 69,
           "kvinner": 0.42602763269,
-          "menn": 0.435616231709,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.435616231709
         },
         {
           "alder": 70,
           "kvinner": 0.425557324841,
-          "menn": 0.446440833143,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.446440833143
         },
         {
           "alder": 71,
           "kvinner": 0.420253973919,
-          "menn": 0.435646733373,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.435646733373
         },
         {
           "alder": 72,
           "kvinner": 0.42796738374,
-          "menn": 0.449159647405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.449159647405
         },
         {
           "alder": 73,
           "kvinner": 0.449819882204,
-          "menn": 0.467747574868,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.467747574868
         },
         {
           "alder": 74,
           "kvinner": 0.473534568933,
-          "menn": 0.503801207698,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.503801207698
         },
         {
           "alder": 75,
           "kvinner": 0.497595623594,
-          "menn": 0.533368835467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.533368835467
         },
         {
           "alder": 76,
           "kvinner": 0.531783480274,
-          "menn": 0.572547787265,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.572547787265
         },
         {
           "alder": 77,
           "kvinner": 0.535498570599,
-          "menn": 0.583840546587,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.583840546587
         },
         {
           "alder": 78,
           "kvinner": 0.514780608593,
-          "menn": 0.559581081081,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.559581081081
         },
         {
           "alder": 79,
           "kvinner": 0.495768919875,
-          "menn": 0.564665507733,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.564665507733
         },
         {
           "alder": 80,
           "kvinner": 0.461278180163,
-          "menn": 0.501177602335,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.501177602335
         },
         {
           "alder": 81,
           "kvinner": 0.448715919718,
-          "menn": 0.491466035725,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.491466035725
         },
         {
           "alder": 82,
           "kvinner": 0.438526181711,
-          "menn": 0.490511125932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.490511125932
         },
         {
           "alder": 83,
           "kvinner": 0.439386792453,
-          "menn": 0.484363999727,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.484363999727
         },
         {
           "alder": 84,
           "kvinner": 0.416730860937,
-          "menn": 0.473610115696,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.473610115696
         },
         {
           "alder": 85,
           "kvinner": 0.384856131291,
-          "menn": 0.439309337686,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.439309337686
         },
         {
           "alder": 86,
           "kvinner": 0.357342861919,
-          "menn": 0.415939781611,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.415939781611
         },
         {
           "alder": 87,
           "kvinner": 0.326938145022,
-          "menn": 0.389617466487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.389617466487
         },
         {
           "alder": 88,
           "kvinner": 0.31100455057,
-          "menn": 0.36863945008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.36863945008
         },
         {
           "alder": 89,
           "kvinner": 0.29495818787,
-          "menn": 0.358438485804,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.358438485804
         },
         {
           "alder": 90,
           "kvinner": 0.278388278388,
-          "menn": 0.339424642663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.339424642663
         },
         {
           "alder": 91,
           "kvinner": 0.265205066561,
-          "menn": 0.31940760389,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.31940760389
         },
         {
           "alder": 92,
           "kvinner": 0.244343697874,
-          "menn": 0.29538432731,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.29538432731
         },
         {
           "alder": 93,
           "kvinner": 0.221058575902,
-          "menn": 0.27941712204,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.27941712204
         },
         {
           "alder": 94,
           "kvinner": 0.202311769589,
-          "menn": 0.276675954762,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276675954762
         },
         {
           "alder": 95,
           "kvinner": 0.189568462038,
-          "menn": 0.248892825509,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.248892825509
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/kreatinin_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/kreatinin_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 40955.6666667,
           "tot_pas": 24489.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.67236521526,
-          "borhf": null
+          "prove_pr_pas": 1.67236521526
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 107210.666667,
           "tot_pas": 65869.6666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.62761817529,
-          "borhf": null
+          "prove_pr_pas": 1.62761817529
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 74903.6666667,
           "tot_pas": 46802.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.6004145063,
-          "borhf": null
+          "prove_pr_pas": 1.6004145063
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 48627.3333333,
           "tot_pas": 28569,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.70210134528,
-          "borhf": null
+          "prove_pr_pas": 1.70210134528
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 79626,
           "tot_pas": 50105.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.58917214402,
-          "borhf": null
+          "prove_pr_pas": 1.58917214402
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 179259,
           "tot_pas": 114609.666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.56408272717,
-          "borhf": null
+          "prove_pr_pas": 1.56408272717
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 165068.333333,
           "tot_pas": 101174.666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.63151843017,
-          "borhf": null
+          "prove_pr_pas": 1.63151843017
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 65311.3333333,
           "tot_pas": 38051,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.71641568772,
-          "borhf": null
+          "prove_pr_pas": 1.71641568772
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 297695.666667,
           "tot_pas": 169037,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.76112724828,
-          "borhf": null
+          "prove_pr_pas": 1.76112724828
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 125711.333333,
           "tot_pas": 69952.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.79709992995,
-          "borhf": null
+          "prove_pr_pas": 1.79709992995
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 210041,
           "tot_pas": 127367.666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.64909199875,
-          "borhf": null
+          "prove_pr_pas": 1.64909199875
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 236290.666667,
           "tot_pas": 139687,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.69157234866,
-          "borhf": null
+          "prove_pr_pas": 1.69157234866
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 383554,
           "tot_pas": 234901,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.63283255499,
-          "borhf": null
+          "prove_pr_pas": 1.63283255499
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 159720.666667,
           "tot_pas": 102751.333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.55443887184,
-          "borhf": null
+          "prove_pr_pas": 1.55443887184
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 72574.6666667,
           "tot_pas": 50815.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.42820408538,
-          "borhf": null
+          "prove_pr_pas": 1.42820408538
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 79780,
           "tot_pas": 51967,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.53520503396,
-          "borhf": null
+          "prove_pr_pas": 1.53520503396
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 251054.333333,
           "tot_pas": 142015,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.76780152331,
-          "borhf": null
+          "prove_pr_pas": 1.76780152331
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 323901.666667,
           "tot_pas": 196406,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.64914344097,
-          "borhf": null
+          "prove_pr_pas": 1.64914344097
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 179264.666667,
           "tot_pas": 104169,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.72090225179,
-          "borhf": null
+          "prove_pr_pas": 1.72090225179
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 110544.666667,
           "tot_pas": 63860.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.73103804657,
-          "borhf": null
+          "prove_pr_pas": 1.73103804657
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 212581,
           "tot_pas": 122234,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.73913150187,
-          "borhf": null
+          "prove_pr_pas": 1.73913150187
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 3403683.66667,
           "tot_pas": 2044840.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.66452268001,
-          "borhf": null
+          "prove_pr_pas": 1.66452268001
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 271697.333333,
           "tot_pas": 165629.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.64039050975,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.64039050975
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 423953.333333,
           "tot_pas": 265730.666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.59542494154,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.59542494154
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 698759.333333,
           "tot_pas": 404159.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.72892044227,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.72892044227
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 2009273.66667,
           "tot_pas": 1204409,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.66826523769,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.66826523769
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 3403683.66667,
           "tot_pas": 2037979,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.67012695747,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.67012695747
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00582953980053,
-          "menn": 0.00727574657322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00727574657322
         },
         {
           "alder": 1,
           "kvinner": 0.0179223486367,
-          "menn": 0.0209736796835,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0209736796835
         },
         {
           "alder": 2,
           "kvinner": 0.0242239113447,
-          "menn": 0.0270530367836,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0270530367836
         },
         {
           "alder": 3,
           "kvinner": 0.0323031753541,
-          "menn": 0.0357292704673,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0357292704673
         },
         {
           "alder": 4,
           "kvinner": 0.0372583935431,
-          "menn": 0.0416427359142,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0416427359142
         },
         {
           "alder": 5,
           "kvinner": 0.0428998244885,
-          "menn": 0.0443540454266,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0443540454266
         },
         {
           "alder": 6,
           "kvinner": 0.0494706435755,
-          "menn": 0.0491064686635,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0491064686635
         },
         {
           "alder": 7,
           "kvinner": 0.0551690443619,
-          "menn": 0.0545983067025,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0545983067025
         },
         {
           "alder": 8,
           "kvinner": 0.0621981410285,
-          "menn": 0.0620983055799,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0620983055799
         },
         {
           "alder": 9,
           "kvinner": 0.0687204390824,
-          "menn": 0.0691663022446,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0691663022446
         },
         {
           "alder": 10,
           "kvinner": 0.0763298173982,
-          "menn": 0.0754469058526,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0754469058526
         },
         {
           "alder": 11,
           "kvinner": 0.083602922239,
-          "menn": 0.078778738801,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.078778738801
         },
         {
           "alder": 12,
           "kvinner": 0.100522069293,
-          "menn": 0.0804710972239,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0804710972239
         },
         {
           "alder": 13,
           "kvinner": 0.133207260275,
-          "menn": 0.0947250798586,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0947250798586
         },
         {
           "alder": 14,
           "kvinner": 0.173546740237,
-          "menn": 0.11466668303,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11466668303
         },
         {
           "alder": 15,
           "kvinner": 0.201223904424,
-          "menn": 0.127280375624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127280375624
         },
         {
           "alder": 16,
           "kvinner": 0.222352511987,
-          "menn": 0.130186689822,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.130186689822
         },
         {
           "alder": 17,
           "kvinner": 0.237032440713,
-          "menn": 0.136324169642,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136324169642
         },
         {
           "alder": 18,
           "kvinner": 0.24189098358,
-          "menn": 0.133609553691,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133609553691
         },
         {
           "alder": 19,
           "kvinner": 0.234209471454,
-          "menn": 0.129719875606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129719875606
         },
         {
           "alder": 20,
           "kvinner": 0.240369219177,
-          "menn": 0.128797581244,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128797581244
         },
         {
           "alder": 21,
           "kvinner": 0.245300142616,
-          "menn": 0.131032383316,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131032383316
         },
         {
           "alder": 22,
           "kvinner": 0.247017385083,
-          "menn": 0.136020323305,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.136020323305
         },
         {
           "alder": 23,
           "kvinner": 0.251226236946,
-          "menn": 0.141499805462,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141499805462
         },
         {
           "alder": 24,
           "kvinner": 0.253801522383,
-          "menn": 0.145529222401,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145529222401
         },
         {
           "alder": 25,
           "kvinner": 0.26284626159,
-          "menn": 0.149886557005,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.149886557005
         },
         {
           "alder": 26,
           "kvinner": 0.265369067395,
-          "menn": 0.152252571453,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.152252571453
         },
         {
           "alder": 27,
           "kvinner": 0.265921059175,
-          "menn": 0.157008644955,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157008644955
         },
         {
           "alder": 28,
           "kvinner": 0.269587039356,
-          "menn": 0.159562409659,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.159562409659
         },
         {
           "alder": 29,
           "kvinner": 0.273492158583,
-          "menn": 0.162973291417,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.162973291417
         },
         {
           "alder": 30,
           "kvinner": 0.283728750234,
-          "menn": 0.170679455279,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170679455279
         },
         {
           "alder": 31,
           "kvinner": 0.292670985237,
-          "menn": 0.174097906739,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.174097906739
         },
         {
           "alder": 32,
           "kvinner": 0.301733857285,
-          "menn": 0.176993052825,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.176993052825
         },
         {
           "alder": 33,
           "kvinner": 0.304518423831,
-          "menn": 0.179169983548,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.179169983548
         },
         {
           "alder": 34,
           "kvinner": 0.307335321716,
-          "menn": 0.180297866631,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.180297866631
         },
         {
           "alder": 35,
           "kvinner": 0.304815155375,
-          "menn": 0.180546582246,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.180546582246
         },
         {
           "alder": 36,
           "kvinner": 0.303406090376,
-          "menn": 0.184653556932,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.184653556932
         },
         {
           "alder": 37,
           "kvinner": 0.301549974515,
-          "menn": 0.188989201242,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.188989201242
         },
         {
           "alder": 38,
           "kvinner": 0.304088695206,
-          "menn": 0.190682497464,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.190682497464
         },
         {
           "alder": 39,
           "kvinner": 0.305571967592,
-          "menn": 0.195981423875,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.195981423875
         },
         {
           "alder": 40,
           "kvinner": 0.312363257921,
-          "menn": 0.20571055218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.20571055218
         },
         {
           "alder": 41,
           "kvinner": 0.31505132348,
-          "menn": 0.207835418193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.207835418193
         },
         {
           "alder": 42,
           "kvinner": 0.313894538361,
-          "menn": 0.211183292323,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.211183292323
         },
         {
           "alder": 43,
           "kvinner": 0.312134062527,
-          "menn": 0.211805844642,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.211805844642
         },
         {
           "alder": 44,
           "kvinner": 0.311816287299,
-          "menn": 0.217368902823,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.217368902823
         },
         {
           "alder": 45,
           "kvinner": 0.314201166756,
-          "menn": 0.218791953488,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.218791953488
         },
         {
           "alder": 46,
           "kvinner": 0.317553250193,
-          "menn": 0.226267218209,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.226267218209
         },
         {
           "alder": 47,
           "kvinner": 0.328535587674,
-          "menn": 0.239464168054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.239464168054
         },
         {
           "alder": 48,
           "kvinner": 0.340675469287,
-          "menn": 0.250218758686,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.250218758686
         },
         {
           "alder": 49,
           "kvinner": 0.353151087501,
-          "menn": 0.264682814302,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.264682814302
         },
         {
           "alder": 50,
           "kvinner": 0.365043302337,
-          "menn": 0.284826570934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.284826570934
         },
         {
           "alder": 51,
           "kvinner": 0.379330689305,
-          "menn": 0.297916915767,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.297916915767
         },
         {
           "alder": 52,
           "kvinner": 0.387304512896,
-          "menn": 0.308477455138,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.308477455138
         },
         {
           "alder": 53,
           "kvinner": 0.395501895269,
-          "menn": 0.320271220385,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.320271220385
         },
         {
           "alder": 54,
           "kvinner": 0.404880289372,
-          "menn": 0.338477152929,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.338477152929
         },
         {
           "alder": 55,
           "kvinner": 0.412631888317,
-          "menn": 0.35515943906,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.35515943906
         },
         {
           "alder": 56,
           "kvinner": 0.418710383565,
-          "menn": 0.36689937078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.36689937078
         },
         {
           "alder": 57,
           "kvinner": 0.425352286013,
-          "menn": 0.383255050982,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.383255050982
         },
         {
           "alder": 58,
           "kvinner": 0.427945184832,
-          "menn": 0.390896185097,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.390896185097
         },
         {
           "alder": 59,
           "kvinner": 0.431299971331,
-          "menn": 0.398421424403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.398421424403
         },
         {
           "alder": 60,
           "kvinner": 0.438106287666,
-          "menn": 0.414298676512,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414298676512
         },
         {
           "alder": 61,
           "kvinner": 0.441203950015,
-          "menn": 0.425061845861,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.425061845861
         },
         {
           "alder": 62,
           "kvinner": 0.446439575712,
-          "menn": 0.433191225886,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.433191225886
         },
         {
           "alder": 63,
           "kvinner": 0.453080222082,
-          "menn": 0.449548978433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.449548978433
         },
         {
           "alder": 64,
           "kvinner": 0.469314811186,
-          "menn": 0.466721651715,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.466721651715
         },
         {
           "alder": 65,
           "kvinner": 0.482824938697,
-          "menn": 0.480935683817,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.480935683817
         },
         {
           "alder": 66,
           "kvinner": 0.498615919405,
-          "menn": 0.494280691015,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.494280691015
         },
         {
           "alder": 67,
           "kvinner": 0.509643627103,
-          "menn": 0.507122008173,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.507122008173
         },
         {
           "alder": 68,
           "kvinner": 0.517458681489,
-          "menn": 0.51449868329,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.51449868329
         },
         {
           "alder": 69,
           "kvinner": 0.52532000269,
-          "menn": 0.518818826369,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.518818826369
         },
         {
           "alder": 70,
           "kvinner": 0.529270820815,
-          "menn": 0.534813458457,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.534813458457
         },
         {
           "alder": 71,
           "kvinner": 0.525494044698,
-          "menn": 0.526988820387,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.526988820387
         },
         {
           "alder": 72,
           "kvinner": 0.540210583643,
-          "menn": 0.547463271303,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.547463271303
         },
         {
           "alder": 73,
           "kvinner": 0.572953542835,
-          "menn": 0.574648528658,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.574648528658
         },
         {
           "alder": 74,
           "kvinner": 0.612957409501,
-          "menn": 0.62457100656,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.62457100656
         },
         {
           "alder": 75,
           "kvinner": 0.65102572021,
-          "menn": 0.668631963331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.668631963331
         },
         {
           "alder": 76,
           "kvinner": 0.70821060927,
-          "menn": 0.728013523471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.728013523471
         },
         {
           "alder": 77,
           "kvinner": 0.724663069879,
-          "menn": 0.747949094233,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.747949094233
         },
         {
           "alder": 78,
           "kvinner": 0.710807036485,
-          "menn": 0.734878378378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.734878378378
         },
         {
           "alder": 79,
           "kvinner": 0.701917247651,
-          "menn": 0.747722095672,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.747722095672
         },
         {
           "alder": 80,
           "kvinner": 0.672233621873,
-          "menn": 0.693607775493,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.693607775493
         },
         {
           "alder": 81,
           "kvinner": 0.674296813179,
-          "menn": 0.695504542417,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.695504542417
         },
         {
           "alder": 82,
           "kvinner": 0.685695201702,
-          "menn": 0.713151033772,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.713151033772
         },
         {
           "alder": 83,
           "kvinner": 0.707900943396,
-          "menn": 0.73090636568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.73090636568
         },
         {
           "alder": 84,
           "kvinner": 0.701496643557,
-          "menn": 0.735230879492,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.735230879492
         },
         {
           "alder": 85,
           "kvinner": 0.683273673298,
-          "menn": 0.713569853678,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.713569853678
         },
         {
           "alder": 86,
           "kvinner": 0.665475593447,
-          "menn": 0.706144601667,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.706144601667
         },
         {
           "alder": 87,
           "kvinner": 0.65253307663,
-          "menn": 0.690195081193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.690195081193
         },
         {
           "alder": 88,
           "kvinner": 0.659318882419,
-          "menn": 0.696873166234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.696873166234
         },
         {
           "alder": 89,
           "kvinner": 0.669887147844,
-          "menn": 0.711257886435,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.711257886435
         },
         {
           "alder": 90,
           "kvinner": 0.68013906997,
-          "menn": 0.725649840179,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.725649840179
         },
         {
           "alder": 91,
           "kvinner": 0.687430478309,
-          "menn": 0.725979958739,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.725979958739
         },
         {
           "alder": 92,
           "kvinner": 0.68940592789,
-          "menn": 0.729238835315,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.729238835315
         },
         {
           "alder": 93,
           "kvinner": 0.670876328354,
-          "menn": 0.729204614451,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.729204614451
         },
         {
           "alder": 94,
           "kvinner": 0.675266619835,
-          "menn": 0.753483035568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.753483035568
         },
         {
           "alder": 95,
           "kvinner": 0.666369240753,
-          "menn": 0.737599645704,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.737599645704
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/laktatd_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/laktatd_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 5770,
           "tot_pas": 4395.66666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.31265640403,
-          "borhf": null
+          "prove_pr_pas": 1.31265640403
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 12135,
           "tot_pas": 9459,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.28290516968,
-          "borhf": null
+          "prove_pr_pas": 1.28290516968
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 8440.66666667,
           "tot_pas": 6593,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.28024672633,
-          "borhf": null
+          "prove_pr_pas": 1.28024672633
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 6753.66666667,
           "tot_pas": 4831,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.39798523425,
-          "borhf": null
+          "prove_pr_pas": 1.39798523425
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 12907,
           "tot_pas": 9603.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.34401249566,
-          "borhf": null
+          "prove_pr_pas": 1.34401249566
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 16311.3333333,
           "tot_pas": 12563,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.29836291756,
-          "borhf": null
+          "prove_pr_pas": 1.29836291756
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 17696.3333333,
           "tot_pas": 13647.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.29665632709,
-          "borhf": null
+          "prove_pr_pas": 1.29665632709
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 8356,
           "tot_pas": 6120.33333333,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.36528511519,
-          "borhf": null
+          "prove_pr_pas": 1.36528511519
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 35899.6666667,
           "tot_pas": 24532,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.46338116202,
-          "borhf": null
+          "prove_pr_pas": 1.46338116202
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 9102.33333333,
           "tot_pas": 6649,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.36897779115,
-          "borhf": null
+          "prove_pr_pas": 1.36897779115
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 35875.3333333,
           "tot_pas": 26592.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.34908557604,
-          "borhf": null
+          "prove_pr_pas": 1.34908557604
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 34315.6666667,
           "tot_pas": 24628,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.3933598614,
-          "borhf": null
+          "prove_pr_pas": 1.3933598614
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 40520,
           "tot_pas": 30878,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.31226115681,
-          "borhf": null
+          "prove_pr_pas": 1.31226115681
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 16543.3333333,
           "tot_pas": 12763.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.29612702724,
-          "borhf": null
+          "prove_pr_pas": 1.29612702724
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 8107.66666667,
           "tot_pas": 6683,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.2131777146,
-          "borhf": null
+          "prove_pr_pas": 1.2131777146
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 8178.33333333,
           "tot_pas": 6362,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.2854972231,
-          "borhf": null
+          "prove_pr_pas": 1.2854972231
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 27565,
           "tot_pas": 20017,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.37707948244,
-          "borhf": null
+          "prove_pr_pas": 1.37707948244
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 31833.6666667,
           "tot_pas": 23759.3333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.3398383793,
-          "borhf": null
+          "prove_pr_pas": 1.3398383793
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 29668,
           "tot_pas": 20710.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.43249855147,
-          "borhf": null
+          "prove_pr_pas": 1.43249855147
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 28305,
           "tot_pas": 20457,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.38363396392,
-          "borhf": null
+          "prove_pr_pas": 1.38363396392
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 15348.6666667,
           "tot_pas": 11533.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.33080924855,
-          "borhf": null
+          "prove_pr_pas": 1.33080924855
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 409635.333333,
           "tot_pas": 302780,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.35291410705,
-          "borhf": null
+          "prove_pr_pas": 1.35291410705
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 33099.3333333,
           "tot_pas": 25273.6666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.30963717176,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.30963717176
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 46914.6666667,
           "tot_pas": 35808.3333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.31016057715,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.31016057715
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 89233.3333333,
           "tot_pas": 63877.3333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.39694831761,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39694831761
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 240388,
           "tot_pas": 177534,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.35403922629,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.35403922629
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 409635.333333,
           "tot_pas": 302385.666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.35467840738,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.35467840738
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00111392480265,
-          "menn": 0.00136508204565,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00136508204565
         },
         {
           "alder": 1,
           "kvinner": 0.00282792650306,
-          "menn": 0.00343368312403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00343368312403
         },
         {
           "alder": 2,
           "kvinner": 0.00341692121901,
-          "menn": 0.00424374465355,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00424374465355
         },
         {
           "alder": 3,
           "kvinner": 0.00400745832522,
-          "menn": 0.0053757801437,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0053757801437
         },
         {
           "alder": 4,
           "kvinner": 0.00491229506519,
-          "menn": 0.00613702802641,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00613702802641
         },
         {
           "alder": 5,
           "kvinner": 0.00554669810689,
-          "menn": 0.00603529792541,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00603529792541
         },
         {
           "alder": 6,
           "kvinner": 0.00585670937736,
-          "menn": 0.00655046564309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00655046564309
         },
         {
           "alder": 7,
           "kvinner": 0.00700280112045,
-          "menn": 0.00682401358605,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00682401358605
         },
         {
           "alder": 8,
           "kvinner": 0.00743972416087,
-          "menn": 0.00797911189015,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00797911189015
         },
         {
           "alder": 9,
           "kvinner": 0.00838455117991,
-          "menn": 0.00887192912042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00887192912042
         },
         {
           "alder": 10,
           "kvinner": 0.009514448099,
-          "menn": 0.00958018025551,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00958018025551
         },
         {
           "alder": 11,
           "kvinner": 0.0104464392279,
-          "menn": 0.0102228765923,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0102228765923
         },
         {
           "alder": 12,
           "kvinner": 0.0123334915361,
-          "menn": 0.0113087369307,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0113087369307
         },
         {
           "alder": 13,
           "kvinner": 0.016317090779,
-          "menn": 0.0132632115919,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0132632115919
         },
         {
           "alder": 14,
           "kvinner": 0.0223097451236,
-          "menn": 0.0170278827745,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0170278827745
         },
         {
           "alder": 15,
           "kvinner": 0.0282419514981,
-          "menn": 0.0185337548175,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185337548175
         },
         {
           "alder": 16,
           "kvinner": 0.0328460496143,
-          "menn": 0.0204552502636,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0204552502636
         },
         {
           "alder": 17,
           "kvinner": 0.0367842392042,
-          "menn": 0.0225382771609,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0225382771609
         },
         {
           "alder": 18,
           "kvinner": 0.038261370547,
-          "menn": 0.0227881795352,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0227881795352
         },
         {
           "alder": 19,
           "kvinner": 0.0375015111315,
-          "menn": 0.0226982973298,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0226982973298
         },
         {
           "alder": 20,
           "kvinner": 0.0373614643182,
-          "menn": 0.0213337076089,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0213337076089
         },
         {
           "alder": 21,
           "kvinner": 0.0371419928013,
-          "menn": 0.0209302592733,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0209302592733
         },
         {
           "alder": 22,
           "kvinner": 0.037760424629,
-          "menn": 0.0219010947699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0219010947699
         },
         {
           "alder": 23,
           "kvinner": 0.037857991807,
-          "menn": 0.0223239710617,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0223239710617
         },
         {
           "alder": 24,
           "kvinner": 0.0381778716206,
-          "menn": 0.0226230782039,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0226230782039
         },
         {
           "alder": 25,
           "kvinner": 0.0385243150011,
-          "menn": 0.0232667219338,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0232667219338
         },
         {
           "alder": 26,
           "kvinner": 0.0405665137745,
-          "menn": 0.0238302304108,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0238302304108
         },
         {
           "alder": 27,
           "kvinner": 0.0397411740003,
-          "menn": 0.0245354062918,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245354062918
         },
         {
           "alder": 28,
           "kvinner": 0.0407377897744,
-          "menn": 0.025539968595,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.025539968595
         },
         {
           "alder": 29,
           "kvinner": 0.0424805836667,
-          "menn": 0.0254377254228,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0254377254228
         },
         {
           "alder": 30,
           "kvinner": 0.0432067465507,
-          "menn": 0.026611396182,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.026611396182
         },
         {
           "alder": 31,
           "kvinner": 0.0453557439848,
-          "menn": 0.0275229833504,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0275229833504
         },
         {
           "alder": 32,
           "kvinner": 0.0469914730125,
-          "menn": 0.027657622231,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.027657622231
         },
         {
           "alder": 33,
           "kvinner": 0.0464680709165,
-          "menn": 0.0290399617895,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0290399617895
         },
         {
           "alder": 34,
           "kvinner": 0.0474551906414,
-          "menn": 0.0285361599356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0285361599356
         },
         {
           "alder": 35,
           "kvinner": 0.0470378598802,
-          "menn": 0.0282713098161,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0282713098161
         },
         {
           "alder": 36,
           "kvinner": 0.0473554948286,
-          "menn": 0.0290670468272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0290670468272
         },
         {
           "alder": 37,
           "kvinner": 0.04697419026,
-          "menn": 0.0301775018581,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0301775018581
         },
         {
           "alder": 38,
           "kvinner": 0.0464507935028,
-          "menn": 0.0298171049384,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0298171049384
         },
         {
           "alder": 39,
           "kvinner": 0.0472959138904,
-          "menn": 0.031256204911,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.031256204911
         },
         {
           "alder": 40,
           "kvinner": 0.0481627777712,
-          "menn": 0.0323557005004,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0323557005004
         },
         {
           "alder": 41,
           "kvinner": 0.0482048662263,
-          "menn": 0.0327575505091,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0327575505091
         },
         {
           "alder": 42,
           "kvinner": 0.0479516629212,
-          "menn": 0.0327674052318,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0327674052318
         },
         {
           "alder": 43,
           "kvinner": 0.0482905857924,
-          "menn": 0.032520189826,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.032520189826
         },
         {
           "alder": 44,
           "kvinner": 0.0475387785969,
-          "menn": 0.0337150092359,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0337150092359
         },
         {
           "alder": 45,
           "kvinner": 0.0481019079559,
-          "menn": 0.0342420692864,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0342420692864
         },
         {
           "alder": 46,
           "kvinner": 0.0483445535813,
-          "menn": 0.0346778934991,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0346778934991
         },
         {
           "alder": 47,
           "kvinner": 0.0504063266976,
-          "menn": 0.0360316892092,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0360316892092
         },
         {
           "alder": 48,
           "kvinner": 0.0524420229417,
-          "menn": 0.0378838571532,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0378838571532
         },
         {
           "alder": 49,
           "kvinner": 0.0532097549423,
-          "menn": 0.0393387158785,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0393387158785
         },
         {
           "alder": 50,
           "kvinner": 0.0570530609154,
-          "menn": 0.0422686536326,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0422686536326
         },
         {
           "alder": 51,
           "kvinner": 0.0594524020234,
-          "menn": 0.0438970882569,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0438970882569
         },
         {
           "alder": 52,
           "kvinner": 0.0614687606918,
-          "menn": 0.0451526319376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0451526319376
         },
         {
           "alder": 53,
           "kvinner": 0.0631363189667,
-          "menn": 0.0461266405318,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0461266405318
         },
         {
           "alder": 54,
           "kvinner": 0.0634495033588,
-          "menn": 0.049704794229,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.049704794229
         },
         {
           "alder": 55,
           "kvinner": 0.064922850845,
-          "menn": 0.0517562860078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0517562860078
         },
         {
           "alder": 56,
           "kvinner": 0.0664172911079,
-          "menn": 0.0528693795067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0528693795067
         },
         {
           "alder": 57,
           "kvinner": 0.06714663713,
-          "menn": 0.0553365747734,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0553365747734
         },
         {
           "alder": 58,
           "kvinner": 0.0677527539472,
-          "menn": 0.0570332558069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0570332558069
         },
         {
           "alder": 59,
           "kvinner": 0.0673717070685,
-          "menn": 0.0588188323454,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0588188323454
         },
         {
           "alder": 60,
           "kvinner": 0.0666731122498,
-          "menn": 0.0597853634117,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0597853634117
         },
         {
           "alder": 61,
           "kvinner": 0.0684959059471,
-          "menn": 0.0607548366635,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0607548366635
         },
         {
           "alder": 62,
           "kvinner": 0.0679437254979,
-          "menn": 0.0615039310661,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0615039310661
         },
         {
           "alder": 63,
           "kvinner": 0.0685993550317,
-          "menn": 0.0651372875312,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0651372875312
         },
         {
           "alder": 64,
           "kvinner": 0.0723228583204,
-          "menn": 0.0666243011378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0666243011378
         },
         {
           "alder": 65,
           "kvinner": 0.072931334098,
-          "menn": 0.068540427118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.068540427118
         },
         {
           "alder": 66,
           "kvinner": 0.076156291372,
-          "menn": 0.0704895045164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0704895045164
         },
         {
           "alder": 67,
           "kvinner": 0.0766860069741,
-          "menn": 0.0743067717455,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0743067717455
         },
         {
           "alder": 68,
           "kvinner": 0.0787205064969,
-          "menn": 0.0749557377293,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0749557377293
         },
         {
           "alder": 69,
           "kvinner": 0.0788704820402,
-          "menn": 0.0759315130487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0759315130487
         },
         {
           "alder": 70,
           "kvinner": 0.0805642350679,
-          "menn": 0.0769283588922,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0769283588922
         },
         {
           "alder": 71,
           "kvinner": 0.0798426789193,
-          "menn": 0.0771370436134,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0771370436134
         },
         {
           "alder": 72,
           "kvinner": 0.0823121842002,
-          "menn": 0.0797257590597,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0797257590597
         },
         {
           "alder": 73,
           "kvinner": 0.0872345888413,
-          "menn": 0.0844100404121,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0844100404121
         },
         {
           "alder": 74,
           "kvinner": 0.0937105681464,
-          "menn": 0.0933663495373,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0933663495373
         },
         {
           "alder": 75,
           "kvinner": 0.0991838355318,
-          "menn": 0.1001635634,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.1001635634
         },
         {
           "alder": 76,
           "kvinner": 0.106683741319,
-          "menn": 0.109477265832,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.109477265832
         },
         {
           "alder": 77,
           "kvinner": 0.10991337618,
-          "menn": 0.114393629562,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114393629562
         },
         {
           "alder": 78,
           "kvinner": 0.10875101217,
-          "menn": 0.111121621622,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111121621622
         },
         {
           "alder": 79,
           "kvinner": 0.1061937961,
-          "menn": 0.11400011989,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11400011989
         },
         {
           "alder": 80,
           "kvinner": 0.102053296009,
-          "menn": 0.107626219067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107626219067
         },
         {
           "alder": 81,
           "kvinner": 0.103503345083,
-          "menn": 0.107284122311,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107284122311
         },
         {
           "alder": 82,
           "kvinner": 0.107119002128,
-          "menn": 0.112067745912,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112067745912
         },
         {
           "alder": 83,
           "kvinner": 0.108271563342,
-          "menn": 0.114936524879,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114936524879
         },
         {
           "alder": 84,
           "kvinner": 0.108359928102,
-          "menn": 0.115234974916,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115234974916
         },
         {
           "alder": 85,
           "kvinner": 0.103612855271,
-          "menn": 0.113306416974,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113306416974
         },
         {
           "alder": 86,
           "kvinner": 0.102202440655,
-          "menn": 0.111423402468,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111423402468
         },
         {
           "alder": 87,
           "kvinner": 0.0971814905192,
-          "menn": 0.10996476187,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.10996476187
         },
         {
           "alder": 88,
           "kvinner": 0.0982042374125,
-          "menn": 0.110612792355,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.110612792355
         },
         {
           "alder": 89,
           "kvinner": 0.0960461151254,
-          "menn": 0.111001577287,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111001577287
         },
         {
           "alder": 90,
           "kvinner": 0.0963245793754,
-          "menn": 0.111754417707,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111754417707
         },
         {
           "alder": 91,
           "kvinner": 0.0962359611037,
-          "menn": 0.11398467433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11398467433
         },
         {
           "alder": 92,
           "kvinner": 0.0950344296651,
-          "menn": 0.106169834285,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106169834285
         },
         {
           "alder": 93,
           "kvinner": 0.094614713281,
-          "menn": 0.116089860352,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.116089860352
         },
         {
           "alder": 94,
           "kvinner": 0.0924069225366,
-          "menn": 0.111457138174,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111457138174
         },
         {
           "alder": 95,
           "kvinner": 0.0899578195977,
-          "menn": 0.11315323295,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.11315323295
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/laktose_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/laktose_rb1.json
@@ -234,8 +234,7 @@
           "prove_pr_pas": 1.01608579088,
           "antsnitt_i_int": 91,
           "antsnitt_prove": 717,
-          "ratesnitt_andel_int": 0.127201147267,
-          "borhf": null
+          "ratesnitt_andel_int": 0.127201147267
         },
         {
           "bohf": "UNN",
@@ -250,8 +249,7 @@
           "prove_pr_pas": 1.01788565953,
           "antsnitt_i_int": 291,
           "antsnitt_prove": 2321,
-          "ratesnitt_andel_int": 0.125874277609,
-          "borhf": null
+          "ratesnitt_andel_int": 0.125874277609
         },
         {
           "bohf": "Nordland",
@@ -266,8 +264,7 @@
           "prove_pr_pas": 1.00814566363,
           "antsnitt_i_int": 88,
           "antsnitt_prove": 965,
-          "ratesnitt_andel_int": 0.0923980013054,
-          "borhf": null
+          "ratesnitt_andel_int": 0.0923980013054
         },
         {
           "bohf": "Helgeland",
@@ -282,8 +279,7 @@
           "prove_pr_pas": 1.01674277017,
           "antsnitt_i_int": 50,
           "antsnitt_prove": 529,
-          "ratesnitt_andel_int": 0.0939749359616,
-          "borhf": null
+          "ratesnitt_andel_int": 0.0939749359616
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -298,8 +294,7 @@
           "prove_pr_pas": 1.01808721506,
           "antsnitt_i_int": 231,
           "antsnitt_prove": 1202,
-          "ratesnitt_andel_int": 0.190348226573,
-          "borhf": null
+          "ratesnitt_andel_int": 0.190348226573
         },
         {
           "bohf": "St. Olav",
@@ -314,8 +309,7 @@
           "prove_pr_pas": 1.01355181577,
           "antsnitt_i_int": 449,
           "antsnitt_prove": 3379,
-          "ratesnitt_andel_int": 0.132071010352,
-          "borhf": null
+          "ratesnitt_andel_int": 0.132071010352
         },
         {
           "bohf": "Møre og Romsdal",
@@ -330,8 +324,7 @@
           "prove_pr_pas": 1.00953743443,
           "antsnitt_i_int": 124,
           "antsnitt_prove": 1278,
-          "ratesnitt_andel_int": 0.0967991005622,
-          "borhf": null
+          "ratesnitt_andel_int": 0.0967991005622
         },
         {
           "bohf": "Førde",
@@ -346,8 +339,7 @@
           "prove_pr_pas": 1.00354452813,
           "antsnitt_i_int": 35,
           "antsnitt_prove": 810,
-          "ratesnitt_andel_int": 0.044001565528,
-          "borhf": null
+          "ratesnitt_andel_int": 0.044001565528
         },
         {
           "bohf": "Bergen",
@@ -362,8 +354,7 @@
           "prove_pr_pas": 1.00456773619,
           "antsnitt_i_int": 76,
           "antsnitt_prove": 2635,
-          "ratesnitt_andel_int": 0.0280683049081,
-          "borhf": null
+          "ratesnitt_andel_int": 0.0280683049081
         },
         {
           "bohf": "Fonna",
@@ -378,8 +369,7 @@
           "prove_pr_pas": 1.01120667188,
           "antsnitt_i_int": 103,
           "antsnitt_prove": 1469,
-          "ratesnitt_andel_int": 0.0693030284406,
-          "borhf": null
+          "ratesnitt_andel_int": 0.0693030284406
         },
         {
           "bohf": "Stavanger",
@@ -394,8 +384,7 @@
           "prove_pr_pas": 1.01581231154,
           "antsnitt_i_int": 614,
           "antsnitt_prove": 4930,
-          "ratesnitt_andel_int": 0.124554322227,
-          "borhf": null
+          "ratesnitt_andel_int": 0.124554322227
         },
         {
           "bohf": "Østfold",
@@ -410,8 +399,7 @@
           "prove_pr_pas": 1.02188449848,
           "antsnitt_i_int": 357,
           "antsnitt_prove": 2391,
-          "ratesnitt_andel_int": 0.148985322826,
-          "borhf": null
+          "ratesnitt_andel_int": 0.148985322826
         },
         {
           "bohf": "Akershus",
@@ -426,8 +414,7 @@
           "prove_pr_pas": 1.02186908588,
           "antsnitt_i_int": 1734,
           "antsnitt_prove": 9909,
-          "ratesnitt_andel_int": 0.1749939595,
-          "borhf": null
+          "ratesnitt_andel_int": 0.1749939595
         },
         {
           "bohf": "OUS",
@@ -442,8 +429,7 @@
           "prove_pr_pas": 1.02711714804,
           "antsnitt_i_int": 1151,
           "antsnitt_prove": 5899,
-          "ratesnitt_andel_int": 0.193882687846,
-          "borhf": null
+          "ratesnitt_andel_int": 0.193882687846
         },
         {
           "bohf": "Lovisenberg",
@@ -458,8 +444,7 @@
           "prove_pr_pas": 1.02332724556,
           "antsnitt_i_int": 630,
           "antsnitt_prove": 3526,
-          "ratesnitt_andel_int": 0.185858276798,
-          "borhf": null
+          "ratesnitt_andel_int": 0.185858276798
         },
         {
           "bohf": "Diakonhjemmet",
@@ -474,8 +459,7 @@
           "prove_pr_pas": 1.02475722975,
           "antsnitt_i_int": 521,
           "antsnitt_prove": 2813,
-          "ratesnitt_andel_int": 0.186085872076,
-          "borhf": null
+          "ratesnitt_andel_int": 0.186085872076
         },
         {
           "bohf": "Innlandet",
@@ -490,8 +474,7 @@
           "prove_pr_pas": 1.02266639192,
           "antsnitt_i_int": 226,
           "antsnitt_prove": 1529,
-          "ratesnitt_andel_int": 0.148574957161,
-          "borhf": null
+          "ratesnitt_andel_int": 0.148574957161
         },
         {
           "bohf": "Vestre Viken",
@@ -506,8 +489,7 @@
           "prove_pr_pas": 1.02233346169,
           "antsnitt_i_int": 1020,
           "antsnitt_prove": 6021,
-          "ratesnitt_andel_int": 0.169360380582,
-          "borhf": null
+          "ratesnitt_andel_int": 0.169360380582
         },
         {
           "bohf": "Vestfold",
@@ -522,8 +504,7 @@
           "prove_pr_pas": 1.02661216318,
           "antsnitt_i_int": 600,
           "antsnitt_prove": 3588,
-          "ratesnitt_andel_int": 0.166218471747,
-          "borhf": null
+          "ratesnitt_andel_int": 0.166218471747
         },
         {
           "bohf": "Telemark",
@@ -538,8 +519,7 @@
           "prove_pr_pas": 1.02134944612,
           "antsnitt_i_int": 207,
           "antsnitt_prove": 1336,
-          "ratesnitt_andel_int": 0.155186636281,
-          "borhf": null
+          "ratesnitt_andel_int": 0.155186636281
         },
         {
           "bohf": "Sørlandet",
@@ -554,8 +534,7 @@
           "prove_pr_pas": 1.00714932127,
           "antsnitt_i_int": 185,
           "antsnitt_prove": 1429,
-          "ratesnitt_andel_int": 0.128626825045,
-          "borhf": null
+          "ratesnitt_andel_int": 0.128626825045
         },
         {
           "bohf": "Norge",
@@ -570,8 +549,7 @@
           "prove_pr_pas": 1.01946043387,
           "antsnitt_i_int": 8775,
           "antsnitt_prove": 58643,
-          "ratesnitt_andel_int": 0.149634227444,
-          "borhf": null
+          "ratesnitt_andel_int": 0.149634227444
         }
       ]
     },
@@ -590,9 +568,7 @@
           "tot_events": 3903,
           "tot_pas": 3842.66666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.01570090215,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.01570090215
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -604,9 +580,7 @@
           "tot_events": 5889.66666667,
           "tot_pas": 5807.66666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.01411926763,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.01411926763
         },
         {
           "borhf": "Helse Vest",
@@ -618,9 +592,7 @@
           "tot_events": 9658,
           "tot_pas": 9555.33333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.01074443592,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.01074443592
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -632,9 +604,7 @@
           "tot_events": 46905.3333333,
           "tot_pas": 45857.6666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.02284605264,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.02284605264
         },
         {
           "borhf": "Norge",
@@ -646,9 +616,7 @@
           "tot_events": 66356,
           "tot_pas": 65058,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.01995142796,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.01995142796
         }
       ]
     },
@@ -660,674 +628,482 @@
         {
           "alder": 0,
           "kvinner": 0.000683207212292,
-          "menn": 0.000879563173745,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000879563173745
         },
         {
           "alder": 1,
           "kvinner": 0.00274775332901,
-          "menn": 0.00333734732496,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00333734732496
         },
         {
           "alder": 2,
           "kvinner": 0.0032961568516,
-          "menn": 0.00368905047049,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00368905047049
         },
         {
           "alder": 3,
           "kvinner": 0.0116814627223,
-          "menn": 0.0127510882677,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0127510882677
         },
         {
           "alder": 4,
           "kvinner": 0.014429866754,
-          "menn": 0.0141648543827,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0141648543827
         },
         {
           "alder": 5,
           "kvinner": 0.017236297378,
-          "menn": 0.0147994897603,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0147994897603
         },
         {
           "alder": 6,
           "kvinner": 0.0191668102135,
-          "menn": 0.0155298263277,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0155298263277
         },
         {
           "alder": 7,
           "kvinner": 0.0191518467852,
-          "menn": 0.0149062240458,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0149062240458
         },
         {
           "alder": 8,
           "kvinner": 0.0184937597155,
-          "menn": 0.0148992112182,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0148992112182
         },
         {
           "alder": 9,
           "kvinner": 0.0190138351418,
-          "menn": 0.0152637916265,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0152637916265
         },
         {
           "alder": 10,
           "kvinner": 0.0186382367396,
-          "menn": 0.0160485937323,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160485937323
         },
         {
           "alder": 11,
           "kvinner": 0.0160182922616,
-          "menn": 0.0156591818122,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0156591818122
         },
         {
           "alder": 12,
           "kvinner": 0.0146116120867,
-          "menn": 0.0130933781997,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0130933781997
         },
         {
           "alder": 13,
           "kvinner": 0.0147198814232,
-          "menn": 0.013044587225,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.013044587225
         },
         {
           "alder": 14,
           "kvinner": 0.0174752149754,
-          "menn": 0.0129780079525,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0129780079525
         },
         {
           "alder": 15,
           "kvinner": 0.0191437860568,
-          "menn": 0.0119269290014,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0119269290014
         },
         {
           "alder": 16,
           "kvinner": 0.0205792682927,
-          "menn": 0.00994852074676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00994852074676
         },
         {
           "alder": 17,
           "kvinner": 0.0207416312786,
-          "menn": 0.00894560485252,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00894560485252
         },
         {
           "alder": 18,
           "kvinner": 0.0202157283231,
-          "menn": 0.00771449735322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00771449735322
         },
         {
           "alder": 19,
           "kvinner": 0.0207295424612,
-          "menn": 0.00801887354487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00801887354487
         },
         {
           "alder": 20,
           "kvinner": 0.0220212866158,
-          "menn": 0.00822821453008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00822821453008
         },
         {
           "alder": 21,
           "kvinner": 0.0220468843573,
-          "menn": 0.00846055760416,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00846055760416
         },
         {
           "alder": 22,
           "kvinner": 0.0211702979863,
-          "menn": 0.00876043790798,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00876043790798
         },
         {
           "alder": 23,
           "kvinner": 0.0195111945026,
-          "menn": 0.00876268022984,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00876268022984
         },
         {
           "alder": 24,
           "kvinner": 0.0190031760677,
-          "menn": 0.00929122495421,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00929122495421
         },
         {
           "alder": 25,
           "kvinner": 0.0177920288932,
-          "menn": 0.00976809633928,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00976809633928
         },
         {
           "alder": 26,
           "kvinner": 0.0174455853087,
-          "menn": 0.00956108140609,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00956108140609
         },
         {
           "alder": 27,
           "kvinner": 0.0165661901631,
-          "menn": 0.009563844338,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.009563844338
         },
         {
           "alder": 28,
           "kvinner": 0.0149975338352,
-          "menn": 0.00930711396275,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00930711396275
         },
         {
           "alder": 29,
           "kvinner": 0.014714692227,
-          "menn": 0.00941051775856,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00941051775856
         },
         {
           "alder": 30,
           "kvinner": 0.0146673427451,
-          "menn": 0.0095295125804,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0095295125804
         },
         {
           "alder": 31,
           "kvinner": 0.0139403004347,
-          "menn": 0.00901704371633,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00901704371633
         },
         {
           "alder": 32,
           "kvinner": 0.0139179263767,
-          "menn": 0.00933805216935,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00933805216935
         },
         {
           "alder": 33,
           "kvinner": 0.0135663869282,
-          "menn": 0.00884678660511,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00884678660511
         },
         {
           "alder": 34,
           "kvinner": 0.0135772215085,
-          "menn": 0.00865691667785,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00865691667785
         },
         {
           "alder": 35,
           "kvinner": 0.0127589338237,
-          "menn": 0.00846900977732,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00846900977732
         },
         {
           "alder": 36,
           "kvinner": 0.0133003562904,
-          "menn": 0.00852096505643,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00852096505643
         },
         {
           "alder": 37,
           "kvinner": 0.0125341735786,
-          "menn": 0.00802802430814,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00802802430814
         },
         {
           "alder": 38,
           "kvinner": 0.0124676656335,
-          "menn": 0.00750226219529,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00750226219529
         },
         {
           "alder": 39,
           "kvinner": 0.0123899499839,
-          "menn": 0.00737970745913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00737970745913
         },
         {
           "alder": 40,
           "kvinner": 0.0125122698298,
-          "menn": 0.00748302358828,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00748302358828
         },
         {
           "alder": 41,
           "kvinner": 0.0122606092287,
-          "menn": 0.00720800317622,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00720800317622
         },
         {
           "alder": 42,
           "kvinner": 0.011271931645,
-          "menn": 0.00676535376579,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00676535376579
         },
         {
           "alder": 43,
           "kvinner": 0.0110958383295,
-          "menn": 0.00653290039686,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00653290039686
         },
         {
           "alder": 44,
           "kvinner": 0.0107546745022,
-          "menn": 0.00644591950274,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00644591950274
         },
         {
           "alder": 45,
           "kvinner": 0.0103373446439,
-          "menn": 0.00584607649642,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00584607649642
         },
         {
           "alder": 46,
           "kvinner": 0.00940845381304,
-          "menn": 0.0059266336301,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0059266336301
         },
         {
           "alder": 47,
           "kvinner": 0.00961548950095,
-          "menn": 0.00579516153299,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00579516153299
         },
         {
           "alder": 48,
           "kvinner": 0.00954279091431,
-          "menn": 0.00551271888737,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00551271888737
         },
         {
           "alder": 49,
           "kvinner": 0.00898849795202,
-          "menn": 0.00543893374343,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00543893374343
         },
         {
           "alder": 50,
           "kvinner": 0.00914731449776,
-          "menn": 0.00528939280457,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00528939280457
         },
         {
           "alder": 51,
           "kvinner": 0.00915576824325,
-          "menn": 0.00540655753045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00540655753045
         },
         {
           "alder": 52,
           "kvinner": 0.00913284845542,
-          "menn": 0.0049697776706,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0049697776706
         },
         {
           "alder": 53,
           "kvinner": 0.00886705040011,
-          "menn": 0.00506008181353,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00506008181353
         },
         {
           "alder": 54,
           "kvinner": 0.00874433025205,
-          "menn": 0.00527114186247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00527114186247
         },
         {
           "alder": 55,
           "kvinner": 0.00852902277737,
-          "menn": 0.00513040953955,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00513040953955
         },
         {
           "alder": 56,
           "kvinner": 0.00890054245198,
-          "menn": 0.00466173701373,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00466173701373
         },
         {
           "alder": 57,
           "kvinner": 0.0082333394868,
-          "menn": 0.0047559478852,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0047559478852
         },
         {
           "alder": 58,
           "kvinner": 0.00833406604449,
-          "menn": 0.00466366629414,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00466366629414
         },
         {
           "alder": 59,
           "kvinner": 0.00765138725194,
-          "menn": 0.00467430361475,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00467430361475
         },
         {
           "alder": 60,
           "kvinner": 0.00765735279899,
-          "menn": 0.00446794530834,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00446794530834
         },
         {
           "alder": 61,
           "kvinner": 0.00736410469356,
-          "menn": 0.00432603869331,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00432603869331
         },
         {
           "alder": 62,
           "kvinner": 0.00740143439667,
-          "menn": 0.00403103575045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00403103575045
         },
         {
           "alder": 63,
           "kvinner": 0.00740051198511,
-          "menn": 0.00402155394429,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00402155394429
         },
         {
           "alder": 64,
           "kvinner": 0.00695931839219,
-          "menn": 0.00366416755116,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00366416755116
         },
         {
           "alder": 65,
           "kvinner": 0.00708844761623,
-          "menn": 0.00357542207927,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00357542207927
         },
         {
           "alder": 66,
           "kvinner": 0.00651332044829,
-          "menn": 0.0035945874766,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0035945874766
         },
         {
           "alder": 67,
           "kvinner": 0.0063736200136,
-          "menn": 0.00365586690018,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00365586690018
         },
         {
           "alder": 68,
           "kvinner": 0.0061618875842,
-          "menn": 0.00356329876661,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00356329876661
         },
         {
           "alder": 69,
           "kvinner": 0.00639631763396,
-          "menn": 0.00341680494796,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00341680494796
         },
         {
           "alder": 70,
           "kvinner": 0.00618915995674,
-          "menn": 0.00302128633555,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00302128633555
         },
         {
           "alder": 71,
           "kvinner": 0.00587351860939,
-          "menn": 0.00304067184368,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00304067184368
         },
         {
           "alder": 72,
           "kvinner": 0.00561253819854,
-          "menn": 0.00292262487757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00292262487757
         },
         {
           "alder": 73,
           "kvinner": 0.00567195997728,
-          "menn": 0.00314677638373,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00314677638373
         },
         {
           "alder": 74,
           "kvinner": 0.00603870671714,
-          "menn": 0.0031104739563,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0031104739563
         },
         {
           "alder": 75,
           "kvinner": 0.0059205011691,
-          "menn": 0.00334734399665,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00334734399665
         },
         {
           "alder": 76,
           "kvinner": 0.00578239669014,
-          "menn": 0.00351090113129,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00351090113129
         },
         {
           "alder": 77,
           "kvinner": 0.00601852846979,
-          "menn": 0.0036687757115,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0036687757115
         },
         {
           "alder": 78,
           "kvinner": 0.0055273256428,
-          "menn": 0.00324324324324,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00324324324324
         },
         {
           "alder": 79,
           "kvinner": 0.00515307668991,
-          "menn": 0.00298225632418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00298225632418
         },
         {
           "alder": 80,
           "kvinner": 0.00410387422033,
-          "menn": 0.00240496251576,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00240496251576
         },
         {
           "alder": 81,
           "kvinner": 0.00420113660888,
-          "menn": 0.00240215290697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00240215290697
         },
         {
           "alder": 82,
           "kvinner": 0.00389890799509,
-          "menn": 0.00266779845995,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00266779845995
         },
         {
           "alder": 83,
           "kvinner": 0.00419474393531,
-          "menn": 0.00208934208435,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00208934208435
         },
         {
           "alder": 84,
           "kvinner": 0.00381497377206,
-          "menn": 0.0020477116822,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0020477116822
         },
         {
           "alder": 85,
           "kvinner": 0.00311014611819,
-          "menn": 0.00200440970134,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00200440970134
         },
         {
           "alder": 86,
           "kvinner": 0.00273737880308,
-          "menn": 0.00190605414486,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00190605414486
         },
         {
           "alder": 87,
           "kvinner": 0.00268642682845,
-          "menn": 0.00178007047626,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00178007047626
         },
         {
           "alder": 88,
           "kvinner": 0.00274012819886,
-          "menn": 0.00213764774918,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00213764774918
         },
         {
           "alder": 89,
           "kvinner": 0.00211090362913,
-          "menn": 0.00162657728707,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00162657728707
         },
         {
           "alder": 90,
           "kvinner": 0.00235922269821,
-          "menn": 0.00132681985405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00132681985405
         },
         {
           "alder": 91,
           "kvinner": 0.00175822598586,
-          "menn": 0.00132625994695,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00132625994695
         },
         {
           "alder": 92,
           "kvinner": 0.00188186989436,
-          "menn": 0.000936241924913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000936241924913
         },
         {
           "alder": 93,
           "kvinner": 0.00169413214231,
-          "menn": 0.000728597449909,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000728597449909
         },
         {
           "alder": 94,
           "kvinner": 0.00140494284437,
-          "menn": 0.000655630224553,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000655630224553
         },
         {
           "alder": 95,
           "kvinner": 0.000892277741726,
-          "menn": 0.0011071744907,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0011071744907
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/ldl_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/ldl_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 21393,
           "tot_pas": 15213.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.40616989111,
-          "borhf": null
+          "prove_pr_pas": 1.40616989111
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 60917,
           "tot_pas": 43257.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.40824677126,
-          "borhf": null
+          "prove_pr_pas": 1.40824677126
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 45093,
           "tot_pas": 31689.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.42297092607,
-          "borhf": null
+          "prove_pr_pas": 1.42297092607
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 28327.6666667,
           "tot_pas": 19739.6666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.43506307097,
-          "borhf": null
+          "prove_pr_pas": 1.43506307097
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 41052,
           "tot_pas": 30287.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.35541810658,
-          "borhf": null
+          "prove_pr_pas": 1.35541810658
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 97143,
           "tot_pas": 71731.6666667,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.35425544274,
-          "borhf": null
+          "prove_pr_pas": 1.35425544274
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 88707.6666667,
           "tot_pas": 64246.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.38074286989,
-          "borhf": null
+          "prove_pr_pas": 1.38074286989
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 34795.3333333,
           "tot_pas": 24437,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.42387909045,
-          "borhf": null
+          "prove_pr_pas": 1.42387909045
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 156127,
           "tot_pas": 105692.333333,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.47718377555,
-          "borhf": null
+          "prove_pr_pas": 1.47718377555
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 69184.3333333,
           "tot_pas": 46670.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.4823943662,
-          "borhf": null
+          "prove_pr_pas": 1.4823943662
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 107004,
           "tot_pas": 78622.6666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.36098156596,
-          "borhf": null
+          "prove_pr_pas": 1.36098156596
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 141615,
           "tot_pas": 96946.3333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.46075663855,
-          "borhf": null
+          "prove_pr_pas": 1.46075663855
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 255959.666667,
           "tot_pas": 176816.666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.44759920822,
-          "borhf": null
+          "prove_pr_pas": 1.44759920822
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 109122.666667,
           "tot_pas": 76123.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.43349199329,
-          "borhf": null
+          "prove_pr_pas": 1.43349199329
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 49034.3333333,
           "tot_pas": 35951.3333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.3639086172,
-          "borhf": null
+          "prove_pr_pas": 1.3639086172
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 53706.3333333,
           "tot_pas": 38278.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.40303563343,
-          "borhf": null
+          "prove_pr_pas": 1.40303563343
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 144966.333333,
           "tot_pas": 101527.666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.42785053664,
-          "borhf": null
+          "prove_pr_pas": 1.42785053664
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 218481,
           "tot_pas": 148277.666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.47345857884,
-          "borhf": null
+          "prove_pr_pas": 1.47345857884
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 117692.333333,
           "tot_pas": 80333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.4650558716,
-          "borhf": null
+          "prove_pr_pas": 1.4650558716
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 65355,
           "tot_pas": 45549,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.43482842653,
-          "borhf": null
+          "prove_pr_pas": 1.43482842653
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 123984.666667,
           "tot_pas": 83240.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.48947825774,
-          "borhf": null
+          "prove_pr_pas": 1.48947825774
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 2029695,
           "tot_pas": 1414657.66667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.4347605416,
-          "borhf": null
+          "prove_pr_pas": 1.4347605416
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 155730.666667,
           "tot_pas": 109853.333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.417623498,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.417623498
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 226902.666667,
           "tot_pas": 166205.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.36519485937,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.36519485937
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 367110.666667,
           "tot_pas": 255312.666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.43788661745,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.43788661745
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 1279951,
           "tot_pas": 880598.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.45350150182,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.45350150182
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 2029695,
           "tot_pas": 1411072.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.43840606328,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.43840606328
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 0.000616371724133,
-          "menn": 0.000823271130626,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000823271130626
         },
         {
           "alder": 1,
           "kvinner": 0.00174923288849,
-          "menn": 0.00214003096508,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00214003096508
         },
         {
           "alder": 2,
           "kvinner": 0.00279178802302,
-          "menn": 0.00280688622754,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00280688622754
         },
         {
           "alder": 3,
           "kvinner": 0.00377786435867,
-          "menn": 0.00416950752609,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00416950752609
         },
         {
           "alder": 4,
           "kvinner": 0.00512379665827,
-          "menn": 0.00554978349391,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00554978349391
         },
         {
           "alder": 5,
           "kvinner": 0.00689317916907,
-          "menn": 0.00724743452241,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00724743452241
         },
         {
           "alder": 6,
           "kvinner": 0.00918920351403,
-          "menn": 0.00902340800403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00902340800403
         },
         {
           "alder": 7,
           "kvinner": 0.0110351117191,
-          "menn": 0.0107721486036,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107721486036
         },
         {
           "alder": 8,
           "kvinner": 0.0137151922622,
-          "menn": 0.0143027558672,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0143027558672
         },
         {
           "alder": 9,
           "kvinner": 0.0154918177909,
-          "menn": 0.0169411313657,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0169411313657
         },
         {
           "alder": 10,
           "kvinner": 0.0175859765856,
-          "menn": 0.0189990981252,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0189990981252
         },
         {
           "alder": 11,
           "kvinner": 0.0204343155792,
-          "menn": 0.0212623911398,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0212623911398
         },
         {
           "alder": 12,
           "kvinner": 0.0254833096029,
-          "menn": 0.0237231102031,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0237231102031
         },
         {
           "alder": 13,
           "kvinner": 0.0355538802604,
-          "menn": 0.0288766351281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0288766351281
         },
         {
           "alder": 14,
           "kvinner": 0.0476684672606,
-          "menn": 0.0365040989642,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0365040989642
         },
         {
           "alder": 15,
           "kvinner": 0.0582620038028,
-          "menn": 0.0441692287706,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0441692287706
         },
         {
           "alder": 16,
           "kvinner": 0.0682522930999,
-          "menn": 0.0484711282019,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0484711282019
         },
         {
           "alder": 17,
           "kvinner": 0.0767679509802,
-          "menn": 0.0540955339236,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0540955339236
         },
         {
           "alder": 18,
           "kvinner": 0.0808245046891,
-          "menn": 0.0561815345888,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0561815345888
         },
         {
           "alder": 19,
           "kvinner": 0.0826254875387,
-          "menn": 0.0572163904345,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0572163904345
         },
         {
           "alder": 20,
           "kvinner": 0.0903456720354,
-          "menn": 0.06025251905,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.06025251905
         },
         {
           "alder": 21,
           "kvinner": 0.0949726188933,
-          "menn": 0.0645655994762,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0645655994762
         },
         {
           "alder": 22,
           "kvinner": 0.0995957952926,
-          "menn": 0.0692234082546,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0692234082546
         },
         {
           "alder": 23,
           "kvinner": 0.104198466374,
-          "menn": 0.0739527356591,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0739527356591
         },
         {
           "alder": 24,
           "kvinner": 0.108406229115,
-          "menn": 0.0794249875118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0794249875118
         },
         {
           "alder": 25,
           "kvinner": 0.115109912371,
-          "menn": 0.0856712771063,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0856712771063
         },
         {
           "alder": 26,
           "kvinner": 0.117549340333,
-          "menn": 0.0903981189203,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0903981189203
         },
         {
           "alder": 27,
           "kvinner": 0.120809411453,
-          "menn": 0.095480014153,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.095480014153
         },
         {
           "alder": 28,
           "kvinner": 0.123454581917,
-          "menn": 0.0998408951468,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0998408951468
         },
         {
           "alder": 29,
           "kvinner": 0.126601981215,
-          "menn": 0.104364648559,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104364648559
         },
         {
           "alder": 30,
           "kvinner": 0.13213952123,
-          "menn": 0.111158718523,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.111158718523
         },
         {
           "alder": 31,
           "kvinner": 0.139058666552,
-          "menn": 0.115754159818,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115754159818
         },
         {
           "alder": 32,
           "kvinner": 0.144827435227,
-          "menn": 0.12023069865,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.12023069865
         },
         {
           "alder": 33,
           "kvinner": 0.149074640138,
-          "menn": 0.124120363,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.124120363
         },
         {
           "alder": 34,
           "kvinner": 0.151952822127,
-          "menn": 0.126944854421,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126944854421
         },
         {
           "alder": 35,
           "kvinner": 0.156196992455,
-          "menn": 0.129576387992,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129576387992
         },
         {
           "alder": 36,
           "kvinner": 0.157920832036,
-          "menn": 0.134061007063,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.134061007063
         },
         {
           "alder": 37,
           "kvinner": 0.162226032158,
-          "menn": 0.14025269969,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.14025269969
         },
         {
           "alder": 38,
           "kvinner": 0.167812449022,
-          "menn": 0.143173654337,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.143173654337
         },
         {
           "alder": 39,
           "kvinner": 0.174857410278,
-          "menn": 0.148669667086,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.148669667086
         },
         {
           "alder": 40,
           "kvinner": 0.183272821883,
-          "menn": 0.160940850608,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160940850608
         },
         {
           "alder": 41,
           "kvinner": 0.188108872309,
-          "menn": 0.164671278148,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.164671278148
         },
         {
           "alder": 42,
           "kvinner": 0.191753286411,
-          "menn": 0.169486965344,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.169486965344
         },
         {
           "alder": 43,
           "kvinner": 0.196198052233,
-          "menn": 0.171626009491,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.171626009491
         },
         {
           "alder": 44,
           "kvinner": 0.201412020066,
-          "menn": 0.178156225848,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.178156225848
         },
         {
           "alder": 45,
           "kvinner": 0.206938533946,
-          "menn": 0.181436968812,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.181436968812
         },
         {
           "alder": 46,
           "kvinner": 0.211659860943,
-          "menn": 0.190009239039,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.190009239039
         },
         {
           "alder": 47,
           "kvinner": 0.223921461685,
-          "menn": 0.201154881788,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.201154881788
         },
         {
           "alder": 48,
           "kvinner": 0.235146932984,
-          "menn": 0.21178414437,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.21178414437
         },
         {
           "alder": 49,
           "kvinner": 0.249718773043,
-          "menn": 0.228553120595,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.228553120595
         },
         {
           "alder": 50,
           "kvinner": 0.264801501653,
-          "menn": 0.247093158398,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.247093158398
         },
         {
           "alder": 51,
           "kvinner": 0.276257279273,
-          "menn": 0.25771604136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25771604136
         },
         {
           "alder": 52,
           "kvinner": 0.286920436611,
-          "menn": 0.267314275529,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.267314275529
         },
         {
           "alder": 53,
           "kvinner": 0.295914642707,
-          "menn": 0.278778549514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.278778549514
         },
         {
           "alder": 54,
           "kvinner": 0.306608485962,
-          "menn": 0.294392727352,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.294392727352
         },
         {
           "alder": 55,
           "kvinner": 0.315838354151,
-          "menn": 0.3088406056,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.3088406056
         },
         {
           "alder": 56,
           "kvinner": 0.323294162928,
-          "menn": 0.320058099481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.320058099481
         },
         {
           "alder": 57,
           "kvinner": 0.332644144976,
-          "menn": 0.335542154456,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.335542154456
         },
         {
           "alder": 58,
           "kvinner": 0.338198535415,
-          "menn": 0.342797595675,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.342797595675
         },
         {
           "alder": 59,
           "kvinner": 0.34228649699,
-          "menn": 0.348435244618,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.348435244618
         },
         {
           "alder": 60,
           "kvinner": 0.349666441071,
-          "menn": 0.362898532587,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.362898532587
         },
         {
           "alder": 61,
           "kvinner": 0.355248303336,
-          "menn": 0.374183317475,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.374183317475
         },
         {
           "alder": 62,
           "kvinner": 0.360211881629,
-          "menn": 0.380220191297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.380220191297
         },
         {
           "alder": 63,
           "kvinner": 0.368137238605,
-          "menn": 0.392157639632,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.392157639632
         },
         {
           "alder": 64,
           "kvinner": 0.380681472673,
-          "menn": 0.405992468851,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.405992468851
         },
         {
           "alder": 65,
           "kvinner": 0.392982986352,
-          "menn": 0.420788525518,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.420788525518
         },
         {
           "alder": 66,
           "kvinner": 0.407323237687,
-          "menn": 0.429620824406,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.429620824406
         },
         {
           "alder": 67,
           "kvinner": 0.415327073054,
-          "menn": 0.439265907764,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.439265907764
         },
         {
           "alder": 68,
           "kvinner": 0.424036514889,
-          "menn": 0.44606698109,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.44606698109
         },
         {
           "alder": 69,
           "kvinner": 0.428530864474,
-          "menn": 0.446726504752,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.446726504752
         },
         {
           "alder": 70,
           "kvinner": 0.426496214397,
-          "menn": 0.457236591135,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.457236591135
         },
         {
           "alder": 71,
           "kvinner": 0.420737238108,
-          "menn": 0.446102376906,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.446102376906
         },
         {
           "alder": 72,
           "kvinner": 0.429200326768,
-          "menn": 0.459510284035,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.459510284035
         },
         {
           "alder": 73,
           "kvinner": 0.450667953037,
-          "menn": 0.478927981916,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.478927981916
         },
         {
           "alder": 74,
           "kvinner": 0.474017993216,
-          "menn": 0.517077197098,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.517077197098
         },
         {
           "alder": 75,
           "kvinner": 0.498045616976,
-          "menn": 0.547205157953,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.547205157953
         },
         {
           "alder": 76,
           "kvinner": 0.533044377678,
-          "menn": 0.587382428157,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.587382428157
         },
         {
           "alder": 77,
           "kvinner": 0.536326118264,
-          "menn": 0.597625520244,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.597625520244
         },
         {
           "alder": 78,
           "kvinner": 0.516411815099,
-          "menn": 0.576297297297,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.576297297297
         },
         {
           "alder": 79,
           "kvinner": 0.496236233202,
-          "menn": 0.579456899652,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.579456899652
         },
         {
           "alder": 80,
           "kvinner": 0.461821739662,
-          "menn": 0.517133284681,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.517133284681
         },
         {
           "alder": 81,
           "kvinner": 0.446298827422,
-          "menn": 0.504199252262,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.504199252262
         },
         {
           "alder": 82,
           "kvinner": 0.436118489523,
-          "menn": 0.502799167324,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.502799167324
         },
         {
           "alder": 83,
           "kvinner": 0.43707884097,
-          "menn": 0.49524220471,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.49524220471
         },
         {
           "alder": 84,
           "kvinner": 0.413484464987,
-          "menn": 0.482620047097,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.482620047097
         },
         {
           "alder": 85,
           "kvinner": 0.378538035718,
-          "menn": 0.44964636486,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.44964636486
         },
         {
           "alder": 86,
           "kvinner": 0.350572550986,
-          "menn": 0.423370162176,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.423370162176
         },
         {
           "alder": 87,
           "kvinner": 0.32015491728,
-          "menn": 0.393286591347,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.393286591347
         },
         {
           "alder": 88,
           "kvinner": 0.302196995645,
-          "menn": 0.372327940314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.372327940314
         },
         {
           "alder": 89,
           "kvinner": 0.284728424129,
-          "menn": 0.362430993691,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.362430993691
         },
         {
           "alder": 90,
           "kvinner": 0.268361581921,
-          "menn": 0.338761232736,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.338761232736
         },
         {
           "alder": 91,
           "kvinner": 0.254512181994,
-          "menn": 0.32102858827,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.32102858827
         },
         {
           "alder": 92,
           "kvinner": 0.231469997006,
-          "menn": 0.294073588615,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.294073588615
         },
         {
           "alder": 93,
           "kvinner": 0.210123722984,
-          "menn": 0.276745598057,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.276745598057
         },
         {
           "alder": 94,
           "kvinner": 0.188964812568,
-          "menn": 0.267988854286,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.267988854286
         },
         {
           "alder": 95,
           "kvinner": 0.176346528228,
-          "menn": 0.24291408326,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.24291408326
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/magnesium_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/magnesium_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 5525,
           "tot_pas": 4268,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.29451733833,
-          "borhf": null
+          "prove_pr_pas": 1.29451733833
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 12749,
           "tot_pas": 9625.66666667,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.32447968972,
-          "borhf": null
+          "prove_pr_pas": 1.32447968972
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 9087.66666667,
           "tot_pas": 7103.33333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.27935241671,
-          "borhf": null
+          "prove_pr_pas": 1.27935241671
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 6065.33333333,
           "tot_pas": 4702.33333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.28985609981,
-          "borhf": null
+          "prove_pr_pas": 1.28985609981
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 6860.66666667,
           "tot_pas": 5378.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.27561202355,
-          "borhf": null
+          "prove_pr_pas": 1.27561202355
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 13468.6666667,
           "tot_pas": 10670.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.26225360032,
-          "borhf": null
+          "prove_pr_pas": 1.26225360032
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 12518.6666667,
           "tot_pas": 10131.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.23559796019,
-          "borhf": null
+          "prove_pr_pas": 1.23559796019
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 6967,
           "tot_pas": 5213.33333333,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.33638107417,
-          "borhf": null
+          "prove_pr_pas": 1.33638107417
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 40309.6666667,
           "tot_pas": 26277,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.53402849133,
-          "borhf": null
+          "prove_pr_pas": 1.53402849133
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 23554.3333333,
           "tot_pas": 16433.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.43329749904,
-          "borhf": null
+          "prove_pr_pas": 1.43329749904
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 34682.6666667,
           "tot_pas": 25323.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.3695932605,
-          "borhf": null
+          "prove_pr_pas": 1.3695932605
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 54310,
           "tot_pas": 38171.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.42278304152,
-          "borhf": null
+          "prove_pr_pas": 1.42278304152
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 91313.3333333,
           "tot_pas": 66224.3333333,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.37884866086,
-          "borhf": null
+          "prove_pr_pas": 1.37884866086
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 45786,
           "tot_pas": 33228.6666667,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.37790662681,
-          "borhf": null
+          "prove_pr_pas": 1.37790662681
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 20996.3333333,
           "tot_pas": 16268.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.29059951645,
-          "borhf": null
+          "prove_pr_pas": 1.29059951645
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 20735.3333333,
           "tot_pas": 15209.6666667,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.36329965592,
-          "borhf": null
+          "prove_pr_pas": 1.36329965592
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 37811.6666667,
           "tot_pas": 27633.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.36833534379,
-          "borhf": null
+          "prove_pr_pas": 1.36833534379
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 59855.3333333,
           "tot_pas": 43205.3333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.38536909024,
-          "borhf": null
+          "prove_pr_pas": 1.38536909024
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 44791.3333333,
           "tot_pas": 30556,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.46587685997,
-          "borhf": null
+          "prove_pr_pas": 1.46587685997
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 31048.6666667,
           "tot_pas": 21786,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.42516600875,
-          "borhf": null
+          "prove_pr_pas": 1.42516600875
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 19469.3333333,
           "tot_pas": 13690.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.42212266563,
-          "borhf": null
+          "prove_pr_pas": 1.42212266563
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 597907.333333,
           "tot_pas": 431102,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.38692776497,
-          "borhf": null
+          "prove_pr_pas": 1.38692776497
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 33427,
           "tot_pas": 25690.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.30115088684,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.30115088684
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 32848,
           "tot_pas": 26173.6666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.25500184664,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.25500184664
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 105513.666667,
           "tot_pas": 73224.6666667,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.44095796498,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44095796498
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 426118.666667,
           "tot_pas": 305145.666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.39644344723,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39644344723
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 597907.333333,
           "tot_pas": 430060.666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.39028602166,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.39028602166
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00089113984212,
-          "menn": 0.000971037743815,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000971037743815
         },
         {
           "alder": 1,
           "kvinner": 0.00255096462905,
-          "menn": 0.00303457767074,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00303457767074
         },
         {
           "alder": 2,
           "kvinner": 0.00373659160332,
-          "menn": 0.0041501817793,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0041501817793
         },
         {
           "alder": 3,
           "kvinner": 0.00479364372582,
-          "menn": 0.00561834583311,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00561834583311
         },
         {
           "alder": 4,
           "kvinner": 0.00568325248514,
-          "menn": 0.00644678338421,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00644678338421
         },
         {
           "alder": 5,
           "kvinner": 0.00611610552124,
-          "menn": 0.00691742874731,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00691742874731
         },
         {
           "alder": 6,
           "kvinner": 0.00704262677391,
-          "menn": 0.00775232821545,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00775232821545
         },
         {
           "alder": 7,
           "kvinner": 0.00859227411895,
-          "menn": 0.00846648733746,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00846648733746
         },
         {
           "alder": 8,
           "kvinner": 0.00952514984999,
-          "menn": 0.00995715259519,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00995715259519
         },
         {
           "alder": 9,
           "kvinner": 0.0109707362724,
-          "menn": 0.0109686037944,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0109686037944
         },
         {
           "alder": 10,
           "kvinner": 0.0125263065038,
-          "menn": 0.0121842691529,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0121842691529
         },
         {
           "alder": 11,
           "kvinner": 0.0147745189801,
-          "menn": 0.0129291074803,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0129291074803
         },
         {
           "alder": 12,
           "kvinner": 0.0188451194431,
-          "menn": 0.0135380362937,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0135380362937
         },
         {
           "alder": 13,
           "kvinner": 0.0259514576133,
-          "menn": 0.0162875153341,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0162875153341
         },
         {
           "alder": 14,
           "kvinner": 0.0343896244537,
-          "menn": 0.021433655687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.021433655687
         },
         {
           "alder": 15,
           "kvinner": 0.0407535513345,
-          "menn": 0.0232104966873,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0232104966873
         },
         {
           "alder": 16,
           "kvinner": 0.0458424536168,
-          "menn": 0.0240401910314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0240401910314
         },
         {
           "alder": 17,
           "kvinner": 0.0495174936818,
-          "menn": 0.0245438536418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245438536418
         },
         {
           "alder": 18,
           "kvinner": 0.0502640591492,
-          "menn": 0.0238902505857,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0238902505857
         },
         {
           "alder": 19,
           "kvinner": 0.050086850293,
-          "menn": 0.0245868433281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245868433281
         },
         {
           "alder": 20,
           "kvinner": 0.0517471978902,
-          "menn": 0.0245910746972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245910746972
         },
         {
           "alder": 21,
           "kvinner": 0.0527248368555,
-          "menn": 0.0256516295045,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0256516295045
         },
         {
           "alder": 22,
           "kvinner": 0.0540203386514,
-          "menn": 0.0266116813433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0266116813433
         },
         {
           "alder": 23,
           "kvinner": 0.0553842812411,
-          "menn": 0.0278894571537,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0278894571537
         },
         {
           "alder": 24,
           "kvinner": 0.0572756791284,
-          "menn": 0.0287228728423,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0287228728423
         },
         {
           "alder": 25,
           "kvinner": 0.0606167594661,
-          "menn": 0.0302041973908,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0302041973908
         },
         {
           "alder": 26,
           "kvinner": 0.0624401140738,
-          "menn": 0.0313083811119,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0313083811119
         },
         {
           "alder": 27,
           "kvinner": 0.0629879925513,
-          "menn": 0.0327156353804,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0327156353804
         },
         {
           "alder": 28,
           "kvinner": 0.0651284302726,
-          "menn": 0.0335368072959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0335368072959
         },
         {
           "alder": 29,
           "kvinner": 0.0661599520743,
-          "menn": 0.0339118220594,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0339118220594
         },
         {
           "alder": 30,
           "kvinner": 0.0697606148755,
-          "menn": 0.0352581640976,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0352581640976
         },
         {
           "alder": 31,
           "kvinner": 0.0712187405845,
-          "menn": 0.0363429898837,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0363429898837
         },
         {
           "alder": 32,
           "kvinner": 0.0736779885504,
-          "menn": 0.0371844278411,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0371844278411
         },
         {
           "alder": 33,
           "kvinner": 0.0747290613016,
-          "menn": 0.0374621875498,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0374621875498
         },
         {
           "alder": 34,
           "kvinner": 0.0759283050262,
-          "menn": 0.0380571581913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0380571581913
         },
         {
           "alder": 35,
           "kvinner": 0.0751829028002,
-          "menn": 0.0370364388164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0370364388164
         },
         {
           "alder": 36,
           "kvinner": 0.0746192073979,
-          "menn": 0.0378383084306,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0378383084306
         },
         {
           "alder": 37,
           "kvinner": 0.0741914183773,
-          "menn": 0.0388886460018,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0388886460018
         },
         {
           "alder": 38,
           "kvinner": 0.0740893943278,
-          "menn": 0.0382955386767,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0382955386767
         },
         {
           "alder": 39,
           "kvinner": 0.0747082394922,
-          "menn": 0.0392867385885,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0392867385885
         },
         {
           "alder": 40,
           "kvinner": 0.0761084239034,
-          "menn": 0.0405591047177,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0405591047177
         },
         {
           "alder": 41,
           "kvinner": 0.0764862424559,
-          "menn": 0.0402675181318,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0402675181318
         },
         {
           "alder": 42,
           "kvinner": 0.0748714786331,
-          "menn": 0.0408443520226,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0408443520226
         },
         {
           "alder": 43,
           "kvinner": 0.0741262831574,
-          "menn": 0.0408847445397,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0408847445397
         },
         {
           "alder": 44,
           "kvinner": 0.0748324452886,
-          "menn": 0.0419806951288,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0419806951288
         },
         {
           "alder": 45,
           "kvinner": 0.0736521714624,
-          "menn": 0.0417729711226,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0417729711226
         },
         {
           "alder": 46,
           "kvinner": 0.0754607659199,
-          "menn": 0.0419693851839,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0419693851839
         },
         {
           "alder": 47,
           "kvinner": 0.0762967003,
-          "menn": 0.0435285633499,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0435285633499
         },
         {
           "alder": 48,
           "kvinner": 0.0784003639475,
-          "menn": 0.0456407827958,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0456407827958
         },
         {
           "alder": 49,
           "kvinner": 0.0806327471971,
-          "menn": 0.0476842240164,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0476842240164
         },
         {
           "alder": 50,
           "kvinner": 0.0824610657622,
-          "menn": 0.0500684418503,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0500684418503
         },
         {
           "alder": 51,
           "kvinner": 0.086198608061,
-          "menn": 0.0523136427201,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0523136427201
         },
         {
           "alder": 52,
           "kvinner": 0.0864944209609,
-          "menn": 0.0539388633468,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0539388633468
         },
         {
           "alder": 53,
           "kvinner": 0.0895746174365,
-          "menn": 0.0550323845236,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0550323845236
         },
         {
           "alder": 54,
           "kvinner": 0.0910949072745,
-          "menn": 0.0592648776069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0592648776069
         },
         {
           "alder": 55,
           "kvinner": 0.0920734753857,
-          "menn": 0.0615760796749,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0615760796749
         },
         {
           "alder": 56,
           "kvinner": 0.0930226963833,
-          "menn": 0.0626636200799,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0626636200799
         },
         {
           "alder": 57,
           "kvinner": 0.0930711956187,
-          "menn": 0.0654680419184,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0654680419184
         },
         {
           "alder": 58,
           "kvinner": 0.0946139449587,
-          "menn": 0.0665659830247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0665659830247
         },
         {
           "alder": 59,
           "kvinner": 0.0931226706591,
-          "menn": 0.0682042934799,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0682042934799
         },
         {
           "alder": 60,
           "kvinner": 0.0928872989784,
-          "menn": 0.0698601420481,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0698601420481
         },
         {
           "alder": 61,
           "kvinner": 0.0941307761182,
-          "menn": 0.0705296542975,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0705296542975
         },
         {
           "alder": 62,
           "kvinner": 0.0943305930326,
-          "menn": 0.0728617773965,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0728617773965
         },
         {
           "alder": 63,
           "kvinner": 0.0947770870042,
-          "menn": 0.0766934770263,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0766934770263
         },
         {
           "alder": 64,
           "kvinner": 0.0974237008709,
-          "menn": 0.079854514971,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.079854514971
         },
         {
           "alder": 65,
           "kvinner": 0.100330382103,
-          "menn": 0.0812683775314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0812683775314
         },
         {
           "alder": 66,
           "kvinner": 0.102620195541,
-          "menn": 0.0845617806376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0845617806376
         },
         {
           "alder": 67,
           "kvinner": 0.104126575319,
-          "menn": 0.0860770577933,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0860770577933
         },
         {
           "alder": 68,
           "kvinner": 0.107395001288,
-          "menn": 0.0876541740437,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0876541740437
         },
         {
           "alder": 69,
           "kvinner": 0.109447271477,
-          "menn": 0.0875320561171,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0875320561171
         },
         {
           "alder": 70,
           "kvinner": 0.10992518928,
-          "menn": 0.0910353246357,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0910353246357
         },
         {
           "alder": 71,
           "kvinner": 0.109708405823,
-          "menn": 0.090305667538,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.090305667538
         },
         {
           "alder": 72,
           "kvinner": 0.112787812774,
-          "menn": 0.0952007835455,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0952007835455
         },
         {
           "alder": 73,
           "kvinner": 0.121398616633,
-          "menn": 0.101054617305,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101054617305
         },
         {
           "alder": 74,
           "kvinner": 0.130499975419,
-          "menn": 0.112454928537,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112454928537
         },
         {
           "alder": 75,
           "kvinner": 0.141889089866,
-          "menn": 0.123328705377,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123328705377
         },
         {
           "alder": 76,
           "kvinner": 0.155395754322,
-          "menn": 0.13760781934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13760781934
         },
         {
           "alder": 77,
           "kvinner": 0.163327816349,
-          "menn": 0.142348497606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.142348497606
         },
         {
           "alder": 78,
           "kvinner": 0.161430767606,
-          "menn": 0.143027027027,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.143027027027
         },
         {
           "alder": 79,
           "kvinner": 0.159631706578,
-          "menn": 0.145501138952,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145501138952
         },
         {
           "alder": 80,
           "kvinner": 0.154520376687,
-          "menn": 0.141395209978,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.141395209978
         },
         {
           "alder": 81,
           "kvinner": 0.159211567513,
-          "menn": 0.142485596113,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.142485596113
         },
         {
           "alder": 82,
           "kvinner": 0.167016170371,
-          "menn": 0.150407243477,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.150407243477
         },
         {
           "alder": 83,
           "kvinner": 0.176937331536,
-          "menn": 0.156609815366,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.156609815366
         },
         {
           "alder": 84,
           "kvinner": 0.178496753604,
-          "menn": 0.164277669704,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.164277669704
         },
         {
           "alder": 85,
           "kvinner": 0.175576550672,
-          "menn": 0.163187584114,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.163187584114
         },
         {
           "alder": 86,
           "kvinner": 0.173583249749,
-          "menn": 0.163532984429,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.163532984429
         },
         {
           "alder": 87,
           "kvinner": 0.173229756655,
-          "menn": 0.166745377266,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.166745377266
         },
         {
           "alder": 88,
           "kvinner": 0.179747516759,
-          "menn": 0.170802246626,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170802246626
         },
         {
           "alder": 89,
           "kvinner": 0.186084273768,
-          "menn": 0.183951104101,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.183951104101
         },
         {
           "alder": 90,
           "kvinner": 0.197119264916,
-          "menn": 0.186719739461,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.186719739461
         },
         {
           "alder": 91,
           "kvinner": 0.204061860849,
-          "menn": 0.190834070144,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.190834070144
         },
         {
           "alder": 92,
           "kvinner": 0.210298960695,
-          "menn": 0.195393689729,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.195393689729
         },
         {
           "alder": 93,
           "kvinner": 0.204373941167,
-          "menn": 0.206071645416,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.206071645416
         },
         {
           "alder": 94,
           "kvinner": 0.213423590268,
-          "menn": 0.215866251434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.215866251434
         },
         {
           "alder": 95,
           "kvinner": 0.205872809864,
-          "menn": 0.210363153233,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.210363153233
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/mma_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/mma_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 1233,
           "tot_pas": 1071,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.1512605042,
-          "borhf": null
+          "prove_pr_pas": 1.1512605042
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 7118,
           "tot_pas": 5341.33333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.33262606091,
-          "borhf": null
+          "prove_pr_pas": 1.33262606091
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 3455.33333333,
           "tot_pas": 3009,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.14833277944,
-          "borhf": null
+          "prove_pr_pas": 1.14833277944
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 1236,
           "tot_pas": 1063.33333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.16238244514,
-          "borhf": null
+          "prove_pr_pas": 1.16238244514
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 4205.66666667,
           "tot_pas": 3367.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.24896060186,
-          "borhf": null
+          "prove_pr_pas": 1.24896060186
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 13884,
           "tot_pas": 11644.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.19233962156,
-          "borhf": null
+          "prove_pr_pas": 1.19233962156
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 4131,
           "tot_pas": 3521.33333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.17313517607,
-          "borhf": null
+          "prove_pr_pas": 1.17313517607
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 6999.66666667,
           "tot_pas": 5737,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.22009180175,
-          "borhf": null
+          "prove_pr_pas": 1.22009180175
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 63714.6666667,
           "tot_pas": 50027,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.27360558632,
-          "borhf": null
+          "prove_pr_pas": 1.27360558632
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 11649,
           "tot_pas": 9489,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.22763199494,
-          "borhf": null
+          "prove_pr_pas": 1.22763199494
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 33665,
           "tot_pas": 27978,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.20326685253,
-          "borhf": null
+          "prove_pr_pas": 1.20326685253
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 27553.6666667,
           "tot_pas": 21674,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.2712774138,
-          "borhf": null
+          "prove_pr_pas": 1.2712774138
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 31642.3333333,
           "tot_pas": 25752,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.22873304339,
-          "borhf": null
+          "prove_pr_pas": 1.22873304339
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 15914,
           "tot_pas": 13144,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.21074254413,
-          "borhf": null
+          "prove_pr_pas": 1.21074254413
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 9524.66666667,
           "tot_pas": 8082.33333333,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.17845506661,
-          "borhf": null
+          "prove_pr_pas": 1.17845506661
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 9383,
           "tot_pas": 7695.33333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.21931040457,
-          "borhf": null
+          "prove_pr_pas": 1.21931040457
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 6682.33333333,
           "tot_pas": 5210,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.28259756878,
-          "borhf": null
+          "prove_pr_pas": 1.28259756878
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 25127.3333333,
           "tot_pas": 20771.6666667,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.20969269036,
-          "borhf": null
+          "prove_pr_pas": 1.20969269036
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 19637.3333333,
           "tot_pas": 16041.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.22414545455,
-          "borhf": null
+          "prove_pr_pas": 1.22414545455
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 3798.66666667,
           "tot_pas": 3326.66666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.14188376754,
-          "borhf": null
+          "prove_pr_pas": 1.14188376754
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 3194,
           "tot_pas": 2767.33333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.15417971573,
-          "borhf": null
+          "prove_pr_pas": 1.15417971573
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 303751,
           "tot_pas": 246716,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.23117673763,
-          "borhf": null
+          "prove_pr_pas": 1.23117673763
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 13042.3333333,
           "tot_pas": 10482.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.24422043438,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.24422043438
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 22220.6666667,
           "tot_pas": 18528.6666667,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.19925880617,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.19925880617
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 116028.333333,
           "tot_pas": 93194.3333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.24501489719,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.24501489719
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 152459.666667,
           "tot_pas": 124216.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.22737213839,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.22737213839
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 303751,
           "tot_pas": 246336,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.23307596129,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.23307596129
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00588152295799,
-          "menn": 0.00663542458274,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00663542458274
         },
         {
           "alder": 1,
           "kvinner": 0.0055683913617,
-          "menn": 0.00643385515224,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00643385515224
         },
         {
           "alder": 2,
           "kvinner": 0.00490161255949,
-          "menn": 0.00565387082977,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00565387082977
         },
         {
           "alder": 3,
           "kvinner": 0.00480060111875,
-          "menn": 0.0067000576913,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0067000576913
         },
         {
           "alder": 4,
           "kvinner": 0.00504192507385,
-          "menn": 0.00707920057305,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00707920057305
         },
         {
           "alder": 5,
           "kvinner": 0.00610270769973,
-          "menn": 0.00759647909223,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00759647909223
         },
         {
           "alder": 6,
           "kvinner": 0.00669148922074,
-          "menn": 0.00729927007299,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00729927007299
         },
         {
           "alder": 7,
           "kvinner": 0.00719171389486,
-          "menn": 0.00801403230405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00801403230405
         },
         {
           "alder": 8,
           "kvinner": 0.00844405493753,
-          "menn": 0.00883119096309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00883119096309
         },
         {
           "alder": 9,
           "kvinner": 0.0095733110757,
-          "menn": 0.00976451348162,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00976451348162
         },
         {
           "alder": 10,
           "kvinner": 0.0114740463499,
-          "menn": 0.011055432452,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.011055432452
         },
         {
           "alder": 11,
           "kvinner": 0.0133171684685,
-          "menn": 0.011689248395,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.011689248395
         },
         {
           "alder": 12,
           "kvinner": 0.0162885619364,
-          "menn": 0.0122821776229,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0122821776229
         },
         {
           "alder": 13,
           "kvinner": 0.0225781514538,
-          "menn": 0.0147935821603,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0147935821603
         },
         {
           "alder": 14,
           "kvinner": 0.0303479572499,
-          "menn": 0.0172856020814,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0172856020814
         },
         {
           "alder": 15,
           "kvinner": 0.0362239368709,
-          "menn": 0.0187317121453,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0187317121453
         },
         {
           "alder": 16,
           "kvinner": 0.0380836981447,
-          "menn": 0.0179743223966,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0179743223966
         },
         {
           "alder": 17,
           "kvinner": 0.0412635008047,
-          "menn": 0.0180991048281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0180991048281
         },
         {
           "alder": 18,
           "kvinner": 0.0389655282783,
-          "menn": 0.0164587988028,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0164587988028
         },
         {
           "alder": 19,
           "kvinner": 0.0383604700732,
-          "menn": 0.014881980769,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.014881980769
         },
         {
           "alder": 20,
           "kvinner": 0.0408652789551,
-          "menn": 0.0151289203904,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0151289203904
         },
         {
           "alder": 21,
           "kvinner": 0.0426984744371,
-          "menn": 0.0156804631768,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0156804631768
         },
         {
           "alder": 22,
           "kvinner": 0.0442668362573,
-          "menn": 0.0162449732858,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0162449732858
         },
         {
           "alder": 23,
           "kvinner": 0.0457131480353,
-          "menn": 0.0166062376299,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0166062376299
         },
         {
           "alder": 24,
           "kvinner": 0.0469312798311,
-          "menn": 0.017810956319,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.017810956319
         },
         {
           "alder": 25,
           "kvinner": 0.0484390012386,
-          "menn": 0.0183090448972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0183090448972
         },
         {
           "alder": 26,
           "kvinner": 0.0481355278749,
-          "menn": 0.0188376387726,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0188376387726
         },
         {
           "alder": 27,
           "kvinner": 0.0479855888513,
-          "menn": 0.018541500536,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.018541500536
         },
         {
           "alder": 28,
           "kvinner": 0.0482392667631,
-          "menn": 0.01822426505,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.01822426505
         },
         {
           "alder": 29,
           "kvinner": 0.0487761826312,
-          "menn": 0.0193972946691,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0193972946691
         },
         {
           "alder": 30,
           "kvinner": 0.0515064983587,
-          "menn": 0.0202360180472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0202360180472
         },
         {
           "alder": 31,
           "kvinner": 0.0525276546292,
-          "menn": 0.0201600149333,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0201600149333
         },
         {
           "alder": 32,
           "kvinner": 0.0540790525083,
-          "menn": 0.0206317997116,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0206317997116
         },
         {
           "alder": 33,
           "kvinner": 0.0540932584894,
-          "menn": 0.0202621663217,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0202621663217
         },
         {
           "alder": 34,
           "kvinner": 0.0537429326572,
-          "menn": 0.0208345632631,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0208345632631
         },
         {
           "alder": 35,
           "kvinner": 0.0536115093122,
-          "menn": 0.0206852737218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0206852737218
         },
         {
           "alder": 36,
           "kvinner": 0.0539681990614,
-          "menn": 0.0210085862598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0210085862598
         },
         {
           "alder": 37,
           "kvinner": 0.0510170983736,
-          "menn": 0.021854369781,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.021854369781
         },
         {
           "alder": 38,
           "kvinner": 0.0516650742234,
-          "menn": 0.0218761139598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0218761139598
         },
         {
           "alder": 39,
           "kvinner": 0.0512036034982,
-          "menn": 0.0220012354667,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0220012354667
         },
         {
           "alder": 40,
           "kvinner": 0.0514978062136,
-          "menn": 0.0234375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0234375
         },
         {
           "alder": 41,
           "kvinner": 0.0529867414342,
-          "menn": 0.0232680381817,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0232680381817
         },
         {
           "alder": 42,
           "kvinner": 0.0502285812546,
-          "menn": 0.0229921136266,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0229921136266
         },
         {
           "alder": 43,
           "kvinner": 0.0499575936595,
-          "menn": 0.022940082702,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.022940082702
         },
         {
           "alder": 44,
           "kvinner": 0.0500268433905,
-          "menn": 0.0231033594422,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0231033594422
         },
         {
           "alder": 45,
           "kvinner": 0.047639714793,
-          "menn": 0.023079432829,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.023079432829
         },
         {
           "alder": 46,
           "kvinner": 0.0475720119192,
-          "menn": 0.02348605745,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.02348605745
         },
         {
           "alder": 47,
           "kvinner": 0.0483174256886,
-          "menn": 0.0245762579962,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245762579962
         },
         {
           "alder": 48,
           "kvinner": 0.0502865003629,
-          "menn": 0.0250620245216,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0250620245216
         },
         {
           "alder": 49,
           "kvinner": 0.0505939405683,
-          "menn": 0.0260310137127,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0260310137127
         },
         {
           "alder": 50,
           "kvinner": 0.0498585438947,
-          "menn": 0.0272992587618,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0272992587618
         },
         {
           "alder": 51,
           "kvinner": 0.0511488413255,
-          "menn": 0.0283376395178,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0283376395178
         },
         {
           "alder": 52,
           "kvinner": 0.0507411127176,
-          "menn": 0.0287964016293,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0287964016293
         },
         {
           "alder": 53,
           "kvinner": 0.0512649164678,
-          "menn": 0.0301101499915,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0301101499915
         },
         {
           "alder": 54,
           "kvinner": 0.0506286961015,
-          "menn": 0.0313049077277,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0313049077277
         },
         {
           "alder": 55,
           "kvinner": 0.0498398236591,
-          "menn": 0.0325633066857,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0325633066857
         },
         {
           "alder": 56,
           "kvinner": 0.0498550654912,
-          "menn": 0.0339755660681,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0339755660681
         },
         {
           "alder": 57,
           "kvinner": 0.0496523290874,
-          "menn": 0.0354689860272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0354689860272
         },
         {
           "alder": 58,
           "kvinner": 0.0500483589364,
-          "menn": 0.0357326245205,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0357326245205
         },
         {
           "alder": 59,
           "kvinner": 0.0493613225878,
-          "menn": 0.0362212462762,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0362212462762
         },
         {
           "alder": 60,
           "kvinner": 0.0482387444004,
-          "menn": 0.0369512843778,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0369512843778
         },
         {
           "alder": 61,
           "kvinner": 0.0482332636933,
-          "menn": 0.0378306374881,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0378306374881
         },
         {
           "alder": 62,
           "kvinner": 0.0482109376024,
-          "menn": 0.0386011983463,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0386011983463
         },
         {
           "alder": 63,
           "kvinner": 0.0472622095149,
-          "menn": 0.0393768902624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0393768902624
         },
         {
           "alder": 64,
           "kvinner": 0.0484179374742,
-          "menn": 0.0404478126542,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0404478126542
         },
         {
           "alder": 65,
           "kvinner": 0.0492619634725,
-          "menn": 0.0421250983586,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0421250983586
         },
         {
           "alder": 66,
           "kvinner": 0.049402119661,
-          "menn": 0.0441030970396,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0441030970396
         },
         {
           "alder": 67,
           "kvinner": 0.0502582726839,
-          "menn": 0.044848219498,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.044848219498
         },
         {
           "alder": 68,
           "kvinner": 0.0512680826002,
-          "menn": 0.0452516626248,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0452516626248
         },
         {
           "alder": 69,
           "kvinner": 0.0521419444507,
-          "menn": 0.0458063056268,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0458063056268
         },
         {
           "alder": 70,
           "kvinner": 0.0529158154068,
-          "menn": 0.0463111314565,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0463111314565
         },
         {
           "alder": 71,
           "kvinner": 0.0514341794174,
-          "menn": 0.0472180519886,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0472180519886
         },
         {
           "alder": 72,
           "kvinner": 0.0538637257572,
-          "menn": 0.0488619000979,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0488619000979
         },
         {
           "alder": 73,
           "kvinner": 0.0572253300863,
-          "menn": 0.0521942057032,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0521942057032
         },
         {
           "alder": 74,
           "kvinner": 0.0621896661914,
-          "menn": 0.0591337590686,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0591337590686
         },
         {
           "alder": 75,
           "kvinner": 0.0664490228085,
-          "menn": 0.0640845204359,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0640845204359
         },
         {
           "alder": 76,
           "kvinner": 0.0729448849924,
-          "menn": 0.0711174201378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0711174201378
         },
         {
           "alder": 77,
           "kvinner": 0.073447542076,
-          "menn": 0.0742175283278,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0742175283278
         },
         {
           "alder": 78,
           "kvinner": 0.0729466161266,
-          "menn": 0.0716351351351,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0716351351351
         },
         {
           "alder": 79,
           "kvinner": 0.0715620895221,
-          "menn": 0.0734474283659,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0734474283659
         },
         {
           "alder": 80,
           "kvinner": 0.0695892049083,
-          "menn": 0.0699761162343,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0699761162343
         },
         {
           "alder": 81,
           "kvinner": 0.0728580677649,
-          "menn": 0.0683439593982,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0683439593982
         },
         {
           "alder": 82,
           "kvinner": 0.0741413858987,
-          "menn": 0.0734048788375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0734048788375
         },
         {
           "alder": 83,
           "kvinner": 0.0775606469003,
-          "menn": 0.0777144414416,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0777144414416
         },
         {
           "alder": 84,
           "kvinner": 0.0762994754411,
-          "menn": 0.0798607556056,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0798607556056
         },
         {
           "alder": 85,
           "kvinner": 0.0723353480821,
-          "menn": 0.0773702144718,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0773702144718
         },
         {
           "alder": 86,
           "kvinner": 0.0714434971581,
-          "menn": 0.0759191057699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0759191057699
         },
         {
           "alder": 87,
           "kvinner": 0.0708321207101,
-          "menn": 0.0737821048425,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0737821048425
         },
         {
           "alder": 88,
           "kvinner": 0.0676958457699,
-          "menn": 0.0753206471624,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0753206471624
         },
         {
           "alder": 89,
           "kvinner": 0.0705528943736,
-          "menn": 0.0768927444795,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0768927444795
         },
         {
           "alder": 90,
           "kvinner": 0.0713354442168,
-          "menn": 0.077136481515,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.077136481515
         },
         {
           "alder": 91,
           "kvinner": 0.0720872654204,
-          "menn": 0.07824933687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.07824933687
         },
         {
           "alder": 92,
           "kvinner": 0.0695864163209,
-          "menn": 0.0738694878757,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0738694878757
         },
         {
           "alder": 93,
           "kvinner": 0.0656604548488,
-          "menn": 0.0706739526412,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0706739526412
         },
         {
           "alder": 94,
           "kvinner": 0.066798646146,
-          "menn": 0.0735944927061,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0735944927061
         },
         {
           "alder": 95,
           "kvinner": 0.0664341336794,
-          "menn": 0.0715234720992,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0715234720992
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/natrium_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/natrium_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 32247.3333333,
           "tot_pas": 20844.6666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.54703041545,
-          "borhf": null
+          "prove_pr_pas": 1.54703041545
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 77998.6666667,
           "tot_pas": 51798.3333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.50581421539,
-          "borhf": null
+          "prove_pr_pas": 1.50581421539
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 56148.3333333,
           "tot_pas": 38134.6666667,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.47236984721,
-          "borhf": null
+          "prove_pr_pas": 1.47236984721
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 40895.6666667,
           "tot_pas": 25192.3333333,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.62333778795,
-          "borhf": null
+          "prove_pr_pas": 1.62333778795
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 58612.6666667,
           "tot_pas": 39860.3333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.47045099138,
-          "borhf": null
+          "prove_pr_pas": 1.47045099138
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 131464.666667,
           "tot_pas": 89592.3333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.46736513913,
-          "borhf": null
+          "prove_pr_pas": 1.46736513913
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 124516,
           "tot_pas": 82793.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.50393146014,
-          "borhf": null
+          "prove_pr_pas": 1.50393146014
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 49025.3333333,
           "tot_pas": 30481.3333333,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.60837233717,
-          "borhf": null
+          "prove_pr_pas": 1.60837233717
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 192283,
           "tot_pas": 114570.333333,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.6782965922,
-          "borhf": null
+          "prove_pr_pas": 1.6782965922
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 91160.3333333,
           "tot_pas": 54811,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.66317588319,
-          "borhf": null
+          "prove_pr_pas": 1.66317588319
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 150524,
           "tot_pas": 95607.6666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.57439256963,
-          "borhf": null
+          "prove_pr_pas": 1.57439256963
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 193749,
           "tot_pas": 119527.666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.62095526001,
-          "borhf": null
+          "prove_pr_pas": 1.62095526001
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 279261.333333,
           "tot_pas": 179887,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.55242643067,
-          "borhf": null
+          "prove_pr_pas": 1.55242643067
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 108392,
           "tot_pas": 71824,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.50913343729,
-          "borhf": null
+          "prove_pr_pas": 1.50913343729
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 48673.3333333,
           "tot_pas": 35296.6666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.37897818491,
-          "borhf": null
+          "prove_pr_pas": 1.37897818491
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 50970.6666667,
           "tot_pas": 34068.3333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.4961303263,
-          "borhf": null
+          "prove_pr_pas": 1.4961303263
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 197225.333333,
           "tot_pas": 121382,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.62483179823,
-          "borhf": null
+          "prove_pr_pas": 1.62483179823
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 229688.666667,
           "tot_pas": 145719.333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.57624016946,
-          "borhf": null
+          "prove_pr_pas": 1.57624016946
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 133260,
           "tot_pas": 83353.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.5987299099,
-          "borhf": null
+          "prove_pr_pas": 1.5987299099
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 82469.6666667,
           "tot_pas": 52571.6666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.56870938085,
-          "borhf": null
+          "prove_pr_pas": 1.56870938085
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 168164.666667,
           "tot_pas": 103588,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.62339910672,
-          "borhf": null
+          "prove_pr_pas": 1.62339910672
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 2496736.33333,
           "tot_pas": 1590909.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.56937688467,
-          "borhf": null
+          "prove_pr_pas": 1.56937688467
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 207290,
           "tot_pas": 135899.333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.52532021251,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.52532021251
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 314593.333333,
           "tot_pas": 212144,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.48292354878,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.48292354878
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 482992.666667,
           "tot_pas": 295336,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.63540058329,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.63540058329
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 1491860.33333,
           "tot_pas": 944459.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.57959192173,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57959192173
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 2496736.33333,
           "tot_pas": 1586658.33333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.57358158394,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57358158394
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00476017198999,
-          "menn": 0.00582622646289,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00582622646289
         },
         {
           "alder": 1,
           "kvinner": 0.0135419779451,
-          "menn": 0.0159298124892,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0159298124892
         },
         {
           "alder": 2,
           "kvinner": 0.0177452582226,
-          "menn": 0.0202429961506,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0202429961506
         },
         {
           "alder": 3,
           "kvinner": 0.0230568001558,
-          "menn": 0.0261774269681,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0261774269681
         },
         {
           "alder": 4,
           "kvinner": 0.0264172312395,
-          "menn": 0.0302656797517,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0302656797517
         },
         {
           "alder": 5,
           "kvinner": 0.0308216883935,
-          "menn": 0.0325690314965,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0325690314965
         },
         {
           "alder": 6,
           "kvinner": 0.0356305237912,
-          "menn": 0.0361313868613,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0361313868613
         },
         {
           "alder": 7,
           "kvinner": 0.0401276789786,
-          "menn": 0.0395867164161,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0395867164161
         },
         {
           "alder": 8,
           "kvinner": 0.0454123833345,
-          "menn": 0.0457627324959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0457627324959
         },
         {
           "alder": 9,
           "kvinner": 0.0499405620052,
-          "menn": 0.0509971185699,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0509971185699
         },
         {
           "alder": 10,
           "kvinner": 0.0562675639232,
-          "menn": 0.0555757963077,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0555757963077
         },
         {
           "alder": 11,
           "kvinner": 0.0621572556582,
-          "menn": 0.0577130560738,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0577130560738
         },
         {
           "alder": 12,
           "kvinner": 0.0736339186838,
-          "menn": 0.0585206105035,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0585206105035
         },
         {
           "alder": 13,
           "kvinner": 0.0993400330942,
-          "menn": 0.0683565520508,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0683565520508
         },
         {
           "alder": 14,
           "kvinner": 0.127824977117,
-          "menn": 0.0823045014972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0823045014972
         },
         {
           "alder": 15,
           "kvinner": 0.147316300772,
-          "menn": 0.0882765958763,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0882765958763
         },
         {
           "alder": 16,
           "kvinner": 0.160660308526,
-          "menn": 0.0873906841159,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0873906841159
         },
         {
           "alder": 17,
           "kvinner": 0.170793663105,
-          "menn": 0.0912292716333,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0912292716333
         },
         {
           "alder": 18,
           "kvinner": 0.175264859328,
-          "menn": 0.0908696725705,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0908696725705
         },
         {
           "alder": 19,
           "kvinner": 0.170118409081,
-          "menn": 0.0904774387265,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0904774387265
         },
         {
           "alder": 20,
           "kvinner": 0.174669555116,
-          "menn": 0.091136101803,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.091136101803
         },
         {
           "alder": 21,
           "kvinner": 0.176794897915,
-          "menn": 0.0928880771042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0928880771042
         },
         {
           "alder": 22,
           "kvinner": 0.17901193046,
-          "menn": 0.0970768161675,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0970768161675
         },
         {
           "alder": 23,
           "kvinner": 0.182931023041,
-          "menn": 0.101030207,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101030207
         },
         {
           "alder": 24,
           "kvinner": 0.18440118999,
-          "menn": 0.103696508853,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103696508853
         },
         {
           "alder": 25,
           "kvinner": 0.191469781333,
-          "menn": 0.107345433919,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107345433919
         },
         {
           "alder": 26,
           "kvinner": 0.194991410445,
-          "menn": 0.109826279285,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.109826279285
         },
         {
           "alder": 27,
           "kvinner": 0.196749755486,
-          "menn": 0.112505875084,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.112505875084
         },
         {
           "alder": 28,
           "kvinner": 0.199862328385,
-          "menn": 0.114867464617,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114867464617
         },
         {
           "alder": 29,
           "kvinner": 0.203293823146,
-          "menn": 0.117433382898,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.117433382898
         },
         {
           "alder": 30,
           "kvinner": 0.212185423394,
-          "menn": 0.123388087593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123388087593
         },
         {
           "alder": 31,
           "kvinner": 0.218154134206,
-          "menn": 0.125128981577,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125128981577
         },
         {
           "alder": 32,
           "kvinner": 0.225023807699,
-          "menn": 0.128446716477,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.128446716477
         },
         {
           "alder": 33,
           "kvinner": 0.2265547713,
-          "menn": 0.129353075413,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129353075413
         },
         {
           "alder": 34,
           "kvinner": 0.229952516512,
-          "menn": 0.13085737287,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13085737287
         },
         {
           "alder": 35,
           "kvinner": 0.227559068609,
-          "menn": 0.131503854934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.131503854934
         },
         {
           "alder": 36,
           "kvinner": 0.226878596054,
-          "menn": 0.133935858789,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.133935858789
         },
         {
           "alder": 37,
           "kvinner": 0.225476113248,
-          "menn": 0.137869977703,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137869977703
         },
         {
           "alder": 38,
           "kvinner": 0.22758733192,
-          "menn": 0.138545065672,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.138545065672
         },
         {
           "alder": 39,
           "kvinner": 0.229711310655,
-          "menn": 0.142735014451,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.142735014451
         },
         {
           "alder": 40,
           "kvinner": 0.233381032913,
-          "menn": 0.149459435311,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.149459435311
         },
         {
           "alder": 41,
           "kvinner": 0.234656417811,
-          "menn": 0.151345698964,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151345698964
         },
         {
           "alder": 42,
           "kvinner": 0.235240054788,
-          "menn": 0.154543773016,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.154543773016
         },
         {
           "alder": 43,
           "kvinner": 0.23431111631,
-          "menn": 0.155834929093,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.155834929093
         },
         {
           "alder": 44,
           "kvinner": 0.233779953471,
-          "menn": 0.160956144726,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160956144726
         },
         {
           "alder": 45,
           "kvinner": 0.235431051489,
-          "menn": 0.161096045742,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161096045742
         },
         {
           "alder": 46,
           "kvinner": 0.238754000662,
-          "menn": 0.166313203427,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.166313203427
         },
         {
           "alder": 47,
           "kvinner": 0.246986637578,
-          "menn": 0.177055933426,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.177055933426
         },
         {
           "alder": 48,
           "kvinner": 0.256696742886,
-          "menn": 0.185250002574,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.185250002574
         },
         {
           "alder": 49,
           "kvinner": 0.267873385973,
-          "menn": 0.196257849545,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.196257849545
         },
         {
           "alder": 50,
           "kvinner": 0.275771787756,
-          "menn": 0.211281283091,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.211281283091
         },
         {
           "alder": 51,
           "kvinner": 0.286702284572,
-          "menn": 0.221752036557,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.221752036557
         },
         {
           "alder": 52,
           "kvinner": 0.293950798503,
-          "menn": 0.230858754515,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.230858754515
         },
         {
           "alder": 53,
           "kvinner": 0.300407131826,
-          "menn": 0.239858530765,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.239858530765
         },
         {
           "alder": 54,
           "kvinner": 0.306419015904,
-          "menn": 0.253926073054,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.253926073054
         },
         {
           "alder": 55,
           "kvinner": 0.313598824394,
-          "menn": 0.267518199276,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.267518199276
         },
         {
           "alder": 56,
           "kvinner": 0.31844096174,
-          "menn": 0.277040371102,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.277040371102
         },
         {
           "alder": 57,
           "kvinner": 0.325463048428,
-          "menn": 0.291546686178,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.291546686178
         },
         {
           "alder": 58,
           "kvinner": 0.327609812468,
-          "menn": 0.297785966714,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.297785966714
         },
         {
           "alder": 59,
           "kvinner": 0.331825566209,
-          "menn": 0.304634378551,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.304634378551
         },
         {
           "alder": 60,
           "kvinner": 0.336755937993,
-          "menn": 0.316867432183,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.316867432183
         },
         {
           "alder": 61,
           "kvinner": 0.34064336971,
-          "menn": 0.326761814145,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.326761814145
         },
         {
           "alder": 62,
           "kvinner": 0.345336899658,
-          "menn": 0.333989048482,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.333989048482
         },
         {
           "alder": 63,
           "kvinner": 0.35387479637,
-          "menn": 0.347986581613,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.347986581613
         },
         {
           "alder": 64,
           "kvinner": 0.367614169983,
-          "menn": 0.362407804271,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.362407804271
         },
         {
           "alder": 65,
           "kvinner": 0.378970938739,
-          "menn": 0.376730766576,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.376730766576
         },
         {
           "alder": 66,
           "kvinner": 0.393772699276,
-          "menn": 0.388984190933,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.388984190933
         },
         {
           "alder": 67,
           "kvinner": 0.403165829873,
-          "menn": 0.399481903094,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.399481903094
         },
         {
           "alder": 68,
           "kvinner": 0.41225015644,
-          "menn": 0.407822891405,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.407822891405
         },
         {
           "alder": 69,
           "kvinner": 0.422463329522,
-          "menn": 0.414376225675,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.414376225675
         },
         {
           "alder": 70,
           "kvinner": 0.426270880904,
-          "menn": 0.427260242618,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.427260242618
         },
         {
           "alder": 71,
           "kvinner": 0.425778055345,
-          "menn": 0.424131808171,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.424131808171
         },
         {
           "alder": 72,
           "kvinner": 0.440516171977,
-          "menn": 0.441590597453,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.441590597453
         },
         {
           "alder": 73,
           "kvinner": 0.46926326764,
-          "menn": 0.465674117561,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.465674117561
         },
         {
           "alder": 74,
           "kvinner": 0.506235353883,
-          "menn": 0.5103696946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.5103696946
         },
         {
           "alder": 75,
           "kvinner": 0.541006749901,
-          "menn": 0.547518971452,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.547518971452
         },
         {
           "alder": 76,
           "kvinner": 0.589765059351,
-          "menn": 0.600569979628,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.600569979628
         },
         {
           "alder": 77,
           "kvinner": 0.610096081508,
-          "menn": 0.62230856208,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.62230856208
         },
         {
           "alder": 78,
           "kvinner": 0.60252543626,
-          "menn": 0.613202702703,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.613202702703
         },
         {
           "alder": 79,
           "kvinner": 0.596519147216,
-          "menn": 0.626079007313,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.626079007313
         },
         {
           "alder": 80,
           "kvinner": 0.576893285681,
-          "menn": 0.587208916606,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.587208916606
         },
         {
           "alder": 81,
           "kvinner": 0.581871807784,
-          "menn": 0.590062672711,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.590062672711
         },
         {
           "alder": 82,
           "kvinner": 0.595740714852,
-          "menn": 0.609187736211,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.609187736211
         },
         {
           "alder": 83,
           "kvinner": 0.619474393531,
-          "menn": 0.628119819226,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.628119819226
         },
         {
           "alder": 84,
           "kvinner": 0.619016176956,
-          "menn": 0.637555032251,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.637555032251
         },
         {
           "alder": 85,
           "kvinner": 0.607534769086,
-          "menn": 0.623371417118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.623371417118
         },
         {
           "alder": 86,
           "kvinner": 0.593718655968,
-          "menn": 0.621825935259,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.621825935259
         },
         {
           "alder": 87,
           "kvinner": 0.588484183662,
-          "menn": 0.610854797108,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.610854797108
         },
         {
           "alder": 88,
           "kvinner": 0.599549836082,
-          "menn": 0.620211249895,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.620211249895
         },
         {
           "alder": 89,
           "kvinner": 0.611350166437,
-          "menn": 0.640575709779,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.640575709779
         },
         {
           "alder": 90,
           "kvinner": 0.628825976284,
-          "menn": 0.65418249804,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.65418249804
         },
         {
           "alder": 91,
           "kvinner": 0.634719580896,
-          "menn": 0.657972295903,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.657972295903
         },
         {
           "alder": 92,
           "kvinner": 0.639964073393,
-          "menn": 0.667446868271,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.667446868271
         },
         {
           "alder": 93,
           "kvinner": 0.629549771549,
-          "menn": 0.673952641166,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.673952641166
         },
         {
           "alder": 94,
           "kvinner": 0.635098026694,
-          "menn": 0.698246189149,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.698246189149
         },
         {
           "alder": 95,
           "kvinner": 0.629136924075,
-          "menn": 0.67736935341,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.67736935341
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/nt_pro_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/nt_pro_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 6638,
           "tot_pas": 4479.66666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.48180668204,
-          "borhf": null
+          "prove_pr_pas": 1.48180668204
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 16530.6666667,
           "tot_pas": 10856,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.52272169,
-          "borhf": null
+          "prove_pr_pas": 1.52272169
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 15640.6666667,
           "tot_pas": 10001.3333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.56385815225,
-          "borhf": null
+          "prove_pr_pas": 1.56385815225
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 6890.66666667,
           "tot_pas": 4441.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.551369606,
-          "borhf": null
+          "prove_pr_pas": 1.551369606
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 8746.33333333,
           "tot_pas": 5731,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.52614436108,
-          "borhf": null
+          "prove_pr_pas": 1.52614436108
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 15680.6666667,
           "tot_pas": 10081,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.55546738088,
-          "borhf": null
+          "prove_pr_pas": 1.55546738088
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 23322.6666667,
           "tot_pas": 14605.6666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.59682315083,
-          "borhf": null
+          "prove_pr_pas": 1.59682315083
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 6597.33333333,
           "tot_pas": 4279.66666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.54155308046,
-          "borhf": null
+          "prove_pr_pas": 1.54155308046
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 38608.6666667,
           "tot_pas": 22110.3333333,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.7461820265,
-          "borhf": null
+          "prove_pr_pas": 1.7461820265
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 16272.6666667,
           "tot_pas": 10240.6666667,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.58902415207,
-          "borhf": null
+          "prove_pr_pas": 1.58902415207
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 14575,
           "tot_pas": 9587.33333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.52023503233,
-          "borhf": null
+          "prove_pr_pas": 1.52023503233
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 29073.3333333,
           "tot_pas": 18487.3333333,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.57260827233,
-          "borhf": null
+          "prove_pr_pas": 1.57260827233
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 54828,
           "tot_pas": 33432,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.6399856425,
-          "borhf": null
+          "prove_pr_pas": 1.6399856425
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 22608.6666667,
           "tot_pas": 13651,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.65619124362,
-          "borhf": null
+          "prove_pr_pas": 1.65619124362
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 7859.33333333,
           "tot_pas": 5184.66666667,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.51588015944,
-          "borhf": null
+          "prove_pr_pas": 1.51588015944
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 11847.3333333,
           "tot_pas": 7290,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.6251486054,
-          "borhf": null
+          "prove_pr_pas": 1.6251486054
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 27734.6666667,
           "tot_pas": 18656.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.48660865836,
-          "borhf": null
+          "prove_pr_pas": 1.48660865836
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 45036.6666667,
           "tot_pas": 26985.3333333,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.66893127131,
-          "borhf": null
+          "prove_pr_pas": 1.66893127131
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 27343.3333333,
           "tot_pas": 16456.6666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.66153534535,
-          "borhf": null
+          "prove_pr_pas": 1.66153534535
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 11597.3333333,
           "tot_pas": 7015.33333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.65314073933,
-          "borhf": null
+          "prove_pr_pas": 1.65314073933
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 42672.3333333,
           "tot_pas": 24690.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.7283012245,
-          "borhf": null
+          "prove_pr_pas": 1.7283012245
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 450107,
           "tot_pas": 278265.666667,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.61754414546,
-          "borhf": null
+          "prove_pr_pas": 1.61754414546
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 45700,
           "tot_pas": 29773,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.53494777147,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.53494777147
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 47749.6666667,
           "tot_pas": 30412,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.57009294577,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57009294577
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 76053.6666667,
           "tot_pas": 46210,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.64582702157,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.64582702157
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 280603.666667,
           "tot_pas": 171567,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.63553402849,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.63553402849
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 450107,
           "tot_pas": 277884.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.61976385858,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.61976385858
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 0.00288877832154,
-          "menn": 0.00312420839314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00312420839314
         },
         {
           "alder": 1,
           "kvinner": 0.00138480937006,
-          "menn": 0.00147944262859,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00147944262859
         },
         {
           "alder": 2,
           "kvinner": 0.000959011152945,
-          "menn": 0.00116953592814,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00116953592814
         },
         {
           "alder": 3,
           "kvinner": 0.000800100186458,
-          "menn": 0.000970262757644,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000970262757644
         },
         {
           "alder": 4,
           "kvinner": 0.000880119532513,
-          "menn": 0.000922812836778,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000922812836778
         },
         {
           "alder": 5,
           "kvinner": 0.000710084540254,
-          "menn": 0.00100270985511,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00100270985511
         },
         {
           "alder": 6,
           "kvinner": 0.000881156501345,
-          "menn": 0.00104455071734,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00104455071734
         },
         {
           "alder": 7,
           "kvinner": 0.000872907302456,
-          "menn": 0.00108465247735,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00108465247735
         },
         {
           "alder": 8,
           "kvinner": 0.00106190387851,
-          "menn": 0.000900769305677,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000900769305677
         },
         {
           "alder": 9,
           "kvinner": 0.00104964969522,
-          "menn": 0.00114418532208,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00114418532208
         },
         {
           "alder": 10,
           "kvinner": 0.00109636686704,
-          "menn": 0.00148122487741,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00148122487741
         },
         {
           "alder": 11,
           "kvinner": 0.00137568862953,
-          "menn": 0.00146637180274,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00146637180274
         },
         {
           "alder": 12,
           "kvinner": 0.00182882455308,
-          "menn": 0.00156832111525,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00156832111525
         },
         {
           "alder": 13,
           "kvinner": 0.00242775822084,
-          "menn": 0.00229555585245,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00229555585245
         },
         {
           "alder": 14,
           "kvinner": 0.00315855969678,
-          "menn": 0.00278582298365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00278582298365
         },
         {
           "alder": 15,
           "kvinner": 0.0039260984964,
-          "menn": 0.00352611490186,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00352611490186
         },
         {
           "alder": 16,
           "kvinner": 0.00476209089014,
-          "menn": 0.0039756869069,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0039756869069
         },
         {
           "alder": 17,
           "kvinner": 0.00534538144823,
-          "menn": 0.00419458983515,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00419458983515
         },
         {
           "alder": 18,
           "kvinner": 0.00608776365906,
-          "menn": 0.00448657340215,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00448657340215
         },
         {
           "alder": 19,
           "kvinner": 0.00629903223959,
-          "menn": 0.00487924029216,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00487924029216
         },
         {
           "alder": 20,
           "kvinner": 0.00621016608584,
-          "menn": 0.004900670772,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.004900670772
         },
         {
           "alder": 21,
           "kvinner": 0.00661838701512,
-          "menn": 0.00546805895395,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00546805895395
         },
         {
           "alder": 22,
           "kvinner": 0.00719129706294,
-          "menn": 0.00559346555633,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00559346555633
         },
         {
           "alder": 23,
           "kvinner": 0.0075715983614,
-          "menn": 0.00569517827036,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00569517827036
         },
         {
           "alder": 24,
           "kvinner": 0.00816787617476,
-          "menn": 0.00592773491702,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00592773491702
         },
         {
           "alder": 25,
           "kvinner": 0.00820725340618,
-          "menn": 0.00634844452201,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00634844452201
         },
         {
           "alder": 26,
           "kvinner": 0.00864058238886,
-          "menn": 0.00665678885095,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00665678885095
         },
         {
           "alder": 27,
           "kvinner": 0.00863121715634,
-          "menn": 0.00717684398418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00717684398418
         },
         {
           "alder": 28,
           "kvinner": 0.00882941186036,
-          "menn": 0.00757047929037,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00757047929037
         },
         {
           "alder": 29,
           "kvinner": 0.00954770106335,
-          "menn": 0.00826314462561,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00826314462561
         },
         {
           "alder": 30,
           "kvinner": 0.0101571882256,
-          "menn": 0.00843511568601,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00843511568601
         },
         {
           "alder": 31,
           "kvinner": 0.0103355141394,
-          "menn": 0.0092503772225,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0092503772225
         },
         {
           "alder": 32,
           "kvinner": 0.0115645216021,
-          "menn": 0.00955826451697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00955826451697
         },
         {
           "alder": 33,
           "kvinner": 0.0119768798977,
-          "menn": 0.0103486705939,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0103486705939
         },
         {
           "alder": 34,
           "kvinner": 0.0124000384848,
-          "menn": 0.0107876023078,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0107876023078
         },
         {
           "alder": 35,
           "kvinner": 0.0126447088119,
-          "menn": 0.0108648834905,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0108648834905
         },
         {
           "alder": 36,
           "kvinner": 0.0133695388979,
-          "menn": 0.0113123156784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0113123156784
         },
         {
           "alder": 37,
           "kvinner": 0.0137736898197,
-          "menn": 0.0122032527434,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0122032527434
         },
         {
           "alder": 38,
           "kvinner": 0.0146524201254,
-          "menn": 0.0125640955332,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0125640955332
         },
         {
           "alder": 39,
           "kvinner": 0.0150984234695,
-          "menn": 0.0132812672359,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0132812672359
         },
         {
           "alder": 40,
           "kvinner": 0.016154783164,
-          "menn": 0.0147817637598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0147817637598
         },
         {
           "alder": 41,
           "kvinner": 0.0173632561897,
-          "menn": 0.0153051238893,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0153051238893
         },
         {
           "alder": 42,
           "kvinner": 0.0182509235157,
-          "menn": 0.0162267598608,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0162267598608
         },
         {
           "alder": 43,
           "kvinner": 0.0191150235428,
-          "menn": 0.0167235589598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0167235589598
         },
         {
           "alder": 44,
           "kvinner": 0.0198179267666,
-          "menn": 0.0179948586118,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0179948586118
         },
         {
           "alder": 45,
           "kvinner": 0.0202068596229,
-          "menn": 0.0189984114504,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0189984114504
         },
         {
           "alder": 46,
           "kvinner": 0.0212338593974,
-          "menn": 0.0208823282379,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0208823282379
         },
         {
           "alder": 47,
           "kvinner": 0.0220234524134,
-          "menn": 0.0225995735342,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0225995735342
         },
         {
           "alder": 48,
           "kvinner": 0.0238244819705,
-          "menn": 0.0245164146223,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0245164146223
         },
         {
           "alder": 49,
           "kvinner": 0.0263788194388,
-          "menn": 0.0265897731642,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0265897731642
         },
         {
           "alder": 50,
           "kvinner": 0.0275609505418,
-          "menn": 0.0298354812883,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0298354812883
         },
         {
           "alder": 51,
           "kvinner": 0.0292700514602,
-          "menn": 0.0326420910901,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0326420910901
         },
         {
           "alder": 52,
           "kvinner": 0.0308530246007,
-          "menn": 0.0336508469067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0336508469067
         },
         {
           "alder": 53,
           "kvinner": 0.0324470026674,
-          "menn": 0.0368533748082,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0368533748082
         },
         {
           "alder": 54,
           "kvinner": 0.0346845036459,
-          "menn": 0.040079230828,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.040079230828
         },
         {
           "alder": 55,
           "kvinner": 0.0362615723733,
-          "menn": 0.0432595685767,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0432595685767
         },
         {
           "alder": 56,
           "kvinner": 0.0377731805006,
-          "menn": 0.0478287328342,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0478287328342
         },
         {
           "alder": 57,
           "kvinner": 0.040446741739,
-          "menn": 0.0515955438066,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0515955438066
         },
         {
           "alder": 58,
           "kvinner": 0.0420031904337,
-          "menn": 0.0533542755309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0533542755309
         },
         {
           "alder": 59,
           "kvinner": 0.0433217596279,
-          "menn": 0.0562881975369,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0562881975369
         },
         {
           "alder": 60,
           "kvinner": 0.0460859196236,
-          "menn": 0.059660210882,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.059660210882
         },
         {
           "alder": 61,
           "kvinner": 0.0473833097595,
-          "menn": 0.0630700919759,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0630700919759
         },
         {
           "alder": 62,
           "kvinner": 0.0500137670613,
-          "menn": 0.0670699852303,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0670699852303
         },
         {
           "alder": 63,
           "kvinner": 0.0526879218059,
-          "menn": 0.0717804456067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0717804456067
         },
         {
           "alder": 64,
           "kvinner": 0.0561745370026,
-          "menn": 0.0764675261461,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0764675261461
         },
         {
           "alder": 65,
           "kvinner": 0.0586170658498,
-          "menn": 0.080460801502,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.080460801502
         },
         {
           "alder": 66,
           "kvinner": 0.0627685859723,
-          "menn": 0.0855298279581,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0855298279581
         },
         {
           "alder": 67,
           "kvinner": 0.0674258099055,
-          "menn": 0.0893607705779,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0893607705779
         },
         {
           "alder": 68,
           "kvinner": 0.0730224169029,
-          "menn": 0.0963876035886,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0963876035886
         },
         {
           "alder": 69,
           "kvinner": 0.0787434523676,
-          "menn": 0.0998491476844,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0998491476844
         },
         {
           "alder": 70,
           "kvinner": 0.0808721908424,
-          "menn": 0.103334096284,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103334096284
         },
         {
           "alder": 71,
           "kvinner": 0.0830024832345,
-          "menn": 0.107398968153,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.107398968153
         },
         {
           "alder": 72,
           "kvinner": 0.0896644579589,
-          "menn": 0.115635651322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.115635651322
         },
         {
           "alder": 73,
           "kvinner": 0.10060143005,
-          "menn": 0.125773480888,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.125773480888
         },
         {
           "alder": 74,
           "kvinner": 0.114014388018,
-          "menn": 0.14405491116,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.14405491116
         },
         {
           "alder": 75,
           "kvinner": 0.129589270746,
-          "menn": 0.163325662337,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.163325662337
         },
         {
           "alder": 76,
           "kvinner": 0.149051864257,
-          "menn": 0.187248060335,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.187248060335
         },
         {
           "alder": 77,
           "kvinner": 0.159845667734,
-          "menn": 0.200543700532,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.200543700532
         },
         {
           "alder": 78,
           "kvinner": 0.170502153427,
-          "menn": 0.207810810811,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.207810810811
         },
         {
           "alder": 79,
           "kvinner": 0.171478730929,
-          "menn": 0.216580745714,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.216580745714
         },
         {
           "alder": 80,
           "kvinner": 0.172661674979,
-          "menn": 0.209629801632,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.209629801632
         },
         {
           "alder": 81,
           "kvinner": 0.18151212143,
-          "menn": 0.216428558528,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.216428558528
         },
         {
           "alder": 82,
           "kvinner": 0.19629681408,
-          "menn": 0.230036985388,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.230036985388
         },
         {
           "alder": 83,
           "kvinner": 0.21221361186,
-          "menn": 0.246360684032,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.246360684032
         },
         {
           "alder": 84,
           "kvinner": 0.223029235905,
-          "menn": 0.257934882769,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.257934882769
         },
         {
           "alder": 85,
           "kvinner": 0.22438041586,
-          "menn": 0.261346390631,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.261346390631
         },
         {
           "alder": 86,
           "kvinner": 0.227808425276,
-          "menn": 0.270045874523,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.270045874523
         },
         {
           "alder": 87,
           "kvinner": 0.232957979807,
-          "menn": 0.273840229593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.273840229593
         },
         {
           "alder": 88,
           "kvinner": 0.25106424622,
-          "menn": 0.280618660407,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.280618660407
         },
         {
           "alder": 89,
           "kvinner": 0.260236529458,
-          "menn": 0.300078864353,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.300078864353
         },
         {
           "alder": 90,
           "kvinner": 0.275284037996,
-          "menn": 0.30926964598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.30926964598
         },
         {
           "alder": 91,
           "kvinner": 0.29121963472,
-          "menn": 0.325375773652,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.325375773652
         },
         {
           "alder": 92,
           "kvinner": 0.30007270861,
-          "menn": 0.332178634959,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.332178634959
         },
         {
           "alder": 93,
           "kvinner": 0.300528774578,
-          "menn": 0.342805100182,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.342805100182
         },
         {
           "alder": 94,
           "kvinner": 0.313046810141,
-          "menn": 0.353220783478,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.353220783478
         },
         {
           "alder": 95,
           "kvinner": 0.320246593121,
-          "menn": 0.348317094774,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.348317094774
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/p_bil_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/p_bil_rb1.json
@@ -200,8 +200,7 @@
           "tot_events": 8434.66666667,
           "tot_pas": 6016.66666667,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.40188365651,
-          "borhf": null
+          "prove_pr_pas": 1.40188365651
         },
         {
           "bohf": "UNN",
@@ -213,8 +212,7 @@
           "tot_events": 8886.66666667,
           "tot_pas": 6843,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.29865068927,
-          "borhf": null
+          "prove_pr_pas": 1.29865068927
         },
         {
           "bohf": "Nordland",
@@ -226,8 +224,7 @@
           "tot_events": 9397.33333333,
           "tot_pas": 7315.33333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.28460767338,
-          "borhf": null
+          "prove_pr_pas": 1.28460767338
         },
         {
           "bohf": "Helgeland",
@@ -239,8 +236,7 @@
           "tot_events": 9965,
           "tot_pas": 7522.66666667,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.32466323999,
-          "borhf": null
+          "prove_pr_pas": 1.32466323999
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -252,8 +248,7 @@
           "tot_events": 15823.6666667,
           "tot_pas": 11730.6666667,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.34891452603,
-          "borhf": null
+          "prove_pr_pas": 1.34891452603
         },
         {
           "bohf": "St. Olav",
@@ -265,8 +260,7 @@
           "tot_events": 26768,
           "tot_pas": 20505,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.30543769812,
-          "borhf": null
+          "prove_pr_pas": 1.30543769812
         },
         {
           "bohf": "Møre og Romsdal",
@@ -278,8 +272,7 @@
           "tot_events": 24598.3333333,
           "tot_pas": 18469.3333333,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.33184738666,
-          "borhf": null
+          "prove_pr_pas": 1.33184738666
         },
         {
           "bohf": "Førde",
@@ -291,8 +284,7 @@
           "tot_events": 10953,
           "tot_pas": 7911,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.38452787258,
-          "borhf": null
+          "prove_pr_pas": 1.38452787258
         },
         {
           "bohf": "Bergen",
@@ -304,8 +296,7 @@
           "tot_events": 65258,
           "tot_pas": 41581,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.5694187249,
-          "borhf": null
+          "prove_pr_pas": 1.5694187249
         },
         {
           "bohf": "Fonna",
@@ -317,8 +308,7 @@
           "tot_events": 30227.6666667,
           "tot_pas": 20617.3333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.46612882364,
-          "borhf": null
+          "prove_pr_pas": 1.46612882364
         },
         {
           "bohf": "Stavanger",
@@ -330,8 +320,7 @@
           "tot_events": 38438.3333333,
           "tot_pas": 27281.3333333,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.4089609501,
-          "borhf": null
+          "prove_pr_pas": 1.4089609501
         },
         {
           "bohf": "Østfold",
@@ -343,8 +332,7 @@
           "tot_events": 44797,
           "tot_pas": 32011.6666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.39939605352,
-          "borhf": null
+          "prove_pr_pas": 1.39939605352
         },
         {
           "bohf": "Akershus",
@@ -356,8 +344,7 @@
           "tot_events": 87188.6666667,
           "tot_pas": 61588.6666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.41566088999,
-          "borhf": null
+          "prove_pr_pas": 1.41566088999
         },
         {
           "bohf": "OUS",
@@ -369,8 +356,7 @@
           "tot_events": 35695.6666667,
           "tot_pas": 25970.3333333,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.3744785717,
-          "borhf": null
+          "prove_pr_pas": 1.3744785717
         },
         {
           "bohf": "Lovisenberg",
@@ -382,8 +368,7 @@
           "tot_events": 15938,
           "tot_pas": 12178,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.3087534899,
-          "borhf": null
+          "prove_pr_pas": 1.3087534899
         },
         {
           "bohf": "Diakonhjemmet",
@@ -395,8 +380,7 @@
           "tot_events": 16028.3333333,
           "tot_pas": 11769,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.36191123573,
-          "borhf": null
+          "prove_pr_pas": 1.36191123573
         },
         {
           "bohf": "Innlandet",
@@ -408,8 +392,7 @@
           "tot_events": 37536.6666667,
           "tot_pas": 26950.3333333,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.39280899432,
-          "borhf": null
+          "prove_pr_pas": 1.39280899432
         },
         {
           "bohf": "Vestre Viken",
@@ -421,8 +404,7 @@
           "tot_events": 63667.6666667,
           "tot_pas": 45475,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.40005864028,
-          "borhf": null
+          "prove_pr_pas": 1.40005864028
         },
         {
           "bohf": "Vestfold",
@@ -434,8 +416,7 @@
           "tot_events": 32424.3333333,
           "tot_pas": 22261.3333333,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.45653150455,
-          "borhf": null
+          "prove_pr_pas": 1.45653150455
         },
         {
           "bohf": "Telemark",
@@ -447,8 +428,7 @@
           "tot_events": 23432.3333333,
           "tot_pas": 16848.3333333,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.39078049263,
-          "borhf": null
+          "prove_pr_pas": 1.39078049263
         },
         {
           "bohf": "Sørlandet",
@@ -460,8 +440,7 @@
           "tot_events": 21534.3333333,
           "tot_pas": 14620.3333333,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.47290303459,
-          "borhf": null
+          "prove_pr_pas": 1.47290303459
         },
         {
           "bohf": "Norge",
@@ -473,8 +452,7 @@
           "tot_events": 626995.333333,
           "tot_pas": 445468,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.40749803203,
-          "borhf": null
+          "prove_pr_pas": 1.40749803203
         }
       ]
     },
@@ -493,9 +471,7 @@
           "tot_events": 36683.6666667,
           "tot_pas": 27689.3333333,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.32483025955,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.32483025955
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -507,9 +483,7 @@
           "tot_events": 67190,
           "tot_pas": 50693,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.32542954649,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.32542954649
         },
         {
           "borhf": "Helse Vest",
@@ -521,9 +495,7 @@
           "tot_events": 144877,
           "tot_pas": 97354.3333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.48814125719,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.48814125719
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -535,9 +507,7 @@
           "tot_events": 378244.666667,
           "tot_pas": 269067.333333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.40576212646,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.40576212646
         },
         {
           "borhf": "Norge",
@@ -549,9 +519,7 @@
           "tot_events": 626995.333333,
           "tot_pas": 444593.333333,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.41026706053,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41026706053
         }
       ]
     },
@@ -563,674 +531,482 @@
         {
           "alder": 0,
           "kvinner": 0.00641620686326,
-          "menn": 0.00839455093023,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00839455093023
         },
         {
           "alder": 1,
           "kvinner": 0.00413256269907,
-          "menn": 0.00520213314984,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00520213314984
         },
         {
           "alder": 2,
           "kvinner": 0.0049442352774,
-          "menn": 0.00533308383234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00533308383234
         },
         {
           "alder": 3,
           "kvinner": 0.00608076141708,
-          "menn": 0.00679839513295,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00679839513295
         },
         {
           "alder": 4,
           "kvinner": 0.00701366573197,
-          "menn": 0.0080859054859,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0080859054859
         },
         {
           "alder": 5,
           "kvinner": 0.00788461796112,
-          "menn": 0.00818033546356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00818033546356
         },
         {
           "alder": 6,
           "kvinner": 0.00921570446143,
-          "menn": 0.00904228542663,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00904228542663
         },
         {
           "alder": 7,
           "kvinner": 0.0100710051462,
-          "menn": 0.00934660534765,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00934660534765
         },
         {
           "alder": 8,
           "kvinner": 0.0107469790114,
-          "menn": 0.0106570746908,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0106570746908
         },
         {
           "alder": 9,
           "kvinner": 0.0126021195336,
-          "menn": 0.0124542475634,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0124542475634
         },
         {
           "alder": 10,
           "kvinner": 0.0137991002231,
-          "menn": 0.0136057672207,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0136057672207
         },
         {
           "alder": 11,
           "kvinner": 0.0155597293851,
-          "menn": 0.0143477923951,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0143477923951
         },
         {
           "alder": 12,
           "kvinner": 0.0173200442968,
-          "menn": 0.015220526379,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.015220526379
         },
         {
           "alder": 13,
           "kvinner": 0.0237728640519,
-          "menn": 0.0179697083794,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0179697083794
         },
         {
           "alder": 14,
           "kvinner": 0.0319207910581,
-          "menn": 0.0225381670021,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0225381670021
         },
         {
           "alder": 15,
           "kvinner": 0.0401110988533,
-          "menn": 0.0258272451145,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0258272451145
         },
         {
           "alder": 16,
           "kvinner": 0.0457251928289,
-          "menn": 0.0286547168641,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0286547168641
         },
         {
           "alder": 17,
           "kvinner": 0.0526070853774,
-          "menn": 0.0317468081984,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0317468081984
         },
         {
           "alder": 18,
           "kvinner": 0.0546618442531,
-          "menn": 0.0314240805536,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0314240805536
         },
         {
           "alder": 19,
           "kvinner": 0.0535863126483,
-          "menn": 0.0305980197076,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0305980197076
         },
         {
           "alder": 20,
           "kvinner": 0.0548868167404,
-          "menn": 0.0303689538413,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0303689538413
         },
         {
           "alder": 21,
           "kvinner": 0.055496903805,
-          "menn": 0.030148993119,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.030148993119
         },
         {
           "alder": 22,
           "kvinner": 0.0555613308792,
-          "menn": 0.0308665884417,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0308665884417
         },
         {
           "alder": 23,
           "kvinner": 0.0567658716991,
-          "menn": 0.0316448915379,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0316448915379
         },
         {
           "alder": 24,
           "kvinner": 0.0583698551548,
-          "menn": 0.0330243658767,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0330243658767
         },
         {
           "alder": 25,
           "kvinner": 0.0595402085962,
-          "menn": 0.0344692176797,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0344692176797
         },
         {
           "alder": 26,
           "kvinner": 0.0605407734569,
-          "menn": 0.0350984560545,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0350984560545
         },
         {
           "alder": 27,
           "kvinner": 0.0613689486161,
-          "menn": 0.0367027709272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0367027709272
         },
         {
           "alder": 28,
           "kvinner": 0.0626676856534,
-          "menn": 0.0371764608009,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0371764608009
         },
         {
           "alder": 29,
           "kvinner": 0.0636085496053,
-          "menn": 0.0387997345092,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0387997345092
         },
         {
           "alder": 30,
           "kvinner": 0.0669370980225,
-          "menn": 0.0399971091403,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0399971091403
         },
         {
           "alder": 31,
           "kvinner": 0.0687599535144,
-          "menn": 0.0407141042327,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0407141042327
         },
         {
           "alder": 32,
           "kvinner": 0.0710454590234,
-          "menn": 0.0426058461135,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0426058461135
         },
         {
           "alder": 33,
           "kvinner": 0.0710165064192,
-          "menn": 0.044058801677,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.044058801677
         },
         {
           "alder": 34,
           "kvinner": 0.0723684582864,
-          "menn": 0.0436978397961,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0436978397961
         },
         {
           "alder": 35,
           "kvinner": 0.0721902074897,
-          "menn": 0.0440786923375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0440786923375
         },
         {
           "alder": 36,
           "kvinner": 0.0711081900677,
-          "menn": 0.0443623423404,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0443623423404
         },
         {
           "alder": 37,
           "kvinner": 0.0712895602613,
-          "menn": 0.0464412189044,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0464412189044
         },
         {
           "alder": 38,
           "kvinner": 0.0713278646501,
-          "menn": 0.0461323315693,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0461323315693
         },
         {
           "alder": 39,
           "kvinner": 0.0711632396385,
-          "menn": 0.0469918591568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0469918591568
         },
         {
           "alder": 40,
           "kvinner": 0.0717799827335,
-          "menn": 0.0494884739099,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0494884739099
         },
         {
           "alder": 41,
           "kvinner": 0.070195551965,
-          "menn": 0.0491475096321,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0491475096321
         },
         {
           "alder": 42,
           "kvinner": 0.0705429620099,
-          "menn": 0.0499190063282,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0499190063282
         },
         {
           "alder": 43,
           "kvinner": 0.0705407539555,
-          "menn": 0.0488718674548,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0488718674548
         },
         {
           "alder": 44,
           "kvinner": 0.0696600414485,
-          "menn": 0.0505697732418,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0505697732418
         },
         {
           "alder": 45,
           "kvinner": 0.0702589972663,
-          "menn": 0.0499617571391,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0499617571391
         },
         {
           "alder": 46,
           "kvinner": 0.0706489349961,
-          "menn": 0.0510089450697,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0510089450697
         },
         {
           "alder": 47,
           "kvinner": 0.0737005726752,
-          "menn": 0.0539100478866,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0539100478866
         },
         {
           "alder": 48,
           "kvinner": 0.0758440658138,
-          "menn": 0.0556264734041,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0556264734041
         },
         {
           "alder": 49,
           "kvinner": 0.0775701990925,
-          "menn": 0.0576086120723,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0576086120723
         },
         {
           "alder": 50,
           "kvinner": 0.0815847411326,
-          "menn": 0.0604922647796,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0604922647796
         },
         {
           "alder": 51,
           "kvinner": 0.084603450348,
-          "menn": 0.0642080692871,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0642080692871
         },
         {
           "alder": 52,
           "kvinner": 0.0879733353935,
-          "menn": 0.0662060360781,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0662060360781
         },
         {
           "alder": 53,
           "kvinner": 0.0891927558613,
-          "menn": 0.0676293250384,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0676293250384
         },
         {
           "alder": 54,
           "kvinner": 0.0910891657576,
-          "menn": 0.0720771354673,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0720771354673
         },
         {
           "alder": 55,
           "kvinner": 0.0927612049963,
-          "menn": 0.0739861998124,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0739861998124
         },
         {
           "alder": 56,
           "kvinner": 0.094345749991,
-          "menn": 0.0765741974005,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0765741974005
         },
         {
           "alder": 57,
           "kvinner": 0.094320349517,
-          "menn": 0.0791163141994,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0791163141994
         },
         {
           "alder": 58,
           "kvinner": 0.0953989926268,
-          "menn": 0.0803697103332,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0803697103332
         },
         {
           "alder": 59,
           "kvinner": 0.0947217532571,
-          "menn": 0.081717391972,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.081717391972
         },
         {
           "alder": 60,
           "kvinner": 0.0962325566406,
-          "menn": 0.0841713338131,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0841713338131
         },
         {
           "alder": 61,
           "kvinner": 0.0964665273867,
-          "menn": 0.0852584839835,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0852584839835
         },
         {
           "alder": 62,
           "kvinner": 0.0967955525836,
-          "menn": 0.0859481318568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0859481318568
         },
         {
           "alder": 63,
           "kvinner": 0.0969380631005,
-          "menn": 0.0896628234082,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0896628234082
         },
         {
           "alder": 64,
           "kvinner": 0.101396593312,
-          "menn": 0.0931793751986,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0931793751986
         },
         {
           "alder": 65,
           "kvinner": 0.103263295991,
-          "menn": 0.0956874059554,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0956874059554
         },
         {
           "alder": 66,
           "kvinner": 0.105848536981,
-          "menn": 0.0976019474834,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0976019474834
         },
         {
           "alder": 67,
           "kvinner": 0.106499500818,
-          "menn": 0.100014594279,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.100014594279
         },
         {
           "alder": 68,
           "kvinner": 0.109183936393,
-          "menn": 0.101944564296,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.101944564296
         },
         {
           "alder": 69,
           "kvinner": 0.111292937897,
-          "menn": 0.102187358576,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.102187358576
         },
         {
           "alder": 70,
           "kvinner": 0.110961723351,
-          "menn": 0.104638742657,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.104638742657
         },
         {
           "alder": 71,
           "kvinner": 0.110318062185,
-          "menn": 0.103809603646,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.103809603646
         },
         {
           "alder": 72,
           "kvinner": 0.115389852047,
-          "menn": 0.108505386876,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.108505386876
         },
         {
           "alder": 73,
           "kvinner": 0.122760198246,
-          "menn": 0.114178382378,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.114178382378
         },
         {
           "alder": 74,
           "kvinner": 0.130991593334,
-          "menn": 0.12613927625,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.12613927625
         },
         {
           "alder": 75,
           "kvinner": 0.140450875722,
-          "menn": 0.134683048365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.134683048365
         },
         {
           "alder": 76,
           "kvinner": 0.151347091563,
-          "menn": 0.149234970309,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.149234970309
         },
         {
           "alder": 77,
           "kvinner": 0.158104593427,
-          "menn": 0.153908148291,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.153908148291
         },
         {
           "alder": 78,
           "kvinner": 0.155070235762,
-          "menn": 0.149675675676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.149675675676
         },
         {
           "alder": 79,
           "kvinner": 0.150954834798,
-          "menn": 0.156051432682,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.156051432682
         },
         {
           "alder": 80,
           "kvinner": 0.147549226107,
-          "menn": 0.145127048365,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.145127048365
         },
         {
           "alder": 81,
           "kvinner": 0.14780231638,
-          "menn": 0.146946737226,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146946737226
         },
         {
           "alder": 82,
           "kvinner": 0.151933143825,
-          "menn": 0.15230703935,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.15230703935
         },
         {
           "alder": 83,
           "kvinner": 0.159703504043,
-          "menn": 0.161810460337,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161810460337
         },
         {
           "alder": 84,
           "kvinner": 0.157679468838,
-          "menn": 0.163228217467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.163228217467
         },
         {
           "alder": 85,
           "kvinner": 0.157326447978,
-          "menn": 0.160725023623,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.160725023623
         },
         {
           "alder": 86,
           "kvinner": 0.149197592778,
-          "menn": 0.157039477935,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157039477935
         },
         {
           "alder": 87,
           "kvinner": 0.151357764893,
-          "menn": 0.159225487703,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.159225487703
         },
         {
           "alder": 88,
           "kvinner": 0.154376865489,
-          "menn": 0.161832509012,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161832509012
         },
         {
           "alder": 89,
           "kvinner": 0.155016102406,
-          "menn": 0.172318611987,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.172318611987
         },
         {
           "alder": 90,
           "kvinner": 0.160396101074,
-          "menn": 0.172426271033,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.172426271033
         },
         {
           "alder": 91,
           "kvinner": 0.166062650257,
-          "menn": 0.176245210728,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.176245210728
         },
         {
           "alder": 92,
           "kvinner": 0.166887643813,
-          "menn": 0.177605093156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.177605093156
         },
         {
           "alder": 93,
           "kvinner": 0.162688022999,
-          "menn": 0.172677595628,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.172677595628
         },
         {
           "alder": 94,
           "kvinner": 0.167379781595,
-          "menn": 0.18505163088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.18505163088
         },
         {
           "alder": 95,
           "kvinner": 0.160934458144,
-          "menn": 0.185341009743,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.185341009743
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/pro_el_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/pro_el_rb1.json
@@ -253,8 +253,7 @@
           "tot_events": 681,
           "tot_pas": 466,
           "tot_pop": 74308.3333333,
-          "prove_pr_pas": 1.46137339056,
-          "borhf": null
+          "prove_pr_pas": 1.46137339056
         },
         {
           "bohf": "UNN",
@@ -271,8 +270,7 @@
           "tot_events": 2578,
           "tot_pas": 1794.33333333,
           "tot_pop": 192689.666667,
-          "prove_pr_pas": 1.43674530931,
-          "borhf": null
+          "prove_pr_pas": 1.43674530931
         },
         {
           "bohf": "Nordland",
@@ -289,8 +287,7 @@
           "tot_events": 3299.66666667,
           "tot_pas": 2044.33333333,
           "tot_pop": 138332.666667,
-          "prove_pr_pas": 1.61405511169,
-          "borhf": null
+          "prove_pr_pas": 1.61405511169
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +304,7 @@
           "tot_events": 2275.66666667,
           "tot_pas": 1508,
           "tot_pop": 77327.6666667,
-          "prove_pr_pas": 1.5090627763,
-          "borhf": null
+          "prove_pr_pas": 1.5090627763
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +321,7 @@
           "tot_events": 4536.33333333,
           "tot_pas": 3158.33333333,
           "tot_pop": 134761.666667,
-          "prove_pr_pas": 1.4363060686,
-          "borhf": null
+          "prove_pr_pas": 1.4363060686
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +338,7 @@
           "tot_events": 4929.33333333,
           "tot_pas": 3270.33333333,
           "tot_pop": 339813.333333,
-          "prove_pr_pas": 1.50728773825,
-          "borhf": null
+          "prove_pr_pas": 1.50728773825
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +355,7 @@
           "tot_events": 8046,
           "tot_pas": 5006.66666667,
           "tot_pop": 266585.666667,
-          "prove_pr_pas": 1.60705725699,
-          "borhf": null
+          "prove_pr_pas": 1.60705725699
         },
         {
           "bohf": "Førde",
@@ -379,8 +372,7 @@
           "tot_events": 2391.66666667,
           "tot_pas": 1504.66666667,
           "tot_pop": 108538.333333,
-          "prove_pr_pas": 1.5894993354,
-          "borhf": null
+          "prove_pr_pas": 1.5894993354
         },
         {
           "bohf": "Bergen",
@@ -397,8 +389,7 @@
           "tot_events": 7524.66666667,
           "tot_pas": 4870,
           "tot_pop": 461698.666667,
-          "prove_pr_pas": 1.54510609172,
-          "borhf": null
+          "prove_pr_pas": 1.54510609172
         },
         {
           "bohf": "Fonna",
@@ -415,8 +406,7 @@
           "tot_events": 3618.33333333,
           "tot_pas": 2421.33333333,
           "tot_pop": 181471.666667,
-          "prove_pr_pas": 1.49435572687,
-          "borhf": null
+          "prove_pr_pas": 1.49435572687
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +423,7 @@
           "tot_events": 7834.33333333,
           "tot_pas": 5846.66666667,
           "tot_pop": 377328,
-          "prove_pr_pas": 1.33996579247,
-          "borhf": null
+          "prove_pr_pas": 1.33996579247
         },
         {
           "bohf": "Østfold",
@@ -451,8 +440,7 @@
           "tot_events": 9049,
           "tot_pas": 6239.66666667,
           "tot_pop": 323951.333333,
-          "prove_pr_pas": 1.45023772637,
-          "borhf": null
+          "prove_pr_pas": 1.45023772637
         },
         {
           "bohf": "Akershus",
@@ -469,8 +457,7 @@
           "tot_events": 17424,
           "tot_pas": 12268.6666667,
           "tot_pop": 594405.333333,
-          "prove_pr_pas": 1.42020322773,
-          "borhf": null
+          "prove_pr_pas": 1.42020322773
         },
         {
           "bohf": "OUS",
@@ -487,8 +474,7 @@
           "tot_events": 8542.66666667,
           "tot_pas": 6457,
           "tot_pop": 282430.333333,
-          "prove_pr_pas": 1.32300862113,
-          "borhf": null
+          "prove_pr_pas": 1.32300862113
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +491,7 @@
           "tot_events": 3459.33333333,
           "tot_pas": 2781,
           "tot_pop": 163625,
-          "prove_pr_pas": 1.24391705621,
-          "borhf": null
+          "prove_pr_pas": 1.24391705621
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +508,7 @@
           "tot_events": 4641.33333333,
           "tot_pas": 3587.33333333,
           "tot_pop": 145340.333333,
-          "prove_pr_pas": 1.29381155919,
-          "borhf": null
+          "prove_pr_pas": 1.29381155919
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +525,7 @@
           "tot_events": 6971.33333333,
           "tot_pas": 4507.66666667,
           "tot_pop": 339460.666667,
-          "prove_pr_pas": 1.54655032167,
-          "borhf": null
+          "prove_pr_pas": 1.54655032167
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +542,7 @@
           "tot_events": 22188,
           "tot_pas": 15955,
           "tot_pop": 495858,
-          "prove_pr_pas": 1.39066123472,
-          "borhf": null
+          "prove_pr_pas": 1.39066123472
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +559,7 @@
           "tot_events": 7371,
           "tot_pas": 4980.66666667,
           "tot_pop": 250921.666667,
-          "prove_pr_pas": 1.47992236648,
-          "borhf": null
+          "prove_pr_pas": 1.47992236648
         },
         {
           "bohf": "Telemark",
@@ -595,8 +576,7 @@
           "tot_events": 4550.33333333,
           "tot_pas": 3135.66666667,
           "tot_pop": 174350,
-          "prove_pr_pas": 1.45115339641,
-          "borhf": null
+          "prove_pr_pas": 1.45115339641
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +593,7 @@
           "tot_events": 3778.66666667,
           "tot_pas": 2479,
           "tot_pop": 312009.333333,
-          "prove_pr_pas": 1.5242705392,
-          "borhf": null
+          "prove_pr_pas": 1.5242705392
         },
         {
           "bohf": "Norge",
@@ -631,8 +610,7 @@
           "tot_events": 135691.333333,
           "tot_pas": 94283,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.43919193633,
-          "borhf": null
+          "prove_pr_pas": 1.43919193633
         }
       ]
     },
@@ -651,9 +629,7 @@
           "tot_events": 8834.33333333,
           "tot_pas": 5812,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.52001605873,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.52001605873
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +641,7 @@
           "tot_events": 17511.6666667,
           "tot_pas": 11433,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.53167730838,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.53167730838
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +653,7 @@
           "tot_events": 21369,
           "tot_pas": 14639.3333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.45969761829,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.45969761829
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +665,7 @@
           "tot_events": 87976.3333333,
           "tot_pas": 62318.6666667,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.41171719549,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.41171719549
         },
         {
           "borhf": "Norge",
@@ -707,9 +677,7 @@
           "tot_events": 135691.333333,
           "tot_pas": 94181,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.44075061141,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.44075061141
         }
       ]
     },
@@ -721,674 +689,482 @@
         {
           "alder": 0,
           "kvinner": 0.000118818645616,
-          "menn": 8.44380646796e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 8.44380646796e-05
         },
         {
           "alder": 1,
           "kvinner": 0.000306115755486,
-          "menn": 0.00041974883881,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00041974883881
         },
         {
           "alder": 2,
           "kvinner": 0.000404915820132,
-          "menn": 0.000481180496151,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000481180496151
         },
         {
           "alder": 3,
           "kvinner": 0.000480060111875,
-          "menn": 0.000603136308806,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000603136308806
         },
         {
           "alder": 4,
           "kvinner": 0.000600391619079,
-          "menn": 0.000574338059254,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000574338059254
         },
         {
           "alder": 5,
           "kvinner": 0.00050911721754,
-          "menn": 0.000590202636238,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000590202636238
         },
         {
           "alder": 6,
           "kvinner": 0.000642647974665,
-          "menn": 0.000534860307073,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000534860307073
         },
         {
           "alder": 7,
           "kvinner": 0.000683994528044,
-          "menn": 0.000780949783689,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000780949783689
         },
         {
           "alder": 8,
           "kvinner": 0.00078043538059,
-          "menn": 0.000693835816535,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000693835816535
         },
         {
           "alder": 9,
           "kvinner": 0.000935832258391,
-          "menn": 0.000844660368655,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000844660368655
         },
         {
           "alder": 10,
           "kvinner": 0.00104595919499,
-          "menn": 0.00102730112466,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00102730112466
         },
         {
           "alder": 11,
           "kvinner": 0.00120608318205,
-          "menn": 0.000989502923802,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000989502923802
         },
         {
           "alder": 12,
           "kvinner": 0.00134155987977,
-          "menn": 0.00103953851701,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00103953851701
         },
         {
           "alder": 13,
           "kvinner": 0.00178248564109,
-          "menn": 0.00135425649497,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00135425649497
         },
         {
           "alder": 14,
           "kvinner": 0.00246883339565,
-          "menn": 0.00160767758087,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00160767758087
         },
         {
           "alder": 15,
           "kvinner": 0.00333556136719,
-          "menn": 0.00208473810864,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00208473810864
         },
         {
           "alder": 16,
           "kvinner": 0.00428653324995,
-          "menn": 0.00238169075234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00238169075234
         },
         {
           "alder": 17,
           "kvinner": 0.00494463942914,
-          "menn": 0.00262314728758,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00262314728758
         },
         {
           "alder": 18,
           "kvinner": 0.00618378516788,
-          "menn": 0.00346881379817,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00346881379817
         },
         {
           "alder": 19,
           "kvinner": 0.00639447212201,
-          "menn": 0.00336006291182,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00336006291182
         },
         {
           "alder": 20,
           "kvinner": 0.00625412074974,
-          "menn": 0.00348544126505,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00348544126505
         },
         {
           "alder": 21,
           "kvinner": 0.00679125533268,
-          "menn": 0.00346923068087,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00346923068087
         },
         {
           "alder": 22,
           "kvinner": 0.00692834997646,
-          "menn": 0.00342898804981,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00342898804981
         },
         {
           "alder": 23,
           "kvinner": 0.00710101296523,
-          "menn": 0.00384565503008,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00384565503008
         },
         {
           "alder": 24,
           "kvinner": 0.00783075166936,
-          "menn": 0.00424043958484,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00424043958484
         },
         {
           "alder": 25,
           "kvinner": 0.00784261520831,
-          "menn": 0.00407413063397,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00407413063397
         },
         {
           "alder": 26,
           "kvinner": 0.00848750120481,
-          "menn": 0.00465975219567,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00465975219567
         },
         {
           "alder": 27,
           "kvinner": 0.0083880842787,
-          "menn": 0.00459444758369,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00459444758369
         },
         {
           "alder": 28,
           "kvinner": 0.00873184929836,
-          "menn": 0.00457036490126,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00457036490126
         },
         {
           "alder": 29,
           "kvinner": 0.0090983974839,
-          "menn": 0.00532010681375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00532010681375
         },
         {
           "alder": 30,
           "kvinner": 0.00979424087961,
-          "menn": 0.00573525919655,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00573525919655
         },
         {
           "alder": 31,
           "kvinner": 0.0101741057978,
-          "menn": 0.00613407861784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00613407861784
         },
         {
           "alder": 32,
           "kvinner": 0.0106614709327,
-          "menn": 0.00626032245379,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00626032245379
         },
         {
           "alder": 33,
           "kvinner": 0.011359973323,
-          "menn": 0.00621450936687,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00621450936687
         },
         {
           "alder": 34,
           "kvinner": 0.0117888088379,
-          "menn": 0.00682141419563,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00682141419563
         },
         {
           "alder": 35,
           "kvinner": 0.0119936262443,
-          "menn": 0.00630464745661,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00630464745661
         },
         {
           "alder": 36,
           "kvinner": 0.0121588432668,
-          "menn": 0.00676344799817,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00676344799817
         },
         {
           "alder": 37,
           "kvinner": 0.0123662017515,
-          "menn": 0.00693503257115,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00693503257115
         },
         {
           "alder": 38,
           "kvinner": 0.0127822702803,
-          "menn": 0.00670706627547,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00670706627547
         },
         {
           "alder": 39,
           "kvinner": 0.01327327503,
-          "menn": 0.0072087276899,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0072087276899
         },
         {
           "alder": 40,
           "kvinner": 0.0143217001549,
-          "menn": 0.00758912616154,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00758912616154
         },
         {
           "alder": 41,
           "kvinner": 0.0143456256237,
-          "menn": 0.00757147889884,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00757147889884
         },
         {
           "alder": 42,
           "kvinner": 0.0145094249002,
-          "menn": 0.00801529070843,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00801529070843
         },
         {
           "alder": 43,
           "kvinner": 0.0144649489662,
-          "menn": 0.00798712291511,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00798712291511
         },
         {
           "alder": 44,
           "kvinner": 0.0144434759016,
-          "menn": 0.00847945363159,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00847945363159
         },
         {
           "alder": 45,
           "kvinner": 0.0151170983288,
-          "menn": 0.00847226456572,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00847226456572
         },
         {
           "alder": 46,
           "kvinner": 0.0160854210352,
-          "menn": 0.0089030740803,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0089030740803
         },
         {
           "alder": 47,
           "kvinner": 0.015925824925,
-          "menn": 0.00939054823162,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00939054823162
         },
         {
           "alder": 48,
           "kvinner": 0.0173308348046,
-          "menn": 0.0100320159771,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0100320159771
         },
         {
           "alder": 49,
           "kvinner": 0.0176325265215,
-          "menn": 0.0103857490709,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0103857490709
         },
         {
           "alder": 50,
           "kvinner": 0.018635421907,
-          "menn": 0.01157054676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.01157054676
         },
         {
           "alder": 51,
           "kvinner": 0.0197373452642,
-          "menn": 0.0119568099231,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0119568099231
         },
         {
           "alder": 52,
           "kvinner": 0.0209641639167,
-          "menn": 0.0121570827195,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0121570827195
         },
         {
           "alder": 53,
           "kvinner": 0.0212326267022,
-          "menn": 0.0127194477587,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0127194477587
         },
         {
           "alder": 54,
           "kvinner": 0.0223172762244,
-          "menn": 0.0141000316487,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0141000316487
         },
         {
           "alder": 55,
           "kvinner": 0.0229243203527,
-          "menn": 0.0147157340003,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0147157340003
         },
         {
           "alder": 56,
           "kvinner": 0.0239172008997,
-          "menn": 0.0156903045056,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0156903045056
         },
         {
           "alder": 57,
           "kvinner": 0.0240846717125,
-          "menn": 0.0170942692598,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0170942692598
         },
         {
           "alder": 58,
           "kvinner": 0.0245625714393,
-          "menn": 0.0171323285106,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0171323285106
         },
         {
           "alder": 59,
           "kvinner": 0.0247188863759,
-          "menn": 0.0174994625472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0174994625472
         },
         {
           "alder": 60,
           "kvinner": 0.0249250700957,
-          "menn": 0.0185726353994,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0185726353994
         },
         {
           "alder": 61,
           "kvinner": 0.0251482553236,
-          "menn": 0.0196764985728,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0196764985728
         },
         {
           "alder": 62,
           "kvinner": 0.0257378489294,
-          "menn": 0.0193038240018,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0193038240018
         },
         {
           "alder": 63,
           "kvinner": 0.0265500847768,
-          "menn": 0.0207945375543,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0207945375543
         },
         {
           "alder": 64,
           "kvinner": 0.0276818713134,
-          "menn": 0.021728107951,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.021728107951
         },
         {
           "alder": 65,
           "kvinner": 0.028779646814,
-          "menn": 0.0232057317191,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0232057317191
         },
         {
           "alder": 66,
           "kvinner": 0.0306834030683,
-          "menn": 0.0237171593506,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0237171593506
         },
         {
           "alder": 67,
           "kvinner": 0.0309131422453,
-          "menn": 0.0248978400467,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0248978400467
         },
         {
           "alder": 68,
           "kvinner": 0.0318327382486,
-          "menn": 0.0262002886346,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0262002886346
         },
         {
           "alder": 69,
           "kvinner": 0.032900685213,
-          "menn": 0.0274324935888,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0274324935888
         },
         {
           "alder": 70,
           "kvinner": 0.0332442014181,
-          "menn": 0.027176317998,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.027176317998
         },
         {
           "alder": 71,
           "kvinner": 0.0342745832776,
-          "menn": 0.0280671538854,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0280671538854
         },
         {
           "alder": 72,
           "kvinner": 0.0354603491574,
-          "menn": 0.0302370225269,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0302370225269
         },
         {
           "alder": 73,
           "kvinner": 0.0387389420122,
-          "menn": 0.033386728247,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.033386728247
         },
         {
           "alder": 74,
           "kvinner": 0.0406568015338,
-          "menn": 0.0373951952735,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0373951952735
         },
         {
           "alder": 75,
           "kvinner": 0.0438787664887,
-          "menn": 0.0407482074593,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0407482074593
         },
         {
           "alder": 76,
           "kvinner": 0.0484558932178,
-          "menn": 0.045717567509,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.045717567509
         },
         {
           "alder": 77,
           "kvinner": 0.0493626808245,
-          "menn": 0.0485240695744,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0485240695744
         },
         {
           "alder": 78,
           "kvinner": 0.0485019891331,
-          "menn": 0.0479864864865,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0479864864865
         },
         {
           "alder": 79,
           "kvinner": 0.0455567343639,
-          "menn": 0.0477161011869,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0477161011869
         },
         {
           "alder": 80,
           "kvinner": 0.0445854679368,
-          "menn": 0.0463079678896,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0463079678896
         },
         {
           "alder": 81,
           "kvinner": 0.0439968347601,
-          "menn": 0.0475373417379,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0475373417379
         },
         {
           "alder": 82,
           "kvinner": 0.0441617347811,
-          "menn": 0.0485458477334,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0485458477334
         },
         {
           "alder": 83,
           "kvinner": 0.0452998652291,
-          "menn": 0.0498943973838,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0498943973838
         },
         {
           "alder": 84,
           "kvinner": 0.0413411100106,
-          "menn": 0.0479676461554,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0479676461554
         },
         {
           "alder": 85,
           "kvinner": 0.0401384895253,
-          "menn": 0.0454428313719,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0454428313719
         },
         {
           "alder": 86,
           "kvinner": 0.0361919090605,
-          "menn": 0.0444530593784,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0444530593784
         },
         {
           "alder": 87,
           "kvinner": 0.0333564664532,
-          "menn": 0.0431212990882,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0431212990882
         },
         {
           "alder": 88,
           "kvinner": 0.0310710965406,
-          "menn": 0.04002850197,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.04002850197
         },
         {
           "alder": 89,
           "kvinner": 0.0293090850045,
-          "menn": 0.0392843059937,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0392843059937
         },
         {
           "alder": 90,
           "kvinner": 0.0259204072763,
-          "menn": 0.0344370062119,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0344370062119
         },
         {
           "alder": 91,
           "kvinner": 0.0236104632387,
-          "menn": 0.0332301797819,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0332301797819
         },
         {
           "alder": 92,
           "kvinner": 0.0232239852872,
-          "menn": 0.0312704802921,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0312704802921
         },
         {
           "alder": 93,
           "kvinner": 0.0187894655783,
-          "menn": 0.029022465088,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.029022465088
         },
         {
           "alder": 94,
           "kvinner": 0.0174340634779,
-          "menn": 0.0295033601049,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0295033601049
         },
         {
           "alder": 95,
           "kvinner": 0.0170343932511,
-          "menn": 0.0265721877768,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0265721877768
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/psa_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/psa_rb1.json
@@ -106,16 +106,13 @@
       "type": "linechart",
       "data": "datasett_3",
       "linevars": [
-        "kvinner",
         "menn"
       ],
       "linevarsLabels": {
         "nb": [
-          "Kvinner",
           "Menn"
         ],
         "en": [
-          "Women",
           "Men"
         ]
       },
@@ -253,8 +250,7 @@
           "tot_events": 6389.33333333,
           "tot_pas": 4236.33333333,
           "tot_pop": 38182.6666667,
-          "prove_pr_pas": 1.50822251947,
-          "borhf": null
+          "prove_pr_pas": 1.50822251947
         },
         {
           "bohf": "UNN",
@@ -271,8 +267,7 @@
           "tot_events": 19232.6666667,
           "tot_pas": 12672.3333333,
           "tot_pop": 97884.6666667,
-          "prove_pr_pas": 1.51768945472,
-          "borhf": null
+          "prove_pr_pas": 1.51768945472
         },
         {
           "bohf": "Nordland",
@@ -289,8 +284,7 @@
           "tot_events": 14574.6666667,
           "tot_pas": 9934,
           "tot_pop": 70037.3333333,
-          "prove_pr_pas": 1.46714985571,
-          "borhf": null
+          "prove_pr_pas": 1.46714985571
         },
         {
           "bohf": "Helgeland",
@@ -307,8 +301,7 @@
           "tot_events": 10154,
           "tot_pas": 6653.33333333,
           "tot_pop": 39458.6666667,
-          "prove_pr_pas": 1.52615230461,
-          "borhf": null
+          "prove_pr_pas": 1.52615230461
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -325,8 +318,7 @@
           "tot_events": 15065.6666667,
           "tot_pas": 10212.6666667,
           "tot_pop": 67992,
-          "prove_pr_pas": 1.47519420328,
-          "borhf": null
+          "prove_pr_pas": 1.47519420328
         },
         {
           "bohf": "St. Olav",
@@ -343,8 +335,7 @@
           "tot_events": 30409,
           "tot_pas": 20511.3333333,
           "tot_pop": 172913.666667,
-          "prove_pr_pas": 1.4825462346,
-          "borhf": null
+          "prove_pr_pas": 1.4825462346
         },
         {
           "bohf": "Møre og Romsdal",
@@ -361,8 +352,7 @@
           "tot_events": 29695,
           "tot_pas": 19474,
           "tot_pop": 135733.666667,
-          "prove_pr_pas": 1.52485365102,
-          "borhf": null
+          "prove_pr_pas": 1.52485365102
         },
         {
           "bohf": "Førde",
@@ -379,8 +369,7 @@
           "tot_events": 12395.6666667,
           "tot_pas": 8079.66666667,
           "tot_pop": 55416.3333333,
-          "prove_pr_pas": 1.53418045299,
-          "borhf": null
+          "prove_pr_pas": 1.53418045299
         },
         {
           "bohf": "Bergen",
@@ -397,8 +386,7 @@
           "tot_events": 40126.3333333,
           "tot_pas": 26703,
           "tot_pop": 233271.666667,
-          "prove_pr_pas": 1.50269008476,
-          "borhf": null
+          "prove_pr_pas": 1.50269008476
         },
         {
           "bohf": "Fonna",
@@ -415,8 +403,7 @@
           "tot_events": 22900.3333333,
           "tot_pas": 15254,
           "tot_pop": 92598.3333333,
-          "prove_pr_pas": 1.50126742712,
-          "borhf": null
+          "prove_pr_pas": 1.50126742712
         },
         {
           "bohf": "Stavanger",
@@ -433,8 +420,7 @@
           "tot_events": 27843,
           "tot_pas": 18034.3333333,
           "tot_pop": 191328.666667,
-          "prove_pr_pas": 1.54388850896,
-          "borhf": null
+          "prove_pr_pas": 1.54388850896
         },
         {
           "bohf": "Østfold",
@@ -451,8 +437,7 @@
           "tot_events": 53529.6666667,
           "tot_pas": 33387,
           "tot_pop": 162630.666667,
-          "prove_pr_pas": 1.60330867304,
-          "borhf": null
+          "prove_pr_pas": 1.60330867304
         },
         {
           "bohf": "Akershus",
@@ -469,8 +454,7 @@
           "tot_events": 76766.3333333,
           "tot_pas": 50806.6666667,
           "tot_pop": 299315.666667,
-          "prove_pr_pas": 1.51095000656,
-          "borhf": null
+          "prove_pr_pas": 1.51095000656
         },
         {
           "bohf": "OUS",
@@ -487,8 +471,7 @@
           "tot_events": 30009.6666667,
           "tot_pas": 20428,
           "tot_pop": 139951,
-          "prove_pr_pas": 1.46904575419,
-          "borhf": null
+          "prove_pr_pas": 1.46904575419
         },
         {
           "bohf": "Lovisenberg",
@@ -505,8 +488,7 @@
           "tot_events": 10691,
           "tot_pas": 7897,
           "tot_pop": 83404.3333333,
-          "prove_pr_pas": 1.3538052425,
-          "borhf": null
+          "prove_pr_pas": 1.3538052425
         },
         {
           "bohf": "Diakonhjemmet",
@@ -523,8 +505,7 @@
           "tot_events": 18687,
           "tot_pas": 12593.3333333,
           "tot_pop": 71313.6666667,
-          "prove_pr_pas": 1.48388035998,
-          "borhf": null
+          "prove_pr_pas": 1.48388035998
         },
         {
           "bohf": "Innlandet",
@@ -541,8 +522,7 @@
           "tot_events": 47059,
           "tot_pas": 30387.6666667,
           "tot_pop": 170462.666667,
-          "prove_pr_pas": 1.54862169959,
-          "borhf": null
+          "prove_pr_pas": 1.54862169959
         },
         {
           "bohf": "Vestre Viken",
@@ -559,8 +539,7 @@
           "tot_events": 68031.6666667,
           "tot_pas": 44567.3333333,
           "tot_pop": 248844.666667,
-          "prove_pr_pas": 1.52649175031,
-          "borhf": null
+          "prove_pr_pas": 1.52649175031
         },
         {
           "bohf": "Vestfold",
@@ -577,8 +556,7 @@
           "tot_events": 33617.6666667,
           "tot_pas": 21663.3333333,
           "tot_pop": 125618.666667,
-          "prove_pr_pas": 1.55182335744,
-          "borhf": null
+          "prove_pr_pas": 1.55182335744
         },
         {
           "bohf": "Telemark",
@@ -595,8 +573,7 @@
           "tot_events": 18045.3333333,
           "tot_pas": 12125.3333333,
           "tot_pop": 87365,
-          "prove_pr_pas": 1.48823400044,
-          "borhf": null
+          "prove_pr_pas": 1.48823400044
         },
         {
           "bohf": "Sørlandet",
@@ -613,8 +590,7 @@
           "tot_events": 36537.3333333,
           "tot_pas": 23479.6666667,
           "tot_pop": 156963,
-          "prove_pr_pas": 1.55612657761,
-          "borhf": null
+          "prove_pr_pas": 1.55612657761
         },
         {
           "bohf": "Norge",
@@ -631,8 +607,7 @@
           "tot_events": 621763.333333,
           "tot_pas": 408484,
           "tot_pop": 2740687,
-          "prove_pr_pas": 1.52212408156,
-          "borhf": null
+          "prove_pr_pas": 1.52212408156
         }
       ]
     },
@@ -651,9 +626,7 @@
           "tot_events": 50350.6666667,
           "tot_pas": 33487,
           "tot_pop": 245563.333333,
-          "prove_pr_pas": 1.50358845721,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.50358845721
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -665,9 +638,7 @@
           "tot_events": 75169.6666667,
           "tot_pas": 50184,
           "tot_pop": 376639.333333,
-          "prove_pr_pas": 1.49788113077,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.49788113077
         },
         {
           "borhf": "Helse Vest",
@@ -679,9 +650,7 @@
           "tot_events": 103265.333333,
           "tot_pas": 68056.6666667,
           "tot_pop": 572615,
-          "prove_pr_pas": 1.51734339031,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.51734339031
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -693,9 +662,7 @@
           "tot_events": 392977.666667,
           "tot_pas": 256888.333333,
           "tot_pop": 1545869.33333,
-          "prove_pr_pas": 1.52976066125,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.52976066125
         },
         {
           "borhf": "Norge",
@@ -707,9 +674,7 @@
           "tot_events": 621763.333333,
           "tot_pas": 408484,
           "tot_pop": 2740687,
-          "prove_pr_pas": 1.52212408156,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.52212408156
         }
       ]
     },
@@ -720,579 +685,387 @@
       "data": [
         {
           "alder": 0,
-          "menn": 0,
-          "bohf": null,
-          "borhf": null
+          "menn": 0
         },
         {
           "alder": 1,
-          "menn": 2.75245140203e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 2.75245140203e-05
         },
         {
           "alder": 2,
-          "menn": 6.01475620188e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 6.01475620188e-05
         },
         {
           "alder": 3,
-          "menn": 0.000124560759427,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000124560759427
         },
         {
           "alder": 4,
-          "menn": 6.45323662083e-05,
-          "bohf": null,
-          "borhf": null
+          "menn": 6.45323662083e-05
         },
         {
           "alder": 5,
-          "menn": 0.000152310357739,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000152310357739
         },
         {
           "alder": 6,
-          "menn": 0.000138434432419,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000138434432419
         },
         {
           "alder": 7,
-          "menn": 0.000173544396375,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000173544396375
         },
         {
           "alder": 8,
-          "menn": 0.00017650209368,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00017650209368
         },
         {
           "alder": 9,
-          "menn": 0.000227638964602,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000227638964602
         },
         {
           "alder": 10,
-          "menn": 0.000244879919249,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000244879919249
         },
         {
           "alder": 11,
-          "menn": 0.000274199605391,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000274199605391
         },
         {
           "alder": 12,
-          "menn": 0.00031847133758,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00031847133758
         },
         {
           "alder": 13,
-          "menn": 0.000491904825526,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000491904825526
         },
         {
           "alder": 14,
-          "menn": 0.000779294094546,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.000779294094546
         },
         {
           "alder": 15,
-          "menn": 0.00122486096591,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00122486096591
         },
         {
           "alder": 16,
-          "menn": 0.0016064007939,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0016064007939
         },
         {
           "alder": 17,
-          "menn": 0.00219512791665,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00219512791665
         },
         {
           "alder": 18,
-          "menn": 0.00310145678135,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00310145678135
         },
         {
           "alder": 19,
-          "menn": 0.00341963849536,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00341963849536
         },
         {
           "alder": 20,
-          "menn": 0.0043509535255,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0043509535255
         },
         {
           "alder": 21,
-          "menn": 0.00512917714903,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00512917714903
         },
         {
           "alder": 22,
-          "menn": 0.00586687324136,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00586687324136
         },
         {
           "alder": 23,
-          "menn": 0.0067721872304,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0067721872304
         },
         {
           "alder": 24,
-          "menn": 0.00809790753178,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00809790753178
         },
         {
           "alder": 25,
-          "menn": 0.00885727998604,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.00885727998604
         },
         {
           "alder": 26,
-          "menn": 0.0104253902811,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0104253902811
         },
         {
           "alder": 27,
-          "menn": 0.011142855634,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.011142855634
         },
         {
           "alder": 28,
-          "menn": 0.0124944105321,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0124944105321
         },
         {
           "alder": 29,
-          "menn": 0.0141337847363,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0141337847363
         },
         {
           "alder": 30,
-          "menn": 0.0160184602042,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0160184602042
         },
         {
           "alder": 31,
-          "menn": 0.0176607538228,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0176607538228
         },
         {
           "alder": 32,
-          "menn": 0.0196985188098,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0196985188098
         },
         {
           "alder": 33,
-          "menn": 0.0203258504484,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0203258504484
         },
         {
           "alder": 34,
-          "menn": 0.0227666711391,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0227666711391
         },
         {
           "alder": 35,
-          "menn": 0.0243356161433,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0243356161433
         },
         {
           "alder": 36,
-          "menn": 0.0268851138849,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0268851138849
         },
         {
           "alder": 37,
-          "menn": 0.029467057229,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.029467057229
         },
         {
           "alder": 38,
-          "menn": 0.0324275411994,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0324275411994
         },
         {
           "alder": 39,
-          "menn": 0.0372625587398,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0372625587398
         },
         {
           "alder": 40,
-          "menn": 0.0459424142244,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0459424142244
         },
         {
           "alder": 41,
-          "menn": 0.0489238322643,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0489238322643
         },
         {
           "alder": 42,
-          "menn": 0.0530858869227,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0530858869227
         },
         {
           "alder": 43,
-          "menn": 0.056709127744,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.056709127744
         },
         {
           "alder": 44,
-          "menn": 0.0616911768736,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0616911768736
         },
         {
           "alder": 45,
-          "menn": 0.0678155570888,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0678155570888
         },
         {
           "alder": 46,
-          "menn": 0.074426759617,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.074426759617
         },
         {
           "alder": 47,
-          "menn": 0.083726335559,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.083726335559
         },
         {
           "alder": 48,
-          "menn": 0.0930831077116,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0930831077116
         },
         {
           "alder": 49,
-          "menn": 0.106769191337,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.106769191337
         },
         {
           "alder": 50,
-          "menn": 0.126372065394,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.126372065394
         },
         {
           "alder": 51,
-          "menn": 0.135429067525,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.135429067525
         },
         {
           "alder": 52,
-          "menn": 0.146671349861,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146671349861
         },
         {
           "alder": 53,
-          "menn": 0.157299301176,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.157299301176
         },
         {
           "alder": 54,
-          "menn": 0.170728246991,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170728246991
         },
         {
           "alder": 55,
-          "menn": 0.185325577241,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.185325577241
         },
         {
           "alder": 56,
-          "menn": 0.197371744822,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.197371744822
         },
         {
           "alder": 57,
-          "menn": 0.212813916163,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.212813916163
         },
         {
           "alder": 58,
-          "menn": 0.222249071193,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.222249071193
         },
         {
           "alder": 59,
-          "menn": 0.23483922484,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.23483922484
         },
         {
           "alder": 60,
-          "menn": 0.248940896718,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.248940896718
         },
         {
           "alder": 61,
-          "menn": 0.260659689185,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.260659689185
         },
         {
           "alder": 62,
-          "menn": 0.271549917122,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.271549917122
         },
         {
           "alder": 63,
-          "menn": 0.288607578219,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.288607578219
         },
         {
           "alder": 64,
-          "menn": 0.303050994125,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.303050994125
         },
         {
           "alder": 65,
-          "menn": 0.319448087356,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.319448087356
         },
         {
           "alder": 66,
-          "menn": 0.332616788503,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.332616788503
         },
         {
           "alder": 67,
-          "menn": 0.349146234676,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.349146234676
         },
         {
           "alder": 68,
-          "menn": 0.356500974514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.356500974514
         },
         {
           "alder": 69,
-          "menn": 0.363176949766,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.363176949766
         },
         {
           "alder": 70,
-          "menn": 0.375761043717,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.375761043717
         },
         {
           "alder": 71,
-          "menn": 0.371556381982,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.371556381982
         },
         {
           "alder": 72,
-          "menn": 0.384830558276,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.384830558276
         },
         {
           "alder": 73,
-          "menn": 0.406470813039,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.406470813039
         },
         {
           "alder": 74,
-          "menn": 0.441895825188,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.441895825188
         },
         {
           "alder": 75,
-          "menn": 0.468856387531,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.468856387531
         },
         {
           "alder": 76,
-          "menn": 0.508495513849,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.508495513849
         },
         {
           "alder": 77,
-          "menn": 0.517934900281,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.517934900281
         },
         {
           "alder": 78,
-          "menn": 0.501432432432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.501432432432
         },
         {
           "alder": 79,
-          "menn": 0.504975422611,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.504975422611
         },
         {
           "alder": 80,
-          "menn": 0.450607045711,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.450607045711
         },
         {
           "alder": 81,
-          "menn": 0.442682464284,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.442682464284
         },
         {
           "alder": 82,
-          "menn": 0.443561915156,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.443561915156
         },
         {
           "alder": 83,
-          "menn": 0.445302386846,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.445302386846
         },
         {
           "alder": 84,
-          "menn": 0.43286065322,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.43286065322
         },
         {
           "alder": 85,
-          "menn": 0.403974458094,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.403974458094
         },
         {
           "alder": 86,
-          "menn": 0.385378303289,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.385378303289
         },
         {
           "alder": 87,
-          "menn": 0.351364115232,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.351364115232
         },
         {
           "alder": 88,
-          "menn": 0.344119372957,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.344119372957
         },
         {
           "alder": 89,
-          "menn": 0.337046529968,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.337046529968
         },
         {
           "alder": 90,
-          "menn": 0.322839394488,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.322839394488
         },
         {
           "alder": 91,
-          "menn": 0.309092248747,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.309092248747
         },
         {
           "alder": 92,
-          "menn": 0.29351184346,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.29351184346
         },
         {
           "alder": 93,
-          "menn": 0.278445658774,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.278445658774
         },
         {
           "alder": 94,
-          "menn": 0.265202425832,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.265202425832
         },
         {
           "alder": 95,
-          "menn": 0.245128432241,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.245128432241
         }
       ]
     }

--- a/apps/skde/public/helseatlas/data/lab/tsh_rb1.json
+++ b/apps/skde/public/helseatlas/data/lab/tsh_rb1.json
@@ -291,8 +291,7 @@
           "andel_kun_TSH_21": 0.108342787286,
           "andel_kun_TSH_22": 0.126192693455,
           "andel_kun_TSH_23": 0.13526171655,
-          "andel_kun_TSH": 0.12370642488,
-          "borhf": null
+          "andel_kun_TSH": 0.12370642488
         },
         {
           "bohf": "UNN",
@@ -313,8 +312,7 @@
           "andel_kun_TSH_21": 0.102791037846,
           "andel_kun_TSH_22": 0.117059771292,
           "andel_kun_TSH_23": 0.146107246459,
-          "andel_kun_TSH": 0.122467704141,
-          "borhf": null
+          "andel_kun_TSH": 0.122467704141
         },
         {
           "bohf": "Nordland",
@@ -335,8 +333,7 @@
           "andel_kun_TSH_21": 0.0157993548401,
           "andel_kun_TSH_22": 0.0241912619522,
           "andel_kun_TSH_23": 0.0107820535686,
-          "andel_kun_TSH": 0.0169548354849,
-          "borhf": null
+          "andel_kun_TSH": 0.0169548354849
         },
         {
           "bohf": "Helgeland",
@@ -357,8 +354,7 @@
           "andel_kun_TSH_21": 0.00549528023642,
           "andel_kun_TSH_22": 0.00511494014758,
           "andel_kun_TSH_23": 0.0100167387978,
-          "andel_kun_TSH": 0.00689881528273,
-          "borhf": null
+          "andel_kun_TSH": 0.00689881528273
         },
         {
           "bohf": "Nord-Trøndelag",
@@ -379,8 +375,7 @@
           "andel_kun_TSH_21": 0.0721085789654,
           "andel_kun_TSH_22": 0.0837109339168,
           "andel_kun_TSH_23": 0.13261763558,
-          "andel_kun_TSH": 0.0967256546958,
-          "borhf": null
+          "andel_kun_TSH": 0.0967256546958
         },
         {
           "bohf": "St. Olav",
@@ -401,8 +396,7 @@
           "andel_kun_TSH_21": 0.0981161426179,
           "andel_kun_TSH_22": 0.118341446577,
           "andel_kun_TSH_23": 0.184537789266,
-          "andel_kun_TSH": 0.134666528491,
-          "borhf": null
+          "andel_kun_TSH": 0.134666528491
         },
         {
           "bohf": "Møre og Romsdal",
@@ -423,8 +417,7 @@
           "andel_kun_TSH_21": 0.12015369202,
           "andel_kun_TSH_22": 0.128081190959,
           "andel_kun_TSH_23": 0.15156946671,
-          "andel_kun_TSH": 0.133328745607,
-          "borhf": null
+          "andel_kun_TSH": 0.133328745607
         },
         {
           "bohf": "Førde",
@@ -445,8 +438,7 @@
           "andel_kun_TSH_21": 0.180381131365,
           "andel_kun_TSH_22": 0.201660168628,
           "andel_kun_TSH_23": 0.218663660871,
-          "andel_kun_TSH": 0.200705327004,
-          "borhf": null
+          "andel_kun_TSH": 0.200705327004
         },
         {
           "bohf": "Bergen",
@@ -467,8 +459,7 @@
           "andel_kun_TSH_21": 0.247119189514,
           "andel_kun_TSH_22": 0.275491266619,
           "andel_kun_TSH_23": 0.312423432185,
-          "andel_kun_TSH": 0.279082177986,
-          "borhf": null
+          "andel_kun_TSH": 0.279082177986
         },
         {
           "bohf": "Fonna",
@@ -489,8 +480,7 @@
           "andel_kun_TSH_21": 0.17462192583,
           "andel_kun_TSH_22": 0.184117200453,
           "andel_kun_TSH_23": 0.201156984546,
-          "andel_kun_TSH": 0.186694302878,
-          "borhf": null
+          "andel_kun_TSH": 0.186694302878
         },
         {
           "bohf": "Stavanger",
@@ -511,8 +501,7 @@
           "andel_kun_TSH_21": 0.189445689263,
           "andel_kun_TSH_22": 0.217280193305,
           "andel_kun_TSH_23": 0.242222843796,
-          "andel_kun_TSH": 0.216503615629,
-          "borhf": null
+          "andel_kun_TSH": 0.216503615629
         },
         {
           "bohf": "Østfold",
@@ -533,8 +522,7 @@
           "andel_kun_TSH_21": 0.0831444172778,
           "andel_kun_TSH_22": 0.101193174829,
           "andel_kun_TSH_23": 0.114874780986,
-          "andel_kun_TSH": 0.0998420875731,
-          "borhf": null
+          "andel_kun_TSH": 0.0998420875731
         },
         {
           "bohf": "Akershus",
@@ -555,8 +543,7 @@
           "andel_kun_TSH_21": 0.157475976991,
           "andel_kun_TSH_22": 0.168273527978,
           "andel_kun_TSH_23": 0.183015344759,
-          "andel_kun_TSH": 0.16994627952,
-          "borhf": null
+          "andel_kun_TSH": 0.16994627952
         },
         {
           "bohf": "OUS",
@@ -577,8 +564,7 @@
           "andel_kun_TSH_21": 0.155804125072,
           "andel_kun_TSH_22": 0.17146399682,
           "andel_kun_TSH_23": 0.183353016383,
-          "andel_kun_TSH": 0.170613947882,
-          "borhf": null
+          "andel_kun_TSH": 0.170613947882
         },
         {
           "bohf": "Lovisenberg",
@@ -599,8 +585,7 @@
           "andel_kun_TSH_21": 0.132956843968,
           "andel_kun_TSH_22": 0.136652340446,
           "andel_kun_TSH_23": 0.161252852768,
-          "andel_kun_TSH": 0.143945576471,
-          "borhf": null
+          "andel_kun_TSH": 0.143945576471
         },
         {
           "bohf": "Diakonhjemmet",
@@ -621,8 +606,7 @@
           "andel_kun_TSH_21": 0.135669197848,
           "andel_kun_TSH_22": 0.149108704704,
           "andel_kun_TSH_23": 0.196891825719,
-          "andel_kun_TSH": 0.161282109243,
-          "borhf": null
+          "andel_kun_TSH": 0.161282109243
         },
         {
           "bohf": "Innlandet",
@@ -643,8 +627,7 @@
           "andel_kun_TSH_21": 0.159803435013,
           "andel_kun_TSH_22": 0.17748834765,
           "andel_kun_TSH_23": 0.200027254399,
-          "andel_kun_TSH": 0.179197919706,
-          "borhf": null
+          "andel_kun_TSH": 0.179197919706
         },
         {
           "bohf": "Vestre Viken",
@@ -665,8 +648,7 @@
           "andel_kun_TSH_21": 0.128930110077,
           "andel_kun_TSH_22": 0.147844452301,
           "andel_kun_TSH_23": 0.186954987818,
-          "andel_kun_TSH": 0.15529647369,
-          "borhf": null
+          "andel_kun_TSH": 0.15529647369
         },
         {
           "bohf": "Vestfold",
@@ -687,8 +669,7 @@
           "andel_kun_TSH_21": 0.323868890206,
           "andel_kun_TSH_22": 0.345240787255,
           "andel_kun_TSH_23": 0.379698395718,
-          "andel_kun_TSH": 0.350018376119,
-          "borhf": null
+          "andel_kun_TSH": 0.350018376119
         },
         {
           "bohf": "Telemark",
@@ -709,8 +690,7 @@
           "andel_kun_TSH_21": 0.0899397316412,
           "andel_kun_TSH_22": 0.108633851423,
           "andel_kun_TSH_23": 0.132064466105,
-          "andel_kun_TSH": 0.110452547638,
-          "borhf": null
+          "andel_kun_TSH": 0.110452547638
         },
         {
           "bohf": "Sørlandet",
@@ -731,8 +711,7 @@
           "andel_kun_TSH_21": 0.0865477816571,
           "andel_kun_TSH_22": 0.107775889066,
           "andel_kun_TSH_23": 0.171322453028,
-          "andel_kun_TSH": 0.122471486108,
-          "borhf": null
+          "andel_kun_TSH": 0.122471486108
         },
         {
           "bohf": "Norge",
@@ -753,8 +732,7 @@
           "andel_kun_TSH_21": 0.146209211289,
           "andel_kun_TSH_22": 0.163826931387,
           "andel_kun_TSH_23": 0.193274181446,
-          "andel_kun_TSH": 0.168183797782,
-          "borhf": null
+          "andel_kun_TSH": 0.168183797782
         }
       ]
     },
@@ -773,9 +751,7 @@
           "tot_events": 211127.666667,
           "tot_pas": 142508.666667,
           "tot_pop": 482658.333333,
-          "prove_pr_pas": 1.48150755744,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.48150755744
         },
         {
           "borhf": "Helse Midt-Norge",
@@ -787,9 +763,7 @@
           "tot_events": 374768.333333,
           "tot_pas": 247126.333333,
           "tot_pop": 741160.666667,
-          "prove_pr_pas": 1.51650505342,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.51650505342
         },
         {
           "borhf": "Helse Vest",
@@ -801,9 +775,7 @@
           "tot_events": 566024.666667,
           "tot_pas": 362512.333333,
           "tot_pop": 1129036.66667,
-          "prove_pr_pas": 1.56139423302,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.56139423302
         },
         {
           "borhf": "Helse Sør-Øst",
@@ -815,9 +787,7 @@
           "tot_events": 1804788.66667,
           "tot_pas": 1144139.33333,
           "tot_pop": 3082352,
-          "prove_pr_pas": 1.57742034915,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.57742034915
         },
         {
           "borhf": "Norge",
@@ -829,9 +799,7 @@
           "tot_events": 2956709.33333,
           "tot_pas": 1894175,
           "tot_pop": 5435207.66667,
-          "prove_pr_pas": 1.56094834603,
-          "bohf": null,
-          "ermann": null
+          "prove_pr_pas": 1.56094834603
         }
       ]
     },
@@ -843,674 +811,482 @@
         {
           "alder": 0,
           "kvinner": 0.0205704780223,
-          "menn": 0.0270905457514,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0270905457514
         },
         {
           "alder": 1,
           "kvinner": 0.0272734561198,
-          "menn": 0.0301393428522,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0301393428522
         },
         {
           "alder": 2,
           "kvinner": 0.032826596576,
-          "menn": 0.0361152694611,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0361152694611
         },
         {
           "alder": 3,
           "kvinner": 0.0401650293602,
-          "menn": 0.0457006870509,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0457006870509
         },
         {
           "alder": 4,
           "kvinner": 0.0456911667383,
-          "menn": 0.0513613102652,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0513613102652
         },
         {
           "alder": 5,
           "kvinner": 0.0515883117405,
-          "menn": 0.0547365348124,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0547365348124
         },
         {
           "alder": 6,
           "kvinner": 0.0608594257245,
-          "menn": 0.0605650641832,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0605650641832
         },
         {
           "alder": 7,
           "kvinner": 0.0692984170412,
-          "menn": 0.0685748286249,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0685748286249
         },
         {
           "alder": 8,
           "kvinner": 0.0804552113253,
-          "menn": 0.0788234005259,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0788234005259
         },
         {
           "alder": 9,
           "kvinner": 0.0865328679465,
-          "menn": 0.086520778046,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.086520778046
         },
         {
           "alder": 10,
           "kvinner": 0.0968520408806,
-          "menn": 0.0949954906259,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0949954906259
         },
         {
           "alder": 11,
           "kvinner": 0.106487094282,
-          "menn": 0.0983661280035,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.0983661280035
         },
         {
           "alder": 12,
           "kvinner": 0.126828033539,
-          "menn": 0.100156231222,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.100156231222
         },
         {
           "alder": 13,
           "kvinner": 0.165042837155,
-          "menn": 0.113466046421,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.113466046421
         },
         {
           "alder": 14,
           "kvinner": 0.211339873915,
-          "menn": 0.132314319376,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132314319376
         },
         {
           "alder": 15,
           "kvinner": 0.23897285476,
-          "menn": 0.140444537924,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140444537924
         },
         {
           "alder": 16,
           "kvinner": 0.257517719408,
-          "menn": 0.13562612417,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13562612417
         },
         {
           "alder": 17,
           "kvinner": 0.271787115498,
-          "menn": 0.137803893753,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.137803893753
         },
         {
           "alder": 18,
           "kvinner": 0.267074224626,
-          "menn": 0.129616804476,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.129616804476
         },
         {
           "alder": 19,
           "kvinner": 0.256058841869,
-          "menn": 0.12373252946,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.12373252946
         },
         {
           "alder": 20,
           "kvinner": 0.261316756146,
-          "menn": 0.123744861021,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.123744861021
         },
         {
           "alder": 21,
           "kvinner": 0.269569619628,
-          "menn": 0.127746952936,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.127746952936
         },
         {
           "alder": 22,
           "kvinner": 0.274070359748,
-          "menn": 0.132790695025,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.132790695025
         },
         {
           "alder": 23,
           "kvinner": 0.28177808882,
-          "menn": 0.13716357567,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.13716357567
         },
         {
           "alder": 24,
           "kvinner": 0.286839723913,
-          "menn": 0.140889160238,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.140889160238
         },
         {
           "alder": 25,
           "kvinner": 0.298019377916,
-          "menn": 0.146139665779,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.146139665779
         },
         {
           "alder": 26,
           "kvinner": 0.303146101816,
-          "menn": 0.147818291138,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.147818291138
         },
         {
           "alder": 27,
           "kvinner": 0.30640820905,
-          "menn": 0.151204854272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.151204854272
         },
         {
           "alder": 28,
           "kvinner": 0.313387209548,
-          "menn": 0.153390597215,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.153390597215
         },
         {
           "alder": 29,
           "kvinner": 0.320963221293,
-          "menn": 0.15562598723,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.15562598723
         },
         {
           "alder": 30,
           "kvinner": 0.335011075232,
-          "menn": 0.161340945931,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.161340945931
         },
         {
           "alder": 31,
           "kvinner": 0.346037963242,
-          "menn": 0.165163826047,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.165163826047
         },
         {
           "alder": 32,
           "kvinner": 0.355988046893,
-          "menn": 0.166711233451,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.166711233451
         },
         {
           "alder": 33,
           "kvinner": 0.356888790085,
-          "menn": 0.168269383856,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.168269383856
         },
         {
           "alder": 34,
           "kvinner": 0.359680349533,
-          "menn": 0.16903260432,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.16903260432
         },
         {
           "alder": 35,
           "kvinner": 0.35383481921,
-          "menn": 0.167581944265,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.167581944265
         },
         {
           "alder": 36,
           "kvinner": 0.349441350444,
-          "menn": 0.170087386142,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.170087386142
         },
         {
           "alder": 37,
           "kvinner": 0.343583476206,
-          "menn": 0.172474096096,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.172474096096
         },
         {
           "alder": 38,
           "kvinner": 0.343484188203,
-          "menn": 0.173073020922,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.173073020922
         },
         {
           "alder": 39,
           "kvinner": 0.343051858785,
-          "menn": 0.176087100404,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.176087100404
         },
         {
           "alder": 40,
           "kvinner": 0.346529559942,
-          "menn": 0.182954342387,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.182954342387
         },
         {
           "alder": 41,
           "kvinner": 0.346053319394,
-          "menn": 0.184064105934,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.184064105934
         },
         {
           "alder": 42,
           "kvinner": 0.341656339498,
-          "menn": 0.186526464472,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.186526464472
         },
         {
           "alder": 43,
           "kvinner": 0.336899365367,
-          "menn": 0.185718646796,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.185718646796
         },
         {
           "alder": 44,
           "kvinner": 0.334815011517,
-          "menn": 0.189984707385,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.189984707385
         },
         {
           "alder": 45,
           "kvinner": 0.333540005073,
-          "menn": 0.189026705819,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.189026705819
         },
         {
           "alder": 46,
           "kvinner": 0.336303939962,
-          "menn": 0.194046069209,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.194046069209
         },
         {
           "alder": 47,
           "kvinner": 0.345115898555,
-          "menn": 0.20361925218,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.20361925218
         },
         {
           "alder": 48,
           "kvinner": 0.355211706979,
-          "menn": 0.211372363314,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.211372363314
         },
         {
           "alder": 49,
           "kvinner": 0.364895340513,
-          "menn": 0.22226323209,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.22226323209
         },
         {
           "alder": 50,
           "kvinner": 0.373768682754,
-          "menn": 0.236715824272,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.236715824272
         },
         {
           "alder": 51,
           "kvinner": 0.385907983437,
-          "menn": 0.244833878321,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.244833878321
         },
         {
           "alder": 52,
           "kvinner": 0.390725882106,
-          "menn": 0.25258842587,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.25258842587
         },
         {
           "alder": 53,
           "kvinner": 0.396102765689,
-          "menn": 0.260892491904,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.260892491904
         },
         {
           "alder": 54,
           "kvinner": 0.400637308377,
-          "menn": 0.272898909758,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.272898909758
         },
         {
           "alder": 55,
           "kvinner": 0.40444379133,
-          "menn": 0.285019650753,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.285019650753
         },
         {
           "alder": 56,
           "kvinner": 0.407650858181,
-          "menn": 0.292713452441,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.292713452441
         },
         {
           "alder": 57,
           "kvinner": 0.41022706295,
-          "menn": 0.304410168051,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.304410168051
         },
         {
           "alder": 58,
           "kvinner": 0.411176566641,
-          "menn": 0.309771347449,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.309771347449
         },
         {
           "alder": 59,
           "kvinner": 0.411467524607,
-          "menn": 0.312171002119,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.312171002119
         },
         {
           "alder": 60,
           "kvinner": 0.414541235618,
-          "menn": 0.321854760489,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.321854760489
         },
         {
           "alder": 61,
           "kvinner": 0.415160323372,
-          "menn": 0.329774817634,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.329774817634
         },
         {
           "alder": 62,
           "kvinner": 0.415293238406,
-          "menn": 0.334111591969,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.334111591969
         },
         {
           "alder": 63,
           "kvinner": 0.419083081219,
-          "menn": 0.345133853692,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.345133853692
         },
         {
           "alder": 64,
           "kvinner": 0.431241258623,
-          "menn": 0.355086229626,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.355086229626
         },
         {
           "alder": 65,
           "kvinner": 0.439696680381,
-          "menn": 0.366384130096,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.366384130096
         },
         {
           "alder": 66,
           "kvinner": 0.452314706653,
-          "menn": 0.373367309896,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.373367309896
         },
         {
           "alder": 67,
           "kvinner": 0.459443230651,
-          "menn": 0.380677174548,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.380677174548
         },
         {
           "alder": 68,
           "kvinner": 0.464813928663,
-          "menn": 0.385639682799,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.385639682799
         },
         {
           "alder": 69,
           "kvinner": 0.470151763097,
-          "menn": 0.388286317695,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.388286317695
         },
         {
           "alder": 70,
           "kvinner": 0.470271001082,
-          "menn": 0.396551461051,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.396551461051
         },
         {
           "alder": 71,
           "kvinner": 0.464907585017,
-          "menn": 0.390029034987,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.390029034987
         },
         {
           "alder": 72,
           "kvinner": 0.476528698073,
-          "menn": 0.404199804114,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.404199804114
         },
         {
           "alder": 73,
           "kvinner": 0.50407307414,
-          "menn": 0.425066879162,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.425066879162
         },
         {
           "alder": 74,
           "kvinner": 0.537666125887,
-          "menn": 0.462435379469,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.462435379469
         },
         {
           "alder": 75,
           "kvinner": 0.56947986059,
-          "menn": 0.494056562506,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.494056562506
         },
         {
           "alder": 76,
           "kvinner": 0.615130768852,
-          "menn": 0.537146200858,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.537146200858
         },
         {
           "alder": 77,
           "kvinner": 0.627055434946,
-          "menn": 0.554394110713,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.554394110713
         },
         {
           "alder": 78,
           "kvinner": 0.613509675754,
-          "menn": 0.543040540541,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.543040540541
         },
         {
           "alder": 79,
           "kvinner": 0.602303728403,
-          "menn": 0.554190145067,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.554190145067
         },
         {
           "alder": 80,
           "kvinner": 0.577423256193,
-          "menn": 0.509072513766,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.509072513766
         },
         {
           "alder": 81,
           "kvinner": 0.576951298468,
-          "menn": 0.51030397168,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.51030397168
         },
         {
           "alder": 82,
           "kvinner": 0.58409059136,
-          "menn": 0.526384930981,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.526384930981
         },
         {
           "alder": 83,
           "kvinner": 0.60298180593,
-          "menn": 0.542343242568,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.542343242568
         },
         {
           "alder": 84,
           "kvinner": 0.596163016764,
-          "menn": 0.544204975939,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.544204975939
         },
         {
           "alder": 85,
           "kvinner": 0.576687596581,
-          "menn": 0.526243449875,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.526243449875
         },
         {
           "alder": 86,
           "kvinner": 0.560076061518,
-          "menn": 0.516120695225,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.516120695225
         },
         {
           "alder": 87,
           "kvinner": 0.54393427209,
-          "menn": 0.505685327133,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.505685327133
         },
         {
           "alder": 88,
           "kvinner": 0.546190732495,
-          "menn": 0.503688490234,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.503688490234
         },
         {
           "alder": 89,
           "kvinner": 0.550052772591,
-          "menn": 0.515920741325,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.515920741325
         },
         {
           "alder": 90,
           "kvinner": 0.558111380145,
-          "menn": 0.51926904288,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.51926904288
         },
         {
           "alder": 91,
           "kvinner": 0.561519968424,
-          "menn": 0.526304155615,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.526304155615
         },
         {
           "alder": 92,
           "kvinner": 0.56220863094,
-          "menn": 0.530474674656,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.530474674656
         },
         {
           "alder": 93,
           "kvinner": 0.543662405668,
-          "menn": 0.524468731026,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.524468731026
         },
         {
           "alder": 94,
           "kvinner": 0.542754965196,
-          "menn": 0.538108506802,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.538108506802
         },
         {
           "alder": 95,
           "kvinner": 0.534231018819,
-          "menn": 0.518379096546,
-          "bohf": null,
-          "borhf": null
+          "menn": 0.518379096546
         }
       ]
     }


### PR DESCRIPTION
4 analysis plus the overall MB include also tests from GP.  Split the aldersfig for these to show the % in specialist and GP separately.  
Remove unnecessary/empty variables (bohf, borhf, ermann) in applicable datasets.