### PR TITLE
Erstatte Norge med Norway i engelske atlas

### DIFF
--- a/apps/skde/src/charts/Abacus/index.tsx
+++ b/apps/skde/src/charts/Abacus/index.tsx
@@ -5,7 +5,7 @@ import { max } from "d3-array";
 import classNames from "../Barchart/ChartLegend.module.css";
 import { customFormat } from "qmongjs";
 import { useBohfQueryParam } from "../../helpers/hooks";
-import { abacusColors } from "../colors";
+import { abacusColors, nationalLabel } from "../colors";
 
 type AbacusData<Data, X extends keyof Data> = {
   [k in X]: number;
@@ -96,8 +96,6 @@ export const Abacus = <Data, X extends string & keyof Data>({
     nb: "Valgte",
     nn: "Valde",
   };
-
-  const nationalLabel = { en: "Norway", nb: "Norge", nn: "Noreg" };
 
   const xScale = scaleLinear<number>({
     domain: [xMin, xMaxVal],

--- a/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
+++ b/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
@@ -560,7 +560,7 @@ exports[`Click in table 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  OUS
+                  Norge
                 </tspan>
               </text>
             </svg>
@@ -2782,7 +2782,7 @@ exports[`Click in table 2`] = `
                   dy="0em"
                   x="-8"
                 >
-                  OUS
+                  Norge
                 </tspan>
               </text>
             </svg>
@@ -5004,7 +5004,7 @@ exports[`Click in table 3`] = `
                   dy="0em"
                   x="-8"
                 >
-                  OUS
+                  Norge
                 </tspan>
               </text>
             </svg>
@@ -7226,7 +7226,7 @@ exports[`Click in table 4`] = `
                   dy="0em"
                   x="-8"
                 >
-                  OUS
+                  Norge
                 </tspan>
               </text>
             </svg>
@@ -9760,7 +9760,7 @@ exports[`English render 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Norway
                 </tspan>
               </text>
             </svg>
@@ -18705,7 +18705,7 @@ exports[`Render with figure split in two 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Noreg
                 </tspan>
               </text>
             </svg>
@@ -20239,7 +20239,7 @@ exports[`Render with figure split in two 2`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Noreg
                 </tspan>
               </text>
             </svg>
@@ -21773,7 +21773,7 @@ exports[`Render with language not in file, picked HF and split figure 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Norway
                 </tspan>
               </text>
             </svg>
@@ -26961,7 +26961,7 @@ exports[`Render with split figure 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Noreg
                 </tspan>
               </text>
             </svg>
@@ -28713,7 +28713,7 @@ exports[`Render with very little info 1`] = `
                   dy="0em"
                   x="-8"
                 >
-                  Norge
+                  Norway
                 </tspan>
               </text>
             </svg>

--- a/apps/skde/src/charts/Barchart/index.tsx
+++ b/apps/skde/src/charts/Barchart/index.tsx
@@ -12,7 +12,12 @@ import { customFormat } from "qmongjs";
 
 import { AnnualVariation } from "./AnnualVariation";
 import { ErrorBars } from "./errorBars";
-import { mainBarColors, nationBarColors, selectedBarColors } from "../colors";
+import {
+  mainBarColors,
+  nationBarColors,
+  selectedBarColors,
+  nationalLabel,
+} from "../colors";
 
 type BarchartData<
   Data,
@@ -202,6 +207,9 @@ export const Barchart = <
             strokeWidth={yAxisLineStrokeWidth}
             stroke={yAxisLineStroke}
             tickValues={data.map((s) => s[y])}
+            tickFormat={(name) =>
+              name === national ? nationalLabel[lang] : name
+            }
             tickStroke={yAxisTickStroke}
             tickLabelProps={() => ({
               fontSize: 14,

--- a/apps/skde/src/charts/Table/__tests__/__snapshots__/table.test.tsx.snap
+++ b/apps/skde/src/charts/Table/__tests__/__snapshots__/table.test.tsx.snap
@@ -308,7 +308,7 @@ exports[`Click in table 1`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -1429,7 +1429,7 @@ exports[`Click in table 2`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -2937,7 +2937,7 @@ exports[`Click in table 3`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -3929,7 +3929,7 @@ exports[`Click in table 4`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -5222,7 +5222,7 @@ exports[`Click in table 5`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -5930,7 +5930,7 @@ exports[`Markdown in caption 1`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            OUS
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -7395,7 +7395,7 @@ exports[`Render english with many picked HF 1`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            Norge
+            Norway
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"
@@ -8903,7 +8903,7 @@ exports[`Render with another national 1`] = `
             scope="row"
             style="font-weight: bolder;"
           >
-            Finnmark
+            Norge
           </th>
           <td
             class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignRight MuiTableCell-paddingNone MuiTableCell-sizeMedium css-yucflr-MuiTableCell-root"

--- a/apps/skde/src/charts/Table/index.tsx
+++ b/apps/skde/src/charts/Table/index.tsx
@@ -10,6 +10,7 @@ import { getOrderComparator } from "../../helpers/functions/dataTransformation";
 import { customFormat } from "qmongjs";
 import { useBohfQueryParam } from "../../helpers/hooks";
 import { Markdown } from "../../components/Markdown";
+import { nationalLabel } from "../colors";
 
 type DataTableProps<Data, Headers extends string & Partial<keyof Data>> = {
   caption: string;
@@ -109,7 +110,9 @@ export const DataTable = <
                   >
                     {cell.format
                       ? customFormat(cell.format, lang)(Number(row[cell.id]))
-                      : row[cell.id]}
+                      : row[cell.id] === national
+                        ? nationalLabel[lang]
+                        : row[cell.id]}
                   </TableCell>
                 ))}
               </TableRow>

--- a/apps/skde/src/charts/colors/index.tsx
+++ b/apps/skde/src/charts/colors/index.tsx
@@ -44,3 +44,5 @@ export const linechartColors: string[] = [
   "#ADB8B3",
   "#B6D7A5",
 ];
+
+export const nationalLabel = { en: "Norway", nb: "Norge", nn: "Noreg" };


### PR DESCRIPTION
For stolpediagram og tabell ble label hentet fra data, som var lik for norsk og engelsk atlas. Gjør det nå tilsvarende abacus-plottet.

Closes #2859