### PR TITLE
Gjorde teksten mindre for jenks-verdier i Map-komponentet mindre når verdiene er større enn 10 000

### DIFF
--- a/apps/skde/src/charts/Map/index.tsx
+++ b/apps/skde/src/charts/Map/index.tsx
@@ -175,7 +175,7 @@ export const Map = ({
                           x={i * w}
                           y={60}
                           textAnchor="middle"
-                          fontSize={30}
+                          fontSize={Math.max(...classes) > 9999 ? 25 : 30}
                         >
                           {customFormat(
                             format ? format : ".1f",


### PR DESCRIPTION
Helseatlas for lab hadde noen "jenks"-verdier for kartet som så litt uryddig ut, så jeg gjorde teksten litt mindre hvis jenks-verdien er større enn 10 000, noe som betyr at kartet nå vil støtte jenks verdier opp til 100 000 før tallene begynner å kollidere igjen.

Før:
![Screenshot from 2024-09-03 13-32-54](https://github.com/user-attachments/assets/97fa05b2-92f3-4082-8a9d-d69463312d7a)
Etter:
![image](https://github.com/user-attachments/assets/1c5ce892-6728-449d-9a68-d2899f2cfedd)
