### PR TITLE
Fjernet feil bakgrunnsfarge for liten TableOfContents

### DIFF
--- a/apps/skde/src/components/TableOfContents/TableOfContents.module.css
+++ b/apps/skde/src/components/TableOfContents/TableOfContents.module.css
@@ -36,6 +36,8 @@
   .toc_small_wrapper {
     width: 100%;
     top: 0;
+    background-color: #f4f4f4;
+    box-shadow: 0 15px 15px #f4f4f4;
     position: sticky;
     z-index: 998;
     margin: auto;

--- a/apps/skde/src/components/TableOfContents/TableOfContents.module.css
+++ b/apps/skde/src/components/TableOfContents/TableOfContents.module.css
@@ -36,7 +36,6 @@
   .toc_small_wrapper {
     width: 100%;
     top: 0;
-    background-color: white;
     position: sticky;
     z-index: 998;
     margin: auto;


### PR DESCRIPTION
I mobilvisning har TableOfContents en hvit bakgrunnsfarge som kræsher med den gråaktige bakgrunnsfargen på resten av helseatlas, så jeg fjernet bagrunnsfargen på liten TOC.

Før:
![image](https://github.com/user-attachments/assets/4c0f2b24-90f9-4d8e-aa55-1e37459da3a8)

Etter:
![image](https://github.com/user-attachments/assets/14478ba7-5cfa-4e39-93f6-fecd66776d76)
