### PR TITLE
Fikset en CSS property

### DIFF
--- a/apps/skde/src/components/ResultBox/ResultBox.module.css
+++ b/apps/skde/src/components/ResultBox/ResultBox.module.css
@@ -29,6 +29,7 @@
   overflow: hidden;
   cursor: pointer;
   print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
 }
 
 .horizontal {


### PR DESCRIPTION
Fant ut at de fleste nettlesere krever vendor prefixen `-webkit-` for `print-color-adjust`.