### PR TITLE
Flyttet HN-logo ned til høyre

### DIFF
--- a/apps/skde/src/components/Footer/index.tsx
+++ b/apps/skde/src/components/Footer/index.tsx
@@ -98,6 +98,7 @@ export const Footer = ({ page, maxWidth, className }: FooterProps) => {
                 spacing={4}
                 size={{ xs: 12, lg: kvalitet ? 6 : 12 }}
                 alignItems="center"
+                paddingTop="3rem"
               >
                 <Grid>
                   <Link href={"https://www.skde.no/"}>
@@ -109,19 +110,6 @@ export const Footer = ({ page, maxWidth, className }: FooterProps) => {
                       alt="SKDE-logo"
                       width={129}
                       height={52}
-                    />
-                  </Link>
-                </Grid>
-                <Grid>
-                  <Link href={"https://www.helse-nord.no/"}>
-                    <Image
-                      className="footer-logo"
-                      id="helse-nord-logo"
-                      loader={imgLoader}
-                      src={"/img/logos/logo-helse-nord-neg.svg"}
-                      alt="Helse Nord logo"
-                      width={220}
-                      height={76}
                     />
                   </Link>
                 </Grid>
@@ -204,10 +192,25 @@ export const Footer = ({ page, maxWidth, className }: FooterProps) => {
             </Grid>
 
             <Grid size={{ xs: 12, md: 4 }}>
-              <Stack>
-                <b>ORGANISASJONSNUMMER</b>
-                990803765
-              </Stack>
+              <Grid>
+                <Stack>
+                  <b>ORGANISASJONSNUMMER</b>
+                  990803765
+                </Stack>
+              </Grid>
+              <Grid paddingTop="3.5rem">
+                <Link href={"https://www.helse-nord.no/"}>
+                  <Image
+                    className="footer-logo"
+                    id="helse-nord-logo"
+                    loader={imgLoader}
+                    src={"/img/logos/logo-helse-nord-neg.svg"}
+                    alt="Helse Nord logo"
+                    width={220}
+                    height={52}
+                  />
+                </Link>
+              </Grid>
             </Grid>
           </Grid>
         </Container>


### PR DESCRIPTION
Fikk også inn litt luft, som manglet.

Før:
![image](https://github.com/user-attachments/assets/1f6824d0-ed66-46e6-a5b2-456852bc3867)

Nå:
![image](https://github.com/user-attachments/assets/8b8f2e6c-3618-4ba8-80fd-334202fac2e4)


## Helseatlas

Før:
![image](https://github.com/user-attachments/assets/3d47fea0-8518-4d59-8811-e0e1d359ea13)

Nå:
![image](https://github.com/user-attachments/assets/82855216-2b25-425a-be55-a7d732176688)

Closes #2870