### PR TITLE
Formatert tekst i målnivåtabell

### DIFF
--- a/packages/qmongjs/src/components/LowLevelIndicatorList/index.tsx
+++ b/packages/qmongjs/src/components/LowLevelIndicatorList/index.tsx
@@ -44,8 +44,10 @@ const result = (data: IndicatorData, point: DataPoint, dg?: boolean) => {
   }
 
   return pointVar ? (
-    <Stack direction="row">
-      {customFormat(data.format!)(pointVar)}
+    <Stack direction="row" alignItems="center" spacing={1}>
+      <Typography variant="subtitle2">
+        <b>{customFormat(data.format!)(pointVar)}</b>
+      </Typography>
       {!dg
         ? newLevelSymbols(
             level2(data, point),


### PR DESCRIPTION
Måloppnåelse med større font og fete typer: 

![image](https://github.com/user-attachments/assets/f18c4d3f-c588-49cd-af4a-4f747abcc74d)
