### PR TITLE
Fikset knapp

### DIFF
--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -311,7 +311,7 @@ export const Skde = (): JSX.Element => {
               <Accordion
                 square={true}
                 sx={{
-                  width: 400,
+                  width: Math.min(400, 0.8 * width),
                   borderRadius: 11,
                   border: 1,
                   borderColor: skdeTheme.palette.primary.main,


### PR DESCRIPTION
"Velg behandlingsenhet"-knappen bruker nå 80 % av skjermbredden hvis den hardkodede lengden er bredere enn 80 % av skjermbredden. 

Før: 
![image](https://github.com/user-attachments/assets/5634e4cd-6fa4-4a07-be97-462cdd18654c)

Etter: 
![image](https://github.com/user-attachments/assets/2e801fb9-7ccb-4e39-a5d5-dcdfd1a6c0ea)
