### PR TITLE
Tabell skjules feilaktig for visse tilfeller

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/[registry].tsx
+++ b/apps/skde/pages/behandlingskvalitet/[registry].tsx
@@ -114,6 +114,7 @@ export default function TreatmentQualityRegistryPage({ registryInfo }) {
     setSelectedYear(
       parseInt(filterSettings.get(yearKey)[0].value ?? defaultYear.toString()),
     );
+
     setSelectedLevel(filterSettings.get(levelKey)?.[0]?.value ?? undefined);
 
     setSelectedMedicalFields([registryName]);

--- a/apps/skde/pages/behandlingskvalitet/index.tsx
+++ b/apps/skde/pages/behandlingskvalitet/index.tsx
@@ -332,7 +332,7 @@ export default function TreatmentQualityPage() {
                   (newIndicatorTableActivated || newTableOnly ? (
                     <IndicatorTableV2Wrapper className="table-wrapper">
                       <IndicatorTableBodyV2
-                        key="indicator-table"
+                        key={"indicator-table2"}
                         context={tableContext}
                         unitNames={selectedTreatmentUnits}
                         year={selectedYear}
@@ -344,7 +344,7 @@ export default function TreatmentQualityPage() {
                   ) : (
                     <IndicatorTableWrapper className="table-wrapper">
                       <IndicatorTable
-                        key="indicator-table"
+                        key={"indicator-table"}
                         context={tableContext}
                         dataQuality={dataQualitySelected}
                         tableType="allRegistries"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongts",
-  "packageManager": "yarn@4.4.1+sha256.920b4530755296dc2ce8b4351f057d4a26429524fcb2789d277560d94837c27e",
+  "packageManager": "yarn@4.4.1",
   "scripts": {
     "build": "turbo run build",
     "export": "turbo run export",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongts",
-  "packageManager": "yarn@4.4.1",
+  "packageManager": "yarn@4.4.1+sha256.920b4530755296dc2ce8b4351f057d4a26429524fcb2789d277560d94837c27e",
   "scripts": {
     "build": "turbo run build",
     "export": "turbo run export",

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -394,7 +394,7 @@ export function TreatmentQualityFilterMenu({
             radios={yearOptions.values}
             defaultvalues={[yearOptions.default]}
             initialselections={[
-              { value: validSelectedYear, valueLabel: validSelectedYear },
+              { value: selectedYear, valueLabel: selectedYear },
             ]}
             sectiontitle={"År"}
             sectionid={yearKey}

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -477,7 +477,7 @@ export function TreatmentQualityFilterMenu({
           radios={yearOptions.values}
           defaultvalues={[yearOptions.default]}
           initialselections={[
-            { value: validSelectedYear, valueLabel: validSelectedYear },
+            { value: selectedYear, valueLabel: selectedYear },
           ]}
           sectiontitle={"År"}
           sectionid={yearKey}

--- a/packages/qmongjs/src/components/FilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/index.tsx
@@ -225,7 +225,7 @@ const createInitialFilterSettings = ({
     );
 
   if (onFilterInitialized) {
-    // Call after the current compoent has finished rendering, because an error
+    // Call after the current component has finished rendering, because an error
     // will be thrown if the other component's state is updated during the current
     // render phase.
     setTimeout(() => {
@@ -253,7 +253,7 @@ const wrapReducer = (
     const newFilterSettings = reducer(filterSettings, action);
 
     if (onSelectionChanged) {
-      // Call after the current compoennt has finished rendering, because an error
+      // Call after the current component has finished rendering, because an error
       // will be thrown if the other component's state is updated during the current
       // render phase.
       setTimeout(() => {

--- a/packages/qmongjs/src/components/FilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/index.tsx
@@ -225,7 +225,7 @@ const createInitialFilterSettings = ({
     );
 
   if (onFilterInitialized) {
-    // Call after the current compoennt has finished rendering, because an error
+    // Call after the current compoent has finished rendering, because an error
     // will be thrown if the other component's state is updated during the current
     // render phase.
     setTimeout(() => {

--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -1,7 +1,7 @@
 import { IndicatorTableHeader } from "./indicatortableheader";
 import { IndicatorTableBody } from "./indicatortablebody";
 import { RegisterName } from "types";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 interface IndicatorTableProps {
   context: string;
@@ -59,8 +59,8 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
 
   return (
     <>
-      {!isTableEmpty && (
         <table>
+        {!isTableEmpty && (
           <IndicatorTableHeader
             colspan={colspan}
             unitNames={unitNames}
@@ -69,21 +69,21 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
             descriptionHeader={descriptionHeader}
             treatmentYear={showTreatmentYear ? treatmentYear : undefined}
           />
-          <IndicatorTableBody
-            context={context}
-            dataQuality={dataQuality}
-            tableType={tableType}
-            colspan={colspan}
-            registerNames={registerNames}
-            unitNames={unitNames}
-            treatmentYear={treatmentYear}
-            medicalFieldFilter={medicalFieldFilter}
-            showLevelFilter={showLevelFilter ?? ""}
-            blockTitle={blockTitle}
-            onEmptyStatusChanged={handleEmptyStatusChanged}
-          />
-        </table>
-      )}
+        )}
+        <IndicatorTableBody
+          context={context}
+          dataQuality={dataQuality}
+          tableType={tableType}
+          colspan={colspan}
+          registerNames={registerNames}
+          unitNames={unitNames}
+          treatmentYear={treatmentYear}
+          medicalFieldFilter={medicalFieldFilter}
+          showLevelFilter={showLevelFilter ?? ""}
+          blockTitle={blockTitle}
+          onEmptyStatusChanged={handleEmptyStatusChanged}
+        />
+      </table>
     </>
   );
 };

--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -1,7 +1,7 @@
 import { IndicatorTableHeader } from "./indicatortableheader";
 import { IndicatorTableBody } from "./indicatortablebody";
 import { RegisterName } from "types";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 
 interface IndicatorTableProps {
   context: string;

--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -59,7 +59,7 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
 
   return (
     <>
-        <table>
+      <table>
         {!isTableEmpty && (
           <IndicatorTableHeader
             colspan={colspan}

--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -27,7 +27,7 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
     dataQuality,
     tableType,
     unitNames = ["Nasjonalt"],
-    treatmentYear = 2019,
+    treatmentYear = 2023,
     colspan,
     medicalFieldFilter,
     showLevelFilter,
@@ -38,7 +38,6 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
     blockTitle,
     showTreatmentYear,
   } = props;
-
   const [emptyBlocks, setEmptyBlocks] = useState<Set<string>>(new Set());
 
   const handleEmptyStatusChanged = useCallback(


### PR DESCRIPTION
På registerspesifikk side:
Når man velger opptaksområde lungekreft for 2024, enten ved å skifte fra behandlingsenheter (default 2024) eller sette year=2024, så blir tabellen skjult fordi valgene kun går til 2023. 

Problemet var at tabellen forsvant for evig og ikke kom tilbake igjen når man valgte andre år.

Dette skal være fikset nå.

En del småendringer ble gjort under feilsøkingen, men selve fiksen er kun endringen i IndicatorTable mellom linje 62-86. IndicatorTableBody må være med selv om den er tom, for ellers vil aldri callback-funksjonen fra denne til IndicatorTable kalles igjen.

