### PR TITLE
Filtermeny i sykehusprofil i egen komponent

### DIFF
--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -1,9 +1,4 @@
-import React, { useState, useEffect } from "react";
-import {
-  useQueryParam,
-  DelimitedArrayParam,
-  withDefault,
-} from "use-query-params";
+import React, { useState } from "react";
 import { UseQueryResult } from "@tanstack/react-query";
 import {
   Header,
@@ -12,32 +7,17 @@ import {
 } from "../../src/components/Header";
 import {
   skdeTheme,
-  FilterSettingsValue,
-  FilterMenu,
   useUnitNamesQuery,
-  useUnitUrlsQuery,
   defaultYear,
-  TreeViewFilterSection,
-  getTreatmentUnitsTree,
-  FilterSettings,
-  CustomAccordionExpandIcon,
   mainHospitals,
 } from "qmongjs";
 import { Footer } from "../../src/components/Footer";
-import {
-  ThemeProvider,
-  Box,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Container,
-  styled,
-} from "@mui/material";
+import { ThemeProvider, Box, Container } from "@mui/material";
 import Grid from "@mui/material/Grid2";
-import { ClickAwayListener } from "@mui/base";
+
 import { PageWrapper } from "../../src/components/StyledComponents/PageWrapper";
 import { HospitalInfoBox } from "../../src/components/HospitalProfile";
-import { URLs } from "types";
+
 import { getUnitFullName } from "../../src/helpers/functions/getUnitFullName";
 import { AffiliatedHospitals } from "../../src/components/HospitalProfile/AffiliatedHospitals";
 import { useScreenSize } from "@visx/responsive";
@@ -45,25 +25,12 @@ import { breakpoints } from "qmongjs";
 import { HospitalProfileMedfieldTable } from "../../src/components/HospitalProfile/HospitalProfileMedfieldTable";
 import { HospitalProfileLowLevelTable } from "../../src/components/HospitalProfile/HospitalProfileLowLevelTable";
 import { HospitalProfileLinePlot } from "../../src/components/HospitalProfile/HospitalProfileLinePlot";
-
-const AccordionWrapper = styled(Box)(() => ({
-  "& MuiAccordion-root:before": {
-    backgroundColor: "white",
-  },
-}));
+import { UnitFilterMenu } from "../../src/components/HospitalProfile/UnitFilterMenu";
 
 export const Skde = (): JSX.Element => {
-  const [expanded, setExpanded] = useState(false);
-
-  const treatmentUnitsKey = "selected_treatment_units";
+  const [unitName, setUnitName] = useState<string>();
 
   const { width } = useScreenSize();
-
-  // Current unit name and its setter function
-  const [selectedTreatmentUnits, setSelectedTreatmentUnits] = useQueryParam(
-    treatmentUnitsKey,
-    withDefault(DelimitedArrayParam, ["Nasjonalt"]),
-  );
 
   // Infobox URL
   const [unitUrl, setUnitUrl] = useState<string | null>(null);
@@ -91,76 +58,10 @@ export const Skde = (): JSX.Element => {
 
     unitFullName =
       unitNamesQuery.data &&
-      getUnitFullName(
-        unitNamesQuery.data.nestedUnitNames,
-        selectedTreatmentUnits[0],
-      );
-  }
-
-  const treatmentUnits = getTreatmentUnitsTree(unitNamesQuery);
-
-  if (treatmentUnits.treedata.length > 1) {
-    // Find the index of "Private" and remove the children. The sub units should not be shown.
-    // TreetmentUnits.treedata starts with one element "Nasjonalt". Need to wait for it to build up the rest.
-    const indPrivate = treatmentUnits.treedata.findIndex(
-      (x) => x.nodeValue.value === "Private",
-    );
-    treatmentUnits.treedata[indPrivate].children = [];
+      getUnitFullName(unitNamesQuery.data.nestedUnitNames, unitName);
   }
 
   // The following code ensures that the page renders correctly
-  const unitUrlsQuery = useUnitUrlsQuery();
-
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const shouldRefreshInitialState = mounted && unitUrlsQuery.isFetched;
-
-  // Callback function for initialising the filter meny
-  const initialiseFilter = (
-    filterInput: Map<string, FilterSettingsValue[]>,
-  ) => {
-    const newUnit = filterInput.get(treatmentUnitsKey).map((el) => el.value);
-
-    let unitUrl: URLs | undefined;
-    if (unitUrlsQuery.data) {
-      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-        return row.shortName === newUnit[0];
-      });
-    }
-
-    if (unitUrl && unitUrl[0]) {
-      setUnitUrl(unitUrl[0].url);
-    } else {
-      setUnitUrl(null);
-    }
-  };
-
-  // Callback function for updating the filter menu
-  const handleChange = (filterInput: FilterSettings) => {
-    const newUnit = filterInput.map
-      .get(treatmentUnitsKey)
-      .map((el) => el.value);
-
-    setExpanded(false);
-    setSelectedTreatmentUnits(newUnit);
-
-    let unitUrl: URLs | undefined;
-    if (unitUrlsQuery.data) {
-      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-        return row.shortName === newUnit[0];
-      });
-    }
-
-    if (unitUrl && unitUrl[0]) {
-      setUnitUrl(unitUrl[0].url);
-    } else {
-      setUnitUrl(null);
-    }
-  };
 
   // Year for filtering
   const lastYear = defaultYear;
@@ -202,60 +103,12 @@ export const Skde = (): JSX.Element => {
           breadcrumbs={breadcrumbs}
           maxWidth={maxWidth}
         >
-          <ClickAwayListener onClickAway={() => setExpanded(false)}>
-            <AccordionWrapper>
-              <Accordion
-                square={true}
-                sx={{
-                  width: Math.min(400, 0.8 * width),
-                  borderRadius: 11,
-                  border: 1,
-                  borderColor: skdeTheme.palette.primary.main,
-                  backgroundColor: "white",
-                  color: skdeTheme.palette.primary.main,
-                }}
-                expanded={expanded}
-                onChange={(e, expanded) => {
-                  setExpanded(expanded);
-                }}
-              >
-                <AccordionSummary expandIcon={<CustomAccordionExpandIcon />}>
-                  <h3>
-                    {selectedTreatmentUnits[0] === "Nasjonalt"
-                      ? "Velg behandlingssted"
-                      : selectedTreatmentUnits[0]}
-                  </h3>
-                </AccordionSummary>
-
-                <AccordionDetails>
-                  <FilterMenu
-                    refreshState={shouldRefreshInitialState}
-                    onSelectionChanged={handleChange}
-                    onFilterInitialized={initialiseFilter}
-                  >
-                    <TreeViewFilterSection
-                      refreshState={shouldRefreshInitialState}
-                      treedata={treatmentUnits.treedata}
-                      defaultvalues={treatmentUnits.defaults}
-                      initialselections={
-                        selectedTreatmentUnits.map((value) => ({
-                          value: value,
-                          valueLabel: value,
-                        })) as FilterSettingsValue[]
-                      }
-                      sectionid={treatmentUnitsKey}
-                      sectiontitle={"Behandlingsenheter"}
-                      filterkey={treatmentUnitsKey}
-                      searchbox={true}
-                      multiselect={false}
-                      accordion={false}
-                      noShadow={true}
-                    />
-                  </FilterMenu>
-                </AccordionDetails>
-              </Accordion>
-            </AccordionWrapper>
-          </ClickAwayListener>
+          <UnitFilterMenu
+            width={Math.min(400, 0.8 * width)}
+            setUnitName={setUnitName}
+            setUnitUrl={setUnitUrl}
+            unitNamesQuery={unitNamesQuery}
+          />
         </Header>
 
         <Container maxWidth={maxWidth} disableGutters={true}>
@@ -265,7 +118,7 @@ export const Skde = (): JSX.Element => {
                 <HospitalInfoBox
                   boxHeight={width > breakpoints.xxl ? 350 : 450}
                   unitNames={unitNamesQuery.data}
-                  selectedTreatmentUnit={selectedTreatmentUnits[0]}
+                  selectedTreatmentUnit={unitName}
                   unitUrl={unitUrl}
                 />
               </Grid>
@@ -274,7 +127,7 @@ export const Skde = (): JSX.Element => {
                   boxHeight={width > breakpoints.xxl ? 350 : 450}
                   titleStyle={titleStyle}
                   unitNames={unitNamesQuery.data}
-                  selectedTreatmentUnit={selectedTreatmentUnits[0]}
+                  selectedTreatmentUnit={unitName}
                 />
               </Grid>
 
@@ -284,14 +137,14 @@ export const Skde = (): JSX.Element => {
                   titlePadding={titlePadding}
                   titleStyle={titleStyle}
                   textMargin={textMargin}
-                  unitName={selectedTreatmentUnits[0]}
+                  unitName={unitName}
                   lastYear={lastYear}
                 />
               </Grid>
 
               <Grid size={{ xs: 12 }}>
                 <HospitalProfileLowLevelTable
-                  unitName={selectedTreatmentUnits[0]}
+                  unitName={unitName}
                   boxMaxHeight={boxMaxHeight}
                   titlePadding={titlePadding}
                   titleStyle={titleStyle}
@@ -304,7 +157,7 @@ export const Skde = (): JSX.Element => {
               <Grid size={{ xs: 12 }}>
                 <HospitalProfileLinePlot
                   unitFullName={unitFullName}
-                  unitNames={selectedTreatmentUnits[0]}
+                  unitNames={unitName}
                   lastYear={lastYear}
                   pastYears={pastYears}
                   titlePadding={titlePadding}

--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -28,14 +28,51 @@ import { HospitalProfileLinePlot } from "../../src/components/HospitalProfile/Ho
 import { UnitFilterMenu } from "../../src/components/HospitalProfile/UnitFilterMenu";
 
 export const Skde = (): JSX.Element => {
+  // States
   const [unitName, setUnitName] = useState<string>();
-
-  const { width } = useScreenSize();
-
-  // Infobox URL
   const [unitUrl, setUnitUrl] = useState<string | null>(null);
 
-  // Get unit names
+  // ############### //
+  // Page parameters //
+  // ############### //
+
+  // Styling
+  const boxMaxHeight = 800;
+  const titleStyle = { marginTop: 20, marginLeft: 20 };
+  const textMargin = 20;
+  const maxWidth = "xxl";
+  const titlePadding = 2;
+
+  // On screen resize
+  const { width } = useScreenSize();
+
+  // Years for filtering
+  const lastYear = defaultYear;
+  const pastYears = 5;
+
+  // Header settings
+  const breadcrumbs: BreadCrumbPath = {
+    path: [
+      {
+        link: "https://www.skde.no",
+        text: "Forside",
+      },
+      {
+        link: "/sykehusprofil/",
+        text: "Sykehusprofil",
+      },
+    ],
+  };
+
+  const headerData: HeaderData = {
+    title: "Sykehusprofil",
+    subtitle:
+      "Her vises alle kvalitetsindikatorer fra nasjonale medisinske kvalitetsregistre i form av sykehusprofiler",
+  };
+
+  // ######## //
+  // Queries //
+  // ####### //
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const unitNamesQuery: UseQueryResult<any, unknown> = useUnitNamesQuery(
@@ -60,39 +97,6 @@ export const Skde = (): JSX.Element => {
       unitNamesQuery.data &&
       getUnitFullName(unitNamesQuery.data.nestedUnitNames, unitName);
   }
-
-  // The following code ensures that the page renders correctly
-
-  // Year for filtering
-  const lastYear = defaultYear;
-  const pastYears = 5;
-
-  const breadcrumbs: BreadCrumbPath = {
-    path: [
-      {
-        link: "https://www.skde.no",
-        text: "Forside",
-      },
-      {
-        link: "/sykehusprofil/",
-        text: "Sykehusprofil",
-      },
-    ],
-  };
-
-  const headerData: HeaderData = {
-    title: "Sykehusprofil",
-    subtitle:
-      "Her vises alle kvalitetsindikatorer fra nasjonale medisinske kvalitetsregistre i form av sykehusprofiler",
-  };
-
-  const boxMaxHeight = 800;
-
-  const titleStyle = { marginTop: 20, marginLeft: 20 };
-  const textMargin = 20;
-
-  const maxWidth = "xxl";
-  const titlePadding = 2;
 
   return (
     <ThemeProvider theme={skdeTheme}>

--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -10,6 +10,7 @@ import {
   useUnitNamesQuery,
   defaultYear,
   mainHospitals,
+  useUnitUrlsQuery,
 } from "qmongjs";
 import { Footer } from "../../src/components/Footer";
 import { ThemeProvider, Box, Container } from "@mui/material";
@@ -75,11 +76,19 @@ export const Skde = (): JSX.Element => {
   // ####### //
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const unitNamesQuery: UseQueryResult<any, unknown> = useUnitNamesQuery(
+  const unitNamesQuery: UseQueryResult<any, Error> = useUnitNamesQuery(
     "all",
     "caregiver",
     "ind",
   );
+
+  // URLs for the web pages to the different treatment units
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const unitUrlsQuery: UseQueryResult<any, Error> = useUnitUrlsQuery();
+
+  if (unitNamesQuery.isFetching || unitUrlsQuery.isFetching) {
+    return null;
+  }
 
   let unitFullName: string;
 
@@ -112,6 +121,7 @@ export const Skde = (): JSX.Element => {
             setUnitName={setUnitName}
             setUnitUrl={setUnitUrl}
             unitNamesQuery={unitNamesQuery}
+            unitUrlsQuery={unitUrlsQuery}
           />
         </Header>
 

--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -15,10 +15,8 @@ import {
 import { Footer } from "../../src/components/Footer";
 import { ThemeProvider, Box, Container } from "@mui/material";
 import Grid from "@mui/material/Grid2";
-
 import { PageWrapper } from "../../src/components/StyledComponents/PageWrapper";
 import { HospitalInfoBox } from "../../src/components/HospitalProfile";
-
 import { getUnitFullName } from "../../src/helpers/functions/getUnitFullName";
 import { AffiliatedHospitals } from "../../src/components/HospitalProfile/AffiliatedHospitals";
 import { useScreenSize } from "@visx/responsive";

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -46,7 +46,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
   // States
   const [expanded, setExpanded] = useState(false);
-  const [firstRender, setFirstRender] = useState(true);
 
   // URL query parameter key
   const treatmentUnitsKey = "selected_treatment_units";
@@ -98,30 +97,26 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
   // Callback function for updating the filter menu
   const handleChange = (filterInput: FilterSettings) => {
     // firstRender is a guard to ensure that handleChange does not trigger at the same time as initaliseFilter
-    if (!firstRender) {
-      const newUnit = filterInput.map
-        .get(treatmentUnitsKey)
-        .map((el) => el.value);
+    const newUnit = filterInput.map
+      .get(treatmentUnitsKey)
+      .map((el) => el.value);
 
-      setExpanded(false);
-      setSelectedTreatmentUnits(newUnit);
+    setExpanded(false);
+    setSelectedTreatmentUnits(newUnit);
 
-      setUnitName(newUnit[0]);
+    setUnitName(newUnit[0]);
 
-      let unitUrl: URLs | undefined;
-      if (unitUrlsQuery.data) {
-        unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-          return row.shortName === newUnit[0];
-        });
-      }
+    let unitUrl: URLs | undefined;
+    if (unitUrlsQuery.data) {
+      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
+        return row.shortName === newUnit[0];
+      });
+    }
 
-      if (unitUrl && unitUrl[0]) {
-        setUnitUrl(unitUrl[0].url);
-      } else {
-        setUnitUrl(null);
-      }
+    if (unitUrl && unitUrl[0]) {
+      setUnitUrl(unitUrl[0].url);
     } else {
-      setFirstRender(false);
+      setUnitUrl(null);
     }
   };
 

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   skdeTheme,
   FilterSettingsValue,
@@ -6,7 +6,6 @@ import {
   TreeViewFilterSection,
   FilterSettings,
   CustomAccordionExpandIcon,
-  useUnitUrlsQuery,
   getTreatmentUnitsTree,
 } from "qmongjs";
 import {
@@ -30,7 +29,9 @@ type UnitFilterMenuProps = {
   setUnitName: React.Dispatch<React.SetStateAction<string>>;
   setUnitUrl: React.Dispatch<React.SetStateAction<string>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unitNamesQuery: UseQueryResult<any, unknown>;
+  unitNamesQuery: UseQueryResult<any, Error>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unitUrlsQuery: UseQueryResult<any, Error>;
 };
 
 const AccordionWrapper = styled(Box)(() => ({
@@ -40,11 +41,11 @@ const AccordionWrapper = styled(Box)(() => ({
 }));
 
 export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
-  const { width, setUnitName, setUnitUrl, unitNamesQuery } = props;
+  const { width, setUnitName, setUnitUrl, unitNamesQuery, unitUrlsQuery } =
+    props;
 
   // States
   const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
   const [firstRender, setFirstRender] = useState(true);
 
   // URL query parameter key
@@ -67,16 +68,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
     );
     treatmentUnits.treedata[indPrivate].children = [];
   }
-
-  // URLs for the web pages to the different treatment units
-  const unitUrlsQuery = useUnitUrlsQuery();
-
-  // Condition for regreshing the filter menu
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const shouldRefreshInitialState = mounted && unitUrlsQuery.isFetched;
 
   // ###################################### //
   // Callback functions for the filter menu //
@@ -115,12 +106,12 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
       setExpanded(false);
       setSelectedTreatmentUnits(newUnit);
 
-      setUnitName(selectedTreatmentUnits[0]);
+      setUnitName(newUnit[0]);
 
       let unitUrl: URLs | undefined;
       if (unitUrlsQuery.data) {
         unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-          return row.shortName === selectedTreatmentUnits[0];
+          return row.shortName === newUnit[0];
         });
       }
 
@@ -162,12 +153,12 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
           <AccordionDetails>
             <FilterMenu
-              refreshState={shouldRefreshInitialState}
+              refreshState={true}
               onSelectionChanged={handleChange}
               onFilterInitialized={initialiseFilter}
             >
               <TreeViewFilterSection
-                refreshState={shouldRefreshInitialState}
+                refreshState={true}
                 treedata={treatmentUnits.treedata}
                 defaultvalues={treatmentUnits.defaults}
                 initialselections={

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -46,7 +46,7 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
   const [mounted, setMounted] = useState(false);
 
-  const [firstRender, setFirstRender] = useState(true)
+  const [firstRender, setFirstRender] = useState(true);
 
   const treatmentUnitsKey = "selected_treatment_units";
 
@@ -75,7 +75,7 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
       setUnitUrl(null);
     }
 
-    setUnitName(selectedTreatmentUnits[0]);
+    setUnitName(newUnit[0]);
   };
 
   const treatmentUnits = getTreatmentUnitsTree(unitNamesQuery);
@@ -93,7 +93,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
   // Callback function for updating the filter menu
   const handleChange = (filterInput: FilterSettings) => {
-    
     if (!firstRender) {
       const newUnit = filterInput.map
         .get(treatmentUnitsKey)
@@ -116,9 +115,9 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
       } else {
         setUnitUrl(null);
       }
-  } else {
-    setFirstRender(false)
-  }
+    } else {
+      setFirstRender(false);
+    }
   };
 
   useEffect(() => {

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -46,6 +46,8 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
   const [mounted, setMounted] = useState(false);
 
+  const [firstRender, setFirstRender] = useState(true)
+
   const treatmentUnitsKey = "selected_treatment_units";
 
   // Current unit name and its setter function
@@ -91,27 +93,32 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
 
   // Callback function for updating the filter menu
   const handleChange = (filterInput: FilterSettings) => {
-    const newUnit = filterInput.map
-      .get(treatmentUnitsKey)
-      .map((el) => el.value);
+    
+    if (!firstRender) {
+      const newUnit = filterInput.map
+        .get(treatmentUnitsKey)
+        .map((el) => el.value);
 
-    setExpanded(false);
-    setSelectedTreatmentUnits(newUnit);
+      setExpanded(false);
+      setSelectedTreatmentUnits(newUnit);
 
-    setUnitName(selectedTreatmentUnits[0]);
+      setUnitName(selectedTreatmentUnits[0]);
 
-    let unitUrl: URLs | undefined;
-    if (unitUrlsQuery.data) {
-      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-        return row.shortName === selectedTreatmentUnits[0];
-      });
-    }
+      let unitUrl: URLs | undefined;
+      if (unitUrlsQuery.data) {
+        unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
+          return row.shortName === selectedTreatmentUnits[0];
+        });
+      }
 
-    if (unitUrl && unitUrl[0]) {
-      setUnitUrl(unitUrl[0].url);
-    } else {
-      setUnitUrl(null);
-    }
+      if (unitUrl && unitUrl[0]) {
+        setUnitUrl(unitUrl[0].url);
+      } else {
+        setUnitUrl(null);
+      }
+  } else {
+    setFirstRender(false)
+  }
   };
 
   useEffect(() => {

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from "react";
+import {
+  skdeTheme,
+  FilterSettingsValue,
+  FilterMenu,
+  TreeViewFilterSection,
+  FilterSettings,
+  CustomAccordionExpandIcon,
+  useUnitUrlsQuery,
+  getTreatmentUnitsTree,
+} from "qmongjs";
+import {
+  Box,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  styled,
+} from "@mui/material";
+import { ClickAwayListener } from "@mui/base";
+import {
+  useQueryParam,
+  DelimitedArrayParam,
+  withDefault,
+} from "use-query-params";
+import { URLs } from "types";
+import { UseQueryResult } from "@tanstack/react-query";
+
+type UnitFilterMenuProps = {
+  width: number;
+  setUnitName: React.Dispatch<React.SetStateAction<string>>;
+  setUnitUrl: React.Dispatch<React.SetStateAction<string>>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unitNamesQuery: UseQueryResult<any, unknown>;
+};
+
+const AccordionWrapper = styled(Box)(() => ({
+  "& MuiAccordion-root:before": {
+    backgroundColor: "white",
+  },
+}));
+
+export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
+  const { width, setUnitName, setUnitUrl, unitNamesQuery } = props;
+
+  const [expanded, setExpanded] = useState(false);
+
+  const [mounted, setMounted] = useState(false);
+
+  const treatmentUnitsKey = "selected_treatment_units";
+
+  // Current unit name and its setter function
+  const [selectedTreatmentUnits, setSelectedTreatmentUnits] = useQueryParam(
+    treatmentUnitsKey,
+    withDefault(DelimitedArrayParam, ["Nasjonalt"]),
+  );
+
+  // Callback function for initialising the filter meny
+  const initialiseFilter = (
+    filterInput: Map<string, FilterSettingsValue[]>,
+  ) => {
+    const newUnit = filterInput.get(treatmentUnitsKey).map((el) => el.value);
+
+    let unitUrl: URLs | undefined;
+    if (unitUrlsQuery.data) {
+      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
+        return row.shortName === selectedTreatmentUnits[0];
+      });
+    }
+
+    if (unitUrl && unitUrl[0]) {
+      setUnitUrl(unitUrl[0].url);
+    } else {
+      setUnitUrl(null);
+    }
+
+    setSelectedTreatmentUnits(newUnit);
+    setUnitName(selectedTreatmentUnits[0]);
+  };
+
+  const treatmentUnits = getTreatmentUnitsTree(unitNamesQuery);
+
+  if (treatmentUnits.treedata.length > 1) {
+    // Find the index of "Private" and remove the children. The sub units should not be shown.
+    // TreetmentUnits.treedata starts with one element "Nasjonalt". Need to wait for it to build up the rest.
+    const indPrivate = treatmentUnits.treedata.findIndex(
+      (x) => x.nodeValue.value === "Private",
+    );
+    treatmentUnits.treedata[indPrivate].children = [];
+  }
+
+  const unitUrlsQuery = useUnitUrlsQuery();
+
+  // Callback function for updating the filter menu
+  const handleChange = (filterInput: FilterSettings) => {
+    const newUnit = filterInput.map
+      .get(treatmentUnitsKey)
+      .map((el) => el.value);
+
+    setExpanded(false);
+    setSelectedTreatmentUnits(newUnit);
+
+    setUnitName(selectedTreatmentUnits[0]);
+
+    let unitUrl: URLs | undefined;
+    if (unitUrlsQuery.data) {
+      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
+        return row.shortName === selectedTreatmentUnits[0];
+      });
+    }
+
+    if (unitUrl && unitUrl[0]) {
+      setUnitUrl(unitUrl[0].url);
+    } else {
+      setUnitUrl(null);
+    }
+  };
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const shouldRefreshInitialState = mounted && unitUrlsQuery.isFetched;
+
+  return (
+    <ClickAwayListener onClickAway={() => setExpanded(false)}>
+      <AccordionWrapper>
+        <Accordion
+          square={true}
+          sx={{
+            width: width,
+            borderRadius: 11,
+            border: 1,
+            borderColor: skdeTheme.palette.primary.main,
+            backgroundColor: "white",
+            color: skdeTheme.palette.primary.main,
+          }}
+          expanded={expanded}
+          onChange={(e, expanded) => {
+            setExpanded(expanded);
+          }}
+        >
+          <AccordionSummary expandIcon={<CustomAccordionExpandIcon />}>
+            <h3>
+              {selectedTreatmentUnits[0] === "Nasjonalt"
+                ? "Velg behandlingssted"
+                : selectedTreatmentUnits[0]}
+            </h3>
+          </AccordionSummary>
+
+          <AccordionDetails>
+            <FilterMenu
+              refreshState={shouldRefreshInitialState}
+              onSelectionChanged={handleChange}
+              onFilterInitialized={initialiseFilter}
+            >
+              <TreeViewFilterSection
+                refreshState={shouldRefreshInitialState}
+                treedata={treatmentUnits.treedata}
+                defaultvalues={treatmentUnits.defaults}
+                initialselections={
+                  selectedTreatmentUnits.map((value) => ({
+                    value: value,
+                    valueLabel: value,
+                  })) as FilterSettingsValue[]
+                }
+                sectionid={treatmentUnitsKey}
+                sectiontitle={"Behandlingsenheter"}
+                filterkey={treatmentUnitsKey}
+                searchbox={true}
+                multiselect={false}
+                accordion={false}
+                noShadow={true}
+              />
+            </FilterMenu>
+          </AccordionDetails>
+        </Accordion>
+      </AccordionWrapper>
+    </ClickAwayListener>
+  );
+};

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -73,7 +73,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
       setUnitUrl(null);
     }
 
-    setSelectedTreatmentUnits(newUnit);
     setUnitName(selectedTreatmentUnits[0]);
   };
 


### PR DESCRIPTION
Flyttet filtermenyen til sykehusprofil ut i en egen komponent. Alle spørringer gjøres i index-filen til siden og sendes til filtermenykomponenten. Komponenten tar også setter-funksjoner for å endre state i hovedkomponenten. 

Når siden bygges skal filtermenyen og knappene for tilknyttede enheter fungerer Knappene fungerer nå stort sett også når man tester med `yarn dev`, men hopper av og til til "Nasjonalt". 