### PR TITLE
Sett behandlingsenhet med knapper uten å laste inn siden på nytt

### DIFF
--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -26,11 +26,11 @@ import { HospitalProfileLowLevelTable } from "../../src/components/HospitalProfi
 import { HospitalProfileLinePlot } from "../../src/components/HospitalProfile/HospitalProfileLinePlot";
 import { UnitFilterMenu } from "../../src/components/HospitalProfile/UnitFilterMenu";
 import { TurnDeviceBox } from "../../src/components/HospitalProfile/TurnDeviceBox";
+import { URLs } from "types";
 
 export const Skde = (): JSX.Element => {
   // States
   const [unitName, setUnitName] = useState<string>();
-  const [unitUrl, setUnitUrl] = useState<string | null>(null);
   const [isMobileAndVertical, setIsMobileAndVertical] = useState<boolean>();
 
   // ############### //
@@ -83,7 +83,7 @@ export const Skde = (): JSX.Element => {
       "Her vises alle kvalitetsindikatorer fra nasjonale medisinske kvalitetsregistre i form av sykehusprofiler",
   };
 
-  // ######## //
+  // ####### //
   // Queries //
   // ####### //
 
@@ -119,6 +119,23 @@ export const Skde = (): JSX.Element => {
       getUnitFullName(unitNamesQuery.data.nestedUnitNames, unitName);
   }
 
+  // ############ //
+  // Set unit URL //
+  // ############ //
+
+  let newUnitUrl: URLs | undefined;
+  let unitUrl = "";
+
+  if (unitUrlsQuery.data) {
+    newUnitUrl = unitUrlsQuery.data.filter((row: URLs) => {
+      return row.shortName === unitName;
+    });
+  }
+
+  if (newUnitUrl && newUnitUrl[0]) {
+    unitUrl = newUnitUrl[0].url;
+  }
+
   return (
     <ThemeProvider theme={skdeTheme}>
       <PageWrapper>
@@ -131,9 +148,7 @@ export const Skde = (): JSX.Element => {
           <UnitFilterMenu
             width={Math.min(400, 0.8 * width)}
             setUnitName={setUnitName}
-            setUnitUrl={setUnitUrl}
             unitNamesQuery={unitNamesQuery}
-            unitUrlsQuery={unitUrlsQuery}
           />
         </Header>
 

--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -157,6 +157,7 @@ export const Skde = (): JSX.Element => {
                   titleStyle={titleStyle}
                   unitNames={unitNamesQuery.data}
                   selectedTreatmentUnit={unitName}
+                  setUnitName={setUnitName}
                 />
               </Grid>
 

--- a/apps/skde/src/components/HospitalProfile/AffiliatedHospitals/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/AffiliatedHospitals/index.tsx
@@ -8,10 +8,17 @@ type AffiliatedHospitalProps = {
   titleStyle: { marginLeft: number; marginTop: number };
   unitNames: { nestedUnitNames: NestedTreatmentUnitName[]; opts_tu: OptsTu[] };
   selectedTreatmentUnit: string;
+  setUnitName: React.Dispatch<React.SetStateAction<string>>;
 };
 
 export const AffiliatedHospitals = (props: AffiliatedHospitalProps) => {
-  const { boxHeight, titleStyle, unitNames, selectedTreatmentUnit } = props;
+  const {
+    boxHeight,
+    titleStyle,
+    unitNames,
+    selectedTreatmentUnit,
+    setUnitName,
+  } = props;
 
   return (
     <ItemBox height={boxHeight} sx={{ overflow: "auto" }}>
@@ -22,6 +29,7 @@ export const AffiliatedHospitals = (props: AffiliatedHospitalProps) => {
         <SubUnits
           RHFs={unitNames.nestedUnitNames}
           selectedUnit={selectedTreatmentUnit}
+          setUnitName={setUnitName}
         />
       ) : null}
     </ItemBox>

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -3,6 +3,7 @@ import { NestedTreatmentUnitName } from "types";
 import { Button, List, ListItem, Stack, Typography, Box } from "@mui/material";
 import { LocalHospital, Undo } from "@mui/icons-material";
 import { skdeTheme } from "qmongjs";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
 const getParentUnit = (
   nestedUnitNames: NestedTreatmentUnitName[],
@@ -69,12 +70,26 @@ const UnitButton = (props: {
   unitName: string;
   buttonVariant: "outlined" | "text" | "contained";
   setUnitName: React.Dispatch<React.SetStateAction<string>>;
+  returnButton?: boolean;
 }) => {
-  const { unitName, buttonVariant, setUnitName } = props;
+  const { unitName, buttonVariant, setUnitName, returnButton } = props;
+
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const params = new URLSearchParams(searchParams.toString());
+  params.set("selected_treatment_units", unitName);
+
+  const symbol = returnButton ? <Undo /> : <LocalHospital />;
+  const text = returnButton ? "Opp et nivå" : unitName;
 
   return (
     <Button
-      onClick={() => setUnitName(unitName)}
+      onClick={() => {
+        router.push(pathname + "?" + params.toString());
+        setUnitName(unitName);
+      }}
       variant={buttonVariant}
       data-testid={`subunit_button_${unitName}`}
     >
@@ -84,8 +99,8 @@ const UnitButton = (props: {
         alignItems="center"
         justifyContent="center"
       >
-        <LocalHospital />
-        <Typography variant="button">{unitName}</Typography>
+        {symbol}
+        <Typography variant="button">{text}</Typography>
       </Stack>
     </Button>
   );
@@ -182,14 +197,12 @@ export const SubUnits = (props: SubUnitsProps) => {
       {buttonList}
       <Box marginLeft={2} marginTop={4}>
         {parentUnit && (
-          <Button
-            variant="contained"
-            onClick={() => {
-              setUnitName(parentUnit);
-            }}
-          >
-            <Undo /> <Typography variant="button">Opp et nivå</Typography>{" "}
-          </Button>
+          <UnitButton
+            buttonVariant="contained"
+            unitName={parentUnit}
+            setUnitName={setUnitName}
+            returnButton={true}
+          ></UnitButton>
         )}
       </Box>
     </>

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -42,6 +42,7 @@ const getParentUnit = (
 type SubUnitsProps = {
   RHFs: NestedTreatmentUnitName[];
   selectedUnit: string;
+  setUnitName: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const getUnitLevel = (
@@ -67,12 +68,13 @@ const getUnitLevel = (
 const UnitButton = (props: {
   unitName: string;
   buttonVariant: "outlined" | "text" | "contained";
+  setUnitName: React.Dispatch<React.SetStateAction<string>>;
 }) => {
-  const { unitName, buttonVariant } = props;
+  const { unitName, buttonVariant, setUnitName } = props;
 
   return (
     <Button
-      href={"/sykehusprofil/?selected_treatment_units=" + unitName}
+      onClick={() => setUnitName(unitName)}
       variant={buttonVariant}
       data-testid={`subunit_button_${unitName}`}
     >
@@ -90,7 +92,7 @@ const UnitButton = (props: {
 };
 
 export const SubUnits = (props: SubUnitsProps) => {
-  const { RHFs, selectedUnit } = props;
+  const { RHFs, selectedUnit, setUnitName } = props;
 
   const HFs = RHFs.map((row) => row.hf).flat();
   const unitLevel = getUnitLevel(RHFs, selectedUnit);
@@ -109,7 +111,11 @@ export const SubUnits = (props: SubUnitsProps) => {
           .map((rhf) => {
             return (
               <ListItem key={"subunit-link-" + rhf}>
-                <UnitButton unitName={rhf} buttonVariant={buttonVariant} />
+                <UnitButton
+                  unitName={rhf}
+                  buttonVariant={buttonVariant}
+                  setUnitName={setUnitName}
+                />
               </ListItem>
             );
           })}
@@ -127,7 +133,11 @@ export const SubUnits = (props: SubUnitsProps) => {
           .map((row) => {
             return (
               <ListItem key={"subunit-link-" + row.hf}>
-                <UnitButton unitName={row.hf} buttonVariant={buttonVariant} />
+                <UnitButton
+                  unitName={row.hf}
+                  buttonVariant={buttonVariant}
+                  setUnitName={setUnitName}
+                />
               </ListItem>
             );
           })}
@@ -140,7 +150,11 @@ export const SubUnits = (props: SubUnitsProps) => {
           (hospital) => {
             return (
               <ListItem key={"subunit-link-" + hospital}>
-                <UnitButton unitName={hospital} buttonVariant={buttonVariant} />
+                <UnitButton
+                  unitName={hospital}
+                  buttonVariant={buttonVariant}
+                  setUnitName={setUnitName}
+                />
               </ListItem>
             );
           },
@@ -170,7 +184,9 @@ export const SubUnits = (props: SubUnitsProps) => {
         {parentUnit && (
           <Button
             variant="contained"
-            href={"/sykehusprofil/?selected_treatment_units=" + parentUnit}
+            onClick={() => {
+              setUnitName(parentUnit);
+            }}
           >
             <Undo /> <Typography variant="button">Opp et nivå</Typography>{" "}
           </Button>

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -86,7 +86,6 @@ const UnitButton = (props: {
 
   // Symbol and text for the button
   const symbol = returnButton ? <Undo /> : <LocalHospital />;
-  const text = returnButton ? "Opp et nivå" : unitName;
 
   return (
     <Button
@@ -104,7 +103,7 @@ const UnitButton = (props: {
         justifyContent="center"
       >
         {symbol}
-        <Typography variant="button">{text}</Typography>
+        <Typography variant="button">{unitName}</Typography>
       </Stack>
     </Button>
   );

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -90,7 +90,7 @@ const UnitButton = (props: {
   return (
     <Button
       onClick={() => {
-        router.push(pathname + "?" + params.toString(), { scroll: false });
+        router.replace(pathname + "?" + params.toString(), { scroll: false });
         setUnitName(unitName);
       }}
       variant={buttonVariant}

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -76,7 +76,7 @@ const UnitButton = (props: {
 }) => {
   const { unitName, buttonVariant, setUnitName, returnButton } = props;
 
-  // Router for updateing the query parameter
+  // Router for updating the query parameter
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -91,7 +91,7 @@ const UnitButton = (props: {
   return (
     <Button
       onClick={() => {
-        router.push(pathname + "?" + params.toString());
+        router.push(pathname + "?" + params.toString(), { scroll: false });
         setUnitName(unitName);
       }}
       variant={buttonVariant}

--- a/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/SubUnits/index.tsx
@@ -5,6 +5,7 @@ import { LocalHospital, Undo } from "@mui/icons-material";
 import { skdeTheme } from "qmongjs";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
+// Find the unit one level above the given unit
 const getParentUnit = (
   nestedUnitNames: NestedTreatmentUnitName[],
   unitShortName: string,
@@ -66,6 +67,7 @@ const getUnitLevel = (
   return unitLevel;
 };
 
+// This button sets the new unit name and updates the URL query parameter "selected_treatment_unit"
 const UnitButton = (props: {
   unitName: string;
   buttonVariant: "outlined" | "text" | "contained";
@@ -74,6 +76,7 @@ const UnitButton = (props: {
 }) => {
   const { unitName, buttonVariant, setUnitName, returnButton } = props;
 
+  // Router for updateing the query parameter
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -81,6 +84,7 @@ const UnitButton = (props: {
   const params = new URLSearchParams(searchParams.toString());
   params.set("selected_treatment_units", unitName);
 
+  // Symbol and text for the button
   const symbol = returnButton ? <Undo /> : <LocalHospital />;
   const text = returnButton ? "Opp et nivå" : unitName;
 
@@ -118,6 +122,8 @@ export const SubUnits = (props: SubUnitsProps) => {
 
   const parentUnit = getParentUnit(RHFs, selectedUnit);
 
+  // Logic for handling the four different unit levels
+  // Nasjonalt, RHF, HF and sykehus
   if (unitLevel === "Nasjonalt") {
     buttonList = (
       <List>

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -21,17 +21,13 @@ import {
   DelimitedArrayParam,
   withDefault,
 } from "use-query-params";
-import { URLs } from "types";
 import { UseQueryResult } from "@tanstack/react-query";
 
 type UnitFilterMenuProps = {
   width: number;
   setUnitName: React.Dispatch<React.SetStateAction<string>>;
-  setUnitUrl: React.Dispatch<React.SetStateAction<string>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   unitNamesQuery: UseQueryResult<any, Error>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unitUrlsQuery: UseQueryResult<any, Error>;
 };
 
 const AccordionWrapper = styled(Box)(() => ({
@@ -41,8 +37,7 @@ const AccordionWrapper = styled(Box)(() => ({
 }));
 
 export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
-  const { width, setUnitName, setUnitUrl, unitNamesQuery, unitUrlsQuery } =
-    props;
+  const { width, setUnitName, unitNamesQuery } = props;
 
   // States
   const [expanded, setExpanded] = useState(false);
@@ -78,19 +73,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
   ) => {
     const newUnit = filterInput.get(treatmentUnitsKey).map((el) => el.value);
 
-    let unitUrl: URLs | undefined;
-    if (unitUrlsQuery.data) {
-      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-        return row.shortName === selectedTreatmentUnits[0];
-      });
-    }
-
-    if (unitUrl && unitUrl[0]) {
-      setUnitUrl(unitUrl[0].url);
-    } else {
-      setUnitUrl(null);
-    }
-
     setUnitName(newUnit[0]);
   };
 
@@ -105,19 +87,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
     setSelectedTreatmentUnits(newUnit);
 
     setUnitName(newUnit[0]);
-
-    let unitUrl: URLs | undefined;
-    if (unitUrlsQuery.data) {
-      unitUrl = unitUrlsQuery.data.filter((row: URLs) => {
-        return row.shortName === newUnit[0];
-      });
-    }
-
-    if (unitUrl && unitUrl[0]) {
-      setUnitUrl(unitUrl[0].url);
-    } else {
-      setUnitUrl(null);
-    }
   };
 
   return (


### PR DESCRIPTION
- Oppdater URL i pages-filen istedenfor å sende en setter-funksjon til komponentene under
- Oppdater state istedenfor å laste inn siden på nytt når man velger behandlingsenhet med knappene
- Tilbake-knappen viser enhetsnavn istedenfor "Opp et nivå"

![image](https://github.com/user-attachments/assets/920977a6-ee6f-4714-b9bb-e99f773977dd)
