### PR TITLE
vertikal posisjon samvarer med tekst, fjerne rotering av ikoner

### DIFF
--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -14,6 +14,7 @@ import {
   AccordionSummary,
   AccordionDetails,
   styled,
+  Typography,
 } from "@mui/material";
 import { ClickAwayListener } from "@mui/base";
 import {
@@ -107,12 +108,14 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
             setExpanded(expanded);
           }}
         >
-          <AccordionSummary expandIcon={<CustomAccordionExpandIcon />}>
-            <h3>
+          <AccordionSummary sx={{ padding: 2 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
               {selectedTreatmentUnits[0] === "Nasjonalt"
                 ? "Velg behandlingssted"
                 : selectedTreatmentUnits[0]}
-            </h3>
+            </Typography>
+            <Box sx={{ flexGrow: 1 }} />
+            <CustomAccordionExpandIcon />
           </AccordionSummary>
 
           <AccordionDetails>

--- a/packages/qmongjs/src/components/FilterMenu/CustomAccordionExpandIcon.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/CustomAccordionExpandIcon.tsx
@@ -1,30 +1,37 @@
-import { Box } from "@mui/material";
+import { Box, styled } from "@mui/material";
 import {
   AddCircleOutlineRounded,
   RemoveCircleOutlineRounded,
 } from "@mui/icons-material";
 
+const WrapperBox = styled(Box)(({ theme }) => ({
+  marginRight: 12,
+  ".Mui-expanded & > .collapseIconWrapper": {
+    display: "none",
+  },
+  ".expandIconWrapper": {
+    display: "none",
+  },
+  ".Mui-expanded & > .expandIconWrapper": {
+    display: "block",
+  },
+  [theme.breakpoints.down("md")]: {
+    paddingTop: 1,
+  },
+  [theme.breakpoints.up("md")]: {
+    paddingTop: 3,
+  },
+}));
+
 export const CustomAccordionExpandIcon = () => {
   return (
-    <Box
-      sx={{
-        ".Mui-expanded & > .collapseIconWrapper": {
-          display: "none",
-        },
-        ".expandIconWrapper": {
-          display: "none",
-        },
-        ".Mui-expanded & > .expandIconWrapper": {
-          display: "block",
-        },
-      }}
-    >
+    <WrapperBox>
       <Box className="expandIconWrapper">
         <RemoveCircleOutlineRounded color="primary" />
       </Box>
       <Box className="collapseIconWrapper">
         <AddCircleOutlineRounded color="primary" />
       </Box>
-    </Box>
+    </WrapperBox>
   );
 };

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -9,6 +9,7 @@ import {
   CheckBoxOutlineBlank,
 } from "@mui/icons-material";
 import Box from "@mui/system/Box";
+import { Typography } from "@mui/material";
 
 /**
  * Props for the TreeViewFilterSectionItem component, which extends the
@@ -99,7 +100,9 @@ export const TreeViewFilterSectionItem = (
             />
           </Box>
           <Box flexGrow={1} ml={1}>
-            {labeledValue.valueLabel}
+            <Typography variant="body1" color="primary.dark">
+              {labeledValue.valueLabel}
+            </Typography>
           </Box>
         </Box>
       }

--- a/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreeViewFilterSectionItem.tsx
@@ -100,9 +100,7 @@ export const TreeViewFilterSectionItem = (
             />
           </Box>
           <Box flexGrow={1} ml={1}>
-            <Typography variant="body1" color="primary.dark">
-              {labeledValue.valueLabel}
-            </Typography>
+            <Typography variant="body2">{labeledValue.valueLabel}</Typography>
           </Box>
         </Box>
       }

--- a/packages/qmongjs/src/components/FilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/index.tsx
@@ -103,11 +103,9 @@ const FilterMenuSection = ({
   } else {
     return (
       <Accordion key={`fms-accordion-${sectionid}`}>
-        <AccordionSummary
-          expandIcon={<CustomAccordionExpandIcon />}
-          sx={{ flexDirection: "row-reverse" }}
-        >
-          <Typography variant="body1" sx={{ margin: 1 }}>
+        <AccordionSummary>
+          <CustomAccordionExpandIcon />
+          <Typography variant="subtitle2" color="primary">
             {sectiontitle}
           </Typography>
         </AccordionSummary>

--- a/packages/qmongjs/src/themes/SkdeTheme.tsx
+++ b/packages/qmongjs/src/themes/SkdeTheme.tsx
@@ -93,7 +93,7 @@ const fonts = {
   body2: {
     fontFamily: `${jakartaStyle.fontFamily}`,
     fontWeight: "400",
-    fontSize: "14px",
+    fontSize: "16px",
     letterSpacing: "0.25px",
   },
   button: {


### PR DESCRIPTION
En sånn sak som virker enkel, men blir vanskelig fordi 3. part rammeverk/bibliotek ikke er enig. I stedet for å bruke MUI Accordions expandIcon-property, måtte jeg legge til expand-ikonet sammen med teksten i accordion-headeren.

Før/etter
![image](https://github.com/user-attachments/assets/267e9180-6e22-4d2e-b0c8-846171b04537) ![image](https://github.com/user-attachments/assets/2bef6e2e-0c95-4b0a-9400-23924870b700)


![image](https://github.com/user-attachments/assets/9466cd22-ace3-44db-9f05-df54f3157189) ![image](https://github.com/user-attachments/assets/3569fd3d-103c-4a61-9b21-fe3aca71e2c0)

![image](https://github.com/user-attachments/assets/9c93d30f-eef5-46f5-bf18-6b8f53168f5a)![image](https://github.com/user-attachments/assets/a62d13b4-1c4a-4b41-a349-a3356ed56994)

![image](https://github.com/user-attachments/assets/502a5a2d-95e6-4be3-a62a-9b53dfc8b8c1)![image](https://github.com/user-attachments/assets/7a76a184-9bf9-4e89-ab2d-5006cb43fb21)


