### PR TITLE
3111 justeringer av utseendet

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
@@ -76,7 +76,7 @@ export function SelectedFiltersSection(props: SelectedFiltersSectionProps) {
           sx={{ width: "100%", marginBottom: 2 }}
         >
           <Typography variant="subtitle2" color="primary">
-            Valgte filter
+            Valgte filtre
           </Typography>
           <Link
             type="button"

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -1,7 +1,9 @@
 import { useContext } from "react";
-import { styled } from "@mui/material";
+import { Stack, styled, Typography } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
+import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
 import { FilterMenuSectionProps } from ".";
 import {
   FilterSettingsContext,
@@ -16,6 +18,7 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   height: "2rem",
   fontSize: theme.typography.button.fontFamily,
   textTransform: "none",
+  border: "1px solid #003087 !important",
 }));
 
 type ToggleButtonFilterSectionProps = FilterMenuSectionProps & {
@@ -40,6 +43,7 @@ export function ToggleButtonFilterSection({
 }: ToggleButtonFilterSectionProps) {
   const filterSettings = useContext(FilterSettingsContext);
   const filterSettingsDispatch = useContext(FilterSettingsDispatchContext);
+  const selectedValue = getSelectedValue(filterkey, filterSettings) ?? null;
 
   const handleSelection = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -70,30 +74,43 @@ export function ToggleButtonFilterSection({
   return (
     <ToggleButtonGroup
       exclusive
-      value={getSelectedValue(filterkey, filterSettings) ?? null}
+      value={selectedValue}
       onChange={handleSelection}
       aria-label={`${sectiontitle}-valg`}
-      color="primary"
-      size="small"
       fullWidth={true}
       sx={{
         ".MuiToggleButtonGroup-grouped": {
           borderRadius: 30,
           height: "2rem",
-          fontSize: "theme.typography.button.fontFamily",
           textTransform: "none",
           mr: 1,
+          color: "primary.main"
         },
+        "& .Mui-selected": {
+          backgroundColor: "primary.main",
+          color: "primary.contrastText",
+          ":hover": {
+            backgroundColor: "primary.main",
+          }
+        },        
       }}
-    >
+      >
       {options.map((option) => (
         <StyledToggleButton
           key={`${sectionid}-toggle-${option.value}`}
           data-testid={getTestIdString(sectionid, option.value, testIdPrefix)}
           value={option.value}
           aria-label={option.valueLabel}
+          color="primary"
         >
-          {option.valueLabel}
+          <Stack direction="row" spacing={1} alignItems="center">
+            { option.value === selectedValue ? (
+              <RadioButtonCheckedIcon fontSize="small" />
+            ) : (
+              <RadioButtonUncheckedIcon fontSize="small" />
+            )} 
+            <Typography variant="body2">{option.valueLabel}</Typography>
+          </Stack>
         </StyledToggleButton>
       ))}
     </ToggleButtonGroup>

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Stack, styled, Typography } from "@mui/material";
+import { Stack, styled, Typography, useMediaQuery } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
@@ -12,6 +12,7 @@ import {
 import { FilterSettingsDispatchContext } from "./FilterSettingsReducer";
 import { FilterSettingsActionType } from "./FilterSettingsReducer";
 import { getSelectedValue } from "./utils";
+import { skdeTheme } from "../../themes/SkdeTheme";
 
 const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   borderRadius: 30,
@@ -19,6 +20,8 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   fontSize: theme.typography.button.fontFamily,
   textTransform: "none",
   border: "1px solid #003087 !important",
+  justifyContent: "flex-start",
+  paddingLeft: theme.spacing(1),
 }));
 
 type ToggleButtonFilterSectionProps = FilterMenuSectionProps & {
@@ -44,6 +47,7 @@ export function ToggleButtonFilterSection({
   const filterSettings = useContext(FilterSettingsContext);
   const filterSettingsDispatch = useContext(FilterSettingsDispatchContext);
   const selectedValue = getSelectedValue(filterkey, filterSettings) ?? null;
+  const isSmallScreen = useMediaQuery(skdeTheme.breakpoints.down("sm"));
 
   const handleSelection = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -77,24 +81,21 @@ export function ToggleButtonFilterSection({
       value={selectedValue}
       onChange={handleSelection}
       aria-label={`${sectiontitle}-valg`}
-      fullWidth={true}
+      orientation={isSmallScreen ? "vertical" : "horizontal"}
       sx={{
         ".MuiToggleButtonGroup-grouped": {
           borderRadius: 30,
           height: "2rem",
           textTransform: "none",
           mr: 1,
-          color: "primary.main"
+          mb: 1,
+          pl: 1,
+          pr: 1,
+          color: "primary.main",
+          justifyContent: "flex-start",
         },
-        "& .Mui-selected": {
-          backgroundColor: "primary.main",
-          color: "primary.contrastText",
-          ":hover": {
-            backgroundColor: "primary.main",
-          }
-        },        
       }}
-      >
+    >
       {options.map((option) => (
         <StyledToggleButton
           key={`${sectionid}-toggle-${option.value}`}
@@ -102,13 +103,20 @@ export function ToggleButtonFilterSection({
           value={option.value}
           aria-label={option.valueLabel}
           color="primary"
+          size="small"
         >
-          <Stack direction="row" spacing={1} alignItems="center">
-            { option.value === selectedValue ? (
+          <Stack
+            direction="row"
+            spacing={1}
+            alignItems="center"
+            justifyContent="flex-start"
+            sx={{ width: '100%' }}
+          >
+            {option.value === selectedValue ? (
               <RadioButtonCheckedIcon fontSize="small" />
             ) : (
               <RadioButtonUncheckedIcon fontSize="small" />
-            )} 
+            )}
             <Typography variant="body2">{option.valueLabel}</Typography>
           </Stack>
         </StyledToggleButton>

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -13,6 +13,7 @@ import { FilterSettingsDispatchContext } from "./FilterSettingsReducer";
 import { FilterSettingsActionType } from "./FilterSettingsReducer";
 import { getSelectedValue } from "./utils";
 import { skdeTheme } from "../../themes/SkdeTheme";
+import { useElementWidth } from "../../hooks/useElementWidth";
 
 const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   borderRadius: 30,
@@ -47,7 +48,16 @@ export function ToggleButtonFilterSection({
   const filterSettings = useContext(FilterSettingsContext);
   const filterSettingsDispatch = useContext(FilterSettingsDispatchContext);
   const selectedValue = getSelectedValue(filterkey, filterSettings) ?? null;
-  const isSmallScreen = useMediaQuery(skdeTheme.breakpoints.down("sm"));
+  const { ref, width } = useElementWidth();
+
+  // Calculate the total width of all buttons
+  const totalButtonWidth = options.reduce((total, option) => {
+    // Estimate button width based on text length (adjust multiplier as needed)
+    return total + option.valueLabel.length * 10 + 30; // 60px for padding and icons
+  }, 0);
+
+  // Determine if vertical orientation is needed
+  const useVerticalOrientation = width > 0 && totalButtonWidth > width;
 
   const handleSelection = (
     _event: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -76,51 +86,55 @@ export function ToggleButtonFilterSection({
   };
 
   return (
-    <ToggleButtonGroup
-      exclusive
-      value={selectedValue}
-      onChange={handleSelection}
-      aria-label={`${sectiontitle}-valg`}
-      orientation={isSmallScreen ? "vertical" : "horizontal"}
-      sx={{
-        ".MuiToggleButtonGroup-grouped": {
-          borderRadius: 30,
-          height: "2rem",
-          textTransform: "none",
-          mr: 1,
-          mb: 1,
-          pl: 1,
-          pr: 1,
-          color: "primary.main",
-          justifyContent: "flex-start",
-        },
-      }}
-    >
-      {options.map((option) => (
-        <StyledToggleButton
-          key={`${sectionid}-toggle-${option.value}`}
-          data-testid={getTestIdString(sectionid, option.value, testIdPrefix)}
-          value={option.value}
-          aria-label={option.valueLabel}
-          color="primary"
-          size="small"
-        >
-          <Stack
-            direction="row"
-            spacing={1}
-            alignItems="center"
-            justifyContent="flex-start"
-            sx={{ width: '100%' }}
+    <div ref={ref}>
+      <ToggleButtonGroup
+        exclusive
+        value={selectedValue}
+        onChange={handleSelection}
+        aria-label={`${sectiontitle}-valg`}
+        orientation={useVerticalOrientation ? "vertical" : "horizontal"}
+        sx={{
+          ".MuiToggleButtonGroup-grouped": {
+            borderRadius: 30,
+            height: "2rem",
+            textTransform: "none",
+            mr: useVerticalOrientation ? 0 : 1,
+            mb: 1,
+            pl: 1,
+            pr: 1,
+            color: "primary.main",
+            justifyContent: "flex-start",
+            width: useVerticalOrientation ? "100%" : "auto",
+          },
+        }}
+      >
+        {options.map((option) => (
+          <StyledToggleButton
+            key={`${sectionid}-toggle-${option.value}`}
+            data-testid={getTestIdString(sectionid, option.value, testIdPrefix)}
+            value={option.value}
+            aria-label={option.valueLabel}
+            color="primary"
+            size="small"
+            sx={{ width: useVerticalOrientation ? "100%" : "auto" }}
           >
-            {option.value === selectedValue ? (
-              <RadioButtonCheckedIcon fontSize="small" />
-            ) : (
-              <RadioButtonUncheckedIcon fontSize="small" />
-            )}
-            <Typography variant="body2">{option.valueLabel}</Typography>
-          </Stack>
-        </StyledToggleButton>
-      ))}
-    </ToggleButtonGroup>
+            <Stack
+              direction="row"
+              spacing={1}
+              alignItems="center"
+              justifyContent="flex-start"
+              sx={{ width: '100%' }}
+            >
+              {option.value === selectedValue ? (
+                <RadioButtonCheckedIcon fontSize="small" />
+              ) : (
+                <RadioButtonUncheckedIcon fontSize="small" />
+              )}
+              <Typography variant="body2">{option.valueLabel}</Typography>
+            </Stack>
+          </StyledToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </div>
   );
 }

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Stack, styled, Typography, useMediaQuery } from "@mui/material";
+import { Stack, styled, Typography } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
@@ -12,7 +12,6 @@ import {
 import { FilterSettingsDispatchContext } from "./FilterSettingsReducer";
 import { FilterSettingsActionType } from "./FilterSettingsReducer";
 import { getSelectedValue } from "./utils";
-import { skdeTheme } from "../../themes/SkdeTheme";
 import { useElementWidth } from "../../hooks/useElementWidth";
 
 const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
@@ -23,6 +22,13 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   border: "1px solid #003087 !important",
   justifyContent: "flex-start",
   paddingLeft: theme.spacing(1),
+  '&.Mui-selected': {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.main,
+    },
+  },
 }));
 
 type ToggleButtonFilterSectionProps = FilterMenuSectionProps & {
@@ -93,6 +99,7 @@ export function ToggleButtonFilterSection({
         onChange={handleSelection}
         aria-label={`${sectiontitle}-valg`}
         orientation={useVerticalOrientation ? "vertical" : "horizontal"}
+        fullWidth={useVerticalOrientation}
         sx={{
           ".MuiToggleButtonGroup-grouped": {
             borderRadius: 30,
@@ -105,6 +112,13 @@ export function ToggleButtonFilterSection({
             color: "primary.main",
             justifyContent: "flex-start",
             width: useVerticalOrientation ? "100%" : "auto",
+            '&.Mui-selected': {
+              backgroundColor: "primary.main",
+              color: "primary.contrastText",
+              '&:hover': {
+                backgroundColor: "primary.main",
+              },
+            },
           },
         }}
       >
@@ -116,7 +130,12 @@ export function ToggleButtonFilterSection({
             aria-label={option.valueLabel}
             color="primary"
             size="small"
-            sx={{ width: useVerticalOrientation ? "100%" : "auto" }}
+            sx={{ 
+              width: useVerticalOrientation ? "100%" : "auto",
+              '&.Mui-selected svg': {
+                color: 'primary.contrastText',
+              },
+            }}
           >
             <Stack
               direction="row"

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -2,8 +2,8 @@ import { useContext } from "react";
 import { Stack, styled, Typography } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
-import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '@mui/icons-material/RadioButtonUnchecked';
+import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
+import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import { FilterMenuSectionProps } from ".";
 import {
   FilterSettingsContext,
@@ -22,10 +22,10 @@ const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   border: "1px solid #003087 !important",
   justifyContent: "flex-start",
   paddingLeft: theme.spacing(1),
-  '&.Mui-selected': {
+  "&.Mui-selected": {
     backgroundColor: theme.palette.primary.main,
     color: theme.palette.primary.contrastText,
-    '&:hover': {
+    "&:hover": {
       backgroundColor: theme.palette.primary.main,
     },
   },
@@ -112,10 +112,10 @@ export function ToggleButtonFilterSection({
             color: "primary.main",
             justifyContent: "flex-start",
             width: useVerticalOrientation ? "100%" : "auto",
-            '&.Mui-selected': {
+            "&.Mui-selected": {
               backgroundColor: "primary.main",
               color: "primary.contrastText",
-              '&:hover': {
+              "&:hover": {
                 backgroundColor: "primary.main",
               },
             },
@@ -130,10 +130,10 @@ export function ToggleButtonFilterSection({
             aria-label={option.valueLabel}
             color="primary"
             size="small"
-            sx={{ 
+            sx={{
               width: useVerticalOrientation ? "100%" : "auto",
-              '&.Mui-selected svg': {
-                color: 'primary.contrastText',
+              "&.Mui-selected svg": {
+                color: "primary.contrastText",
               },
             }}
           >
@@ -142,7 +142,7 @@ export function ToggleButtonFilterSection({
               spacing={1}
               alignItems="center"
               justifyContent="flex-start"
-              sx={{ width: '100%' }}
+              sx={{ width: "100%" }}
             >
               {option.value === selectedValue ? (
                 <RadioButtonCheckedIcon fontSize="small" />

--- a/packages/qmongjs/src/hooks/useElementWidth.ts
+++ b/packages/qmongjs/src/hooks/useElementWidth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from "react";
 
 export function useElementWidth() {
   const ref = useRef<HTMLDivElement>(null);
@@ -12,10 +12,10 @@ export function useElementWidth() {
     };
 
     updateWidth();
-    window.addEventListener('resize', updateWidth);
+    window.addEventListener("resize", updateWidth);
 
     return () => {
-      window.removeEventListener('resize', updateWidth);
+      window.removeEventListener("resize", updateWidth);
     };
   }, []);
 

--- a/packages/qmongjs/src/hooks/useElementWidth.ts
+++ b/packages/qmongjs/src/hooks/useElementWidth.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useElementWidth() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const updateWidth = () => {
+      if (ref.current) {
+        setWidth(ref.current.offsetWidth);
+      }
+    };
+
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+
+    return () => {
+      window.removeEventListener('resize', updateWidth);
+    };
+  }, []);
+
+  return { ref, width };
+}

--- a/packages/qmongjs/src/themes/SkdeTheme.tsx
+++ b/packages/qmongjs/src/themes/SkdeTheme.tsx
@@ -126,6 +126,7 @@ const colorTokens = {
     main: "#003087",
     light: "#e3ebf2",
     dark: "#001b52",
+    contrastText: "#ffff",
   },
 
   secondary: {


### PR DESCRIPTION
Før:
![image](https://github.com/user-attachments/assets/9a7e4ee9-d505-44a3-aa3c-c3542a98195e)

Etter:
![image](https://github.com/user-attachments/assets/42cef1f2-19d4-406c-a4eb-477904feafe2)

Hvis det er plass til begge knappene på samme linje, blir det slik:
![image](https://github.com/user-attachments/assets/5f5fcbfb-ef62-4e89-8cb9-5294b9bba339)


Basert på følgende Figma-skisse fra Ramsalt:
![image](https://github.com/user-attachments/assets/5d924b03-380f-4fde-89bb-7e83346d7d64)
