### PR TITLE
En divider og bruk av skip-property for context-valg

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Stack, styled, Typography } from "@mui/material";
+import { Divider, Stack, styled, Typography } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
@@ -154,6 +154,7 @@ export function ToggleButtonFilterSection({
           </StyledToggleButton>
         ))}
       </ToggleButtonGroup>
+      <Divider sx={{ mt: 1 }} />
     </div>
   );
 }

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -382,29 +382,26 @@ export function TreatmentQualityFilterMenu({
         onSelectionChanged={handleFilterChanged}
         onFilterInitialized={onFilterInitialized}
       >
-        {enableTableContextSection ? (
-          <ToggleButtonFilterSection
-            accordion={false}
-            noShadow={true}
-            filterkey={tableContextKey}
-            sectionid={tableContextKey}
-            testIdPrefix={testIdPrefix}
-            sectiontitle="Tabellkontekst"
-            options={tableContextOptions.values}
-            defaultvalues={[tableContextOptions.default]}
-            initialselections={[
-              {
-                value: selectedTableContext,
-                valueLabel:
-                  selectedTableContext === "resident"
-                    ? "Opptaksområder"
-                    : "Behandlingsenheter",
-              },
-            ]}
-          />
-        ) : (
-          <></>
-        )}
+        <ToggleButtonFilterSection
+          accordion={false}
+          noShadow={true}
+          skip={!enableTableContextSection}
+          filterkey={tableContextKey}
+          sectionid={tableContextKey}
+          testIdPrefix={testIdPrefix}
+          sectiontitle="Tabellkontekst"
+          options={tableContextOptions.values}
+          defaultvalues={[tableContextOptions.default]}
+          initialselections={[
+            {
+              value: selectedTableContext,
+              valueLabel:
+                selectedTableContext === "resident"
+                  ? "Opptaksområder"
+                  : "Behandlingsenheter",
+            },
+          ]}
+        />
         <SelectedFiltersSection
           accordion={false}
           noShadow={true}


### PR DESCRIPTION
Før 
![image](https://github.com/user-attachments/assets/535d1073-ac6a-446b-8c7c-793f6ddd77ed)


Etter
![image](https://github.com/user-attachments/assets/9ba7a5c0-4cf6-42d1-9dc5-9f58474fed71)
