### PR TITLE
Samstemte skrifttyper i filtermeny

### DIFF
--- a/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
@@ -11,8 +11,12 @@ import { FilterSettingsActionType } from "./FilterSettingsReducer";
 type SelectedFiltersSectionProps = FilterMenuSectionProps;
 
 const StyledChip = styled(Chip)(({ theme }) => ({
-  fontFamily: theme.typography.button.fontFamily,
-  padding: "1rem",
+  ...theme.typography.body2,
+  height: "2rem",
+  mr: 1,
+  mb: 1,
+  paddingLeft: 4,
+  paddingRight: 4,
 }));
 
 /**

--- a/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/SelectedFiltersSection.tsx
@@ -75,14 +75,20 @@ export function SelectedFiltersSection(props: SelectedFiltersSectionProps) {
           alignItems="baseline"
           sx={{ width: "100%", marginBottom: 2 }}
         >
-          <Typography variant="body2" color="primary">
+          <Typography
+            variant="body2"
+            color="primary"
+            sx={{
+              fontWeight: "600",
+            }}
+          >
             Valgte filtre
           </Typography>
           <Link
             type="button"
             variant="body2"
             onClick={() => handleReset(filterSettingsDispatch)}
-            sx={{ cursor: "pointer", fontWeight: "600" }}
+            sx={{ cursor: "pointer" }}
           >
             Tilbakestill
           </Link>

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Divider, Stack, styled, Typography } from "@mui/material";
+import { Box, Stack, styled, Typography } from "@mui/material";
 import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
@@ -58,7 +58,7 @@ export function ToggleButtonFilterSection({
   // Calculate the total width of all buttons
   const totalButtonWidth = options.reduce((total, option) => {
     // Estimate button width based on text length and average large sized chars (adjust multiplier as needed)
-    return total + option.valueLabel.length * 12.5 + 56; // 56px for padding, margins, and icon
+    return total + option.valueLabel.length * 10 + 56; // 56px for padding, margins, and icon
   }, 0);
 
   // Determine if vertical orientation is needed
@@ -91,7 +91,7 @@ export function ToggleButtonFilterSection({
   };
 
   return (
-    <div ref={ref}>
+    <Box ref={ref}>
       <ToggleButtonGroup
         exclusive
         value={selectedValue}
@@ -103,7 +103,6 @@ export function ToggleButtonFilterSection({
           ".MuiToggleButtonGroup-grouped": {
             borderRadius: 30,
             height: "2rem",
-            textTransform: "none",
             mr: useVerticalOrientation ? 0 : 1,
             mb: 1,
             pl: 1,
@@ -148,12 +147,11 @@ export function ToggleButtonFilterSection({
               ) : (
                 <RadioButtonUncheckedIcon fontSize="small" />
               )}
-              <Typography variant="subtitle2">{option.valueLabel}</Typography>
+              <Typography variant="body2">{option.valueLabel}</Typography>
             </Stack>
           </StyledToggleButton>
         ))}
       </ToggleButtonGroup>
-      <Divider sx={{ mt: 1 }} />
-    </div>
+    </Box>
   );
 }

--- a/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/ToggleButtonFilterSection.tsx
@@ -17,7 +17,6 @@ import { useElementWidth } from "../../hooks/useElementWidth";
 const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
   borderRadius: 30,
   height: "2rem",
-  fontSize: theme.typography.button.fontFamily,
   textTransform: "none",
   border: "1px solid #003087 !important",
   justifyContent: "flex-start",
@@ -58,8 +57,8 @@ export function ToggleButtonFilterSection({
 
   // Calculate the total width of all buttons
   const totalButtonWidth = options.reduce((total, option) => {
-    // Estimate button width based on text length (adjust multiplier as needed)
-    return total + option.valueLabel.length * 10 + 30; // 60px for padding and icons
+    // Estimate button width based on text length and average large sized chars (adjust multiplier as needed)
+    return total + option.valueLabel.length * 12.5 + 56; // 56px for padding, margins, and icon
   }, 0);
 
   // Determine if vertical orientation is needed
@@ -108,7 +107,7 @@ export function ToggleButtonFilterSection({
             mr: useVerticalOrientation ? 0 : 1,
             mb: 1,
             pl: 1,
-            pr: 1,
+            pr: 3,
             color: "primary.main",
             justifyContent: "flex-start",
             width: useVerticalOrientation ? "100%" : "auto",
@@ -149,7 +148,7 @@ export function ToggleButtonFilterSection({
               ) : (
                 <RadioButtonUncheckedIcon fontSize="small" />
               )}
-              <Typography variant="body2">{option.valueLabel}</Typography>
+              <Typography variant="subtitle2">{option.valueLabel}</Typography>
             </Stack>
           </StyledToggleButton>
         ))}

--- a/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
+++ b/packages/qmongjs/src/components/FilterMenu/TreatmentQualityFilterMenu/index.tsx
@@ -404,7 +404,7 @@ export function TreatmentQualityFilterMenu({
         />
         <SelectedFiltersSection
           accordion={false}
-          noShadow={true}
+          noShadow={false}
           filterkey="selectedfilters"
           sectionid="selectedfilters"
           sectiontitle="Valgte filtre"


### PR DESCRIPTION
Før:
![image](https://github.com/user-attachments/assets/6985ed09-140e-46b0-9dcd-5691763dbdaa)

Etter:
![image](https://github.com/user-attachments/assets/5e3c1454-095d-4cc1-9fec-fc9acd499474)
