### PR TITLE
Nytt API-endepunkt for stadiumvurdering

### DIFF
--- a/apps/api/src/controllers/data/index.ts
+++ b/apps/api/src/controllers/data/index.ts
@@ -3,3 +3,4 @@ export * from "./indicators";
 export * from "./unitNames";
 export * from "./selectionyears";
 export { dataController } from "./data";
+export { registryRankController } from "./registryRank";

--- a/apps/api/src/controllers/data/registryRank.ts
+++ b/apps/api/src/controllers/data/registryRank.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from "express";
+import { registryRankModel } from "../../models/data";
+import { parseQuery } from "./indicators";
+
+export const registryRankController: RequestHandler = async (req, res) => {
+  const query = parseQuery(req);
+
+  try {
+    const rows = await registryRankModel(query.filter);
+    res.json(rows);
+  } catch (error) {
+    const error_message =
+      error instanceof Error ? error.message : String(error);
+    res.status(500).json({ message: error_message });
+  }
+};

--- a/apps/api/src/models/data/index.ts
+++ b/apps/api/src/models/data/index.ts
@@ -2,6 +2,7 @@ export * from "./unitNames";
 export * from "./indicators";
 export * from "./description";
 export * from "./selectionyears";
+export { registryRankModel } from "./registryRank";
 export { aggData, indTable, regTable, medfieldTable } from "./nestedData";
 
 export interface Filter {

--- a/apps/api/src/models/data/registryRank.ts
+++ b/apps/api/src/models/data/registryRank.ts
@@ -1,0 +1,21 @@
+import db from "../../db";
+import { RegistryRank } from "types";
+import { Filter } from ".";
+
+export const registryRankModel = (filter?: Filter): Promise<RegistryRank[]> =>
+  db
+    .select(
+      "registry.id",
+      "registry.name",
+      "registry.full_name",
+      "registry.short_name",
+      "evaluation.verdict",
+      "evaluation.year",
+    )
+    .from("evaluation")
+    .modify((queryBuilder) => {
+      if (filter?.year) {
+        queryBuilder.where("evaluation.year", filter.year);
+      }
+    })
+    .leftJoin("registry", "evaluation.registry_id", "registry.id");

--- a/apps/api/src/models/data/registryRank.ts
+++ b/apps/api/src/models/data/registryRank.ts
@@ -9,6 +9,7 @@ export const registryRankModel = (filter?: Filter): Promise<RegistryRank[]> =>
       "registry.name",
       "registry.full_name",
       "registry.short_name",
+      "registry.url",
       "evaluation.verdict",
       "evaluation.year",
     )

--- a/apps/api/src/routes/data.ts
+++ b/apps/api/src/routes/data.ts
@@ -5,6 +5,7 @@ import {
   unitNamesContoller,
   selectionYearsContoller,
   dataController,
+  registryRankController,
 } from "../controllers/data";
 
 const Router = express.Router();
@@ -22,5 +23,8 @@ Router.get("/:register/years", selectionYearsContoller);
 
 // Nested data output
 Router.get("/:register/nestedData", dataController);
+
+// Registry rank output
+Router.get("/registryRank", registryRankController);
 
 export default Router;

--- a/packages/qmongjs/src/helpers/hooks/apihooks.ts
+++ b/packages/qmongjs/src/helpers/hooks/apihooks.ts
@@ -217,3 +217,25 @@ export const useMedicalFieldsQuery = () => {
     gcTime: 1000 * 60 * 60,
   });
 };
+
+const fetchRegistryRanks = async (year?: number) => {
+  const yearQuery: string = year ? `year=${year}&` : "";
+
+  const response = await fetch(`${API_HOST}/data/registryRank?${yearQuery}`);
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  return await response.json();
+};
+
+export const useRegistryRankQuery = (year?: number) => {
+  return useQuery({
+    queryKey: ["registryRank", year],
+    queryFn: () => fetchRegistryRanks(year),
+    staleTime: 1000 * 60 * 60,
+    refetchOnWindowFocus: false,
+    gcTime: 1000 * 60 * 60,
+  });
+};

--- a/packages/qmongjs/src/helpers/hooks/index.ts
+++ b/packages/qmongjs/src/helpers/hooks/index.ts
@@ -9,6 +9,7 @@ export {
   useRegisterNamesQuery,
   useMedicalFieldsQuery,
   useUnitUrlsQuery,
+  useRegistryRankQuery,
   type FetchIndicatorParams,
 } from "./apihooks";
 export {

--- a/packages/qmongjs/src/index.tsx
+++ b/packages/qmongjs/src/index.tsx
@@ -6,6 +6,7 @@ export {
   useIndicatorQuery,
   useMedicalFieldsQuery,
   useUnitUrlsQuery,
+  useRegistryRankQuery,
 } from "./helpers/hooks";
 export { API_HOST } from "./components/RegisterPage";
 export { Layout } from "./components/Layout";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -154,3 +154,12 @@ export type URLs = {
   shortName: string;
   url: string;
 };
+
+export type RegistryRank = {
+  id: number;
+  name: string;
+  full_name: string;
+  short_name: string;
+  verdict: string;
+  year: number;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -160,6 +160,7 @@ export type RegistryRank = {
   name: string;
   full_name: string;
   short_name: string;
+  url: string;
   verdict: string;
   year: number;
 };


### PR DESCRIPTION
For å teste: http://localhost:4000/data/registryRank?year=2022

Uten `year`-parameteren får man vurderingene for alle år. 