### PR TITLE
Bruk Collapse i ny tabell

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
@@ -260,11 +260,7 @@ const IndicatorRow = (props: {
             <tbody>
               <tr>
                 <td>
-                  <IconButton
-                    onClick={onClick}
-                    aria-label="expand"
-                    size="small"
-                  >
+                  <IconButton aria-label="expand" size="small">
                     {open ? <KeyboardArrowUp /> : <KeyboardArrowDown />}
                   </IconButton>
                 </td>

--- a/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
@@ -13,7 +13,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { PluggableList } from "react-markdown/lib";
 import { useScreenSize } from "@visx/responsive";
-import { Skeleton } from "@mui/material";
+import { Skeleton, Collapse } from "@mui/material";
 import {
   StyledTable,
   StyledTableRow,
@@ -324,71 +324,69 @@ const IndicatorRow = (props: {
         })}
       </StyledTableRow>
 
-      <TableRow
-        key={indData.indicatorID + "-collapse"}
-        sx={{ visibility: open ? "visible" : "collapse" }}
+      <StyledTableCell
+        style={{ paddingBottom: 0, paddingTop: 0 }}
+        colSpan={unitNames.length + 1}
       >
-        <StyledTableCell key={indData.indicatorID + "-shortDescription"}>
-          {indData.shortDescription}
-        </StyledTableCell>
-        <StyledTableCell
-          key={indData.indicatorTitle + "-targetLevel"}
-          colSpan={unitNames.length}
-          align="center"
-          style={{ backgroundColor: "#E0E7EB" }}
-        >
-          {"Ønsket målnivå: " +
-            (indData.levelGreen === null
-              ? ""
-              : customFormat(",.0%")(indData.levelGreen))}
-        </StyledTableCell>
-      </TableRow>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <TableRow key={indData.indicatorID + "-collapse"}>
+            <StyledTableCell key={indData.indicatorID + "-shortDescription"}>
+              {indData.shortDescription}
+            </StyledTableCell>
+            <StyledTableCell
+              key={indData.indicatorTitle + "-targetLevel"}
+              colSpan={unitNames.length}
+              align="center"
+              style={{ backgroundColor: "#E0E7EB" }}
+            >
+              {"Ønsket målnivå: " +
+                (indData.levelGreen === null
+                  ? ""
+                  : customFormat(",.0%")(indData.levelGreen))}
+            </StyledTableCell>
+          </TableRow>
 
-      <TableRow
-        key={indData.indicatorID + "-charts"}
-        sx={{ visibility: open ? "visible" : "collapse" }}
-      >
-        <StyledTableCell
-          key={indData.indicatorID + "-charts"}
-          colSpan={unitNames.length + 1}
-          align="center"
-        >
-          {responsiveChart}
-        </StyledTableCell>
-      </TableRow>
+          <TableRow key={indData.indicatorID + "-charts"}>
+            <StyledTableCell
+              key={indData.indicatorID + "-charts"}
+              colSpan={unitNames.length + 1}
+              align="center"
+            >
+              {responsiveChart}
+            </StyledTableCell>
+          </TableRow>
 
-      <StyledTableRow
-        key={indData.indicatorTitle + "-description"}
-        sx={{ visibility: open ? "visible" : "collapse" }}
-      >
-        <StyledTableCell
-          key={indData.indicatorTitle + "-decription"}
-          colSpan={unitNames.length + 1}
-        >
-          <ReactMarkdown
-            remarkPlugins={remarkPlugins}
-            components={{
-              p({ children }) {
-                return <p style={{ margin: 0 }}>{children}</p>;
-              },
-              a({ href, children }) {
-                return (
-                  <a
-                    href={href}
-                    target={href?.startsWith("#") ? "_self" : "_blank"}
-                    rel="noreferrer"
-                    style={{ color: "#006492" }}
-                  >
-                    {children}
-                  </a>
-                );
-              },
-            }}
-          >
-            {indData.longDescription}
-          </ReactMarkdown>
-        </StyledTableCell>
-      </StyledTableRow>
+          <StyledTableRow key={indData.indicatorTitle + "-description"}>
+            <StyledTableCell
+              key={indData.indicatorTitle + "-decription"}
+              colSpan={unitNames.length + 1}
+            >
+              <ReactMarkdown
+                remarkPlugins={remarkPlugins}
+                components={{
+                  p({ children }) {
+                    return <p style={{ margin: 0 }}>{children}</p>;
+                  },
+                  a({ href, children }) {
+                    return (
+                      <a
+                        href={href}
+                        target={href?.startsWith("#") ? "_self" : "_blank"}
+                        rel="noreferrer"
+                        style={{ color: "#006492" }}
+                      >
+                        {children}
+                      </a>
+                    );
+                  },
+                }}
+              >
+                {indData.longDescription}
+              </ReactMarkdown>
+            </StyledTableCell>
+          </StyledTableRow>
+        </Collapse>
+      </StyledTableCell>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
Bruk MUI sin `Collapse`-komponent for å gjøre rader ekspanderbare istedenfor å sette `visibility` slik at ikke alt skjult innhold må rendres. 