### PR TITLE
Lagt til statisk generering av sider på stadiumvurdering/[register]

### DIFF
--- a/apps/skde/pages/behandlingskvalitet/[registry].tsx
+++ b/apps/skde/pages/behandlingskvalitet/[registry].tsx
@@ -369,9 +369,9 @@ export default function TreatmentQualityRegistryPage({ registryInfo }) {
 }
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  const registries = await fetchRegisterNames();
+  const registries: RegisterName[] = await fetchRegisterNames();
 
-  const registryInfo: RegisterName = registries.filter(
+  const registryInfo = registries.filter(
     (register) => register.rname === context.params?.registry,
   );
 

--- a/apps/skde/pages/stadiumvurdering/[registry].tsx
+++ b/apps/skde/pages/stadiumvurdering/[registry].tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import { GetStaticProps, GetStaticPaths } from "next";
 import {
   LinechartBase,
   LinechartData,
@@ -11,6 +12,8 @@ import { useRegistryRankQuery } from "qmongjs";
 import { RegistryRank } from "types";
 import { Stack, Typography } from "@mui/material";
 import { FaCircle } from "react-icons/fa";
+import { fetchRegisterNames } from "qmongjs";
+import { RegisterName } from "types";
 
 const levelAColour = "#58A55C";
 const levelBColour = "#FD9C00";
@@ -107,6 +110,28 @@ const Stadiumfigur = () => {
       <LinechartBase {...linechartProps} />
     </div>
   );
+};
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const registries = (await fetchRegisterNames()) as RegisterName[];
+
+  const registryInfo = registries.filter(
+    (register: RegisterName) => register.rname === context.params?.registry,
+  );
+
+  return {
+    props: { registryInfo: registryInfo },
+  };
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const registries: RegisterName[] = await fetchRegisterNames();
+
+  const paths = registries.flatMap((registry: RegisterName) => {
+    return [{ params: { registry: registry.rname } }];
+  });
+
+  return { paths, fallback: false };
 };
 
 export default Stadiumfigur;

--- a/apps/skde/pages/stadiumvurdering/[registry].tsx
+++ b/apps/skde/pages/stadiumvurdering/[registry].tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import { GetStaticProps, GetStaticPaths } from "next";
 import {
   LinechartBase,
@@ -20,10 +19,7 @@ const levelBColour = "#FD9C00";
 const levelCColour = "#D85140";
 const noLevelColour = "#777777";
 
-const Stadiumfigur = () => {
-  const router = useRouter();
-  const { registry } = router.query;
-
+const Stadiumfigur = ({ registry }) => {
   const rankQuery = useRegistryRankQuery();
 
   if (rankQuery.isFetching) {
@@ -113,14 +109,14 @@ const Stadiumfigur = () => {
 };
 
 export const getStaticProps: GetStaticProps = async (context) => {
-  const registries = (await fetchRegisterNames()) as RegisterName[];
+  const registries: RegisterName[] = await fetchRegisterNames();
 
-  const registryInfo = registries.filter(
-    (register: RegisterName) => register.rname === context.params?.registry,
+  const filteredRegistries = registries.filter(
+    (register) => register.rname === context.params?.registry,
   );
 
   return {
-    props: { registryInfo: registryInfo },
+    props: { registry: filteredRegistries[0].rname },
   };
 };
 


### PR DESCRIPTION
- Bruk `GetStaticPaths` istedenfor `useRouter`
- Rettet opp i typefeil i behandlingskvalitet