### PR TITLE
til toppen

### DIFF
--- a/apps/skde/src/components/TreatmentQuality/TreatmentQualityToolbar.tsx
+++ b/apps/skde/src/components/TreatmentQuality/TreatmentQualityToolbar.tsx
@@ -1,5 +1,5 @@
-import { Button, Toolbar, styled } from "@mui/material";
-import { TuneRounded } from "@mui/icons-material";
+import { Button, Toolbar, Tooltip, styled } from "@mui/material";
+import { TuneRounded, KeyboardArrowUpRounded } from "@mui/icons-material";
 import { useMediaQuery } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import Grid from "@mui/material/Grid2";
@@ -13,30 +13,62 @@ type StickyToolbarProps = {
   openDrawer: () => void;
 };
 
+const scrollToTop = () => {
+  if (window) {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }
+};
+
 export const TreatmentQualityToolbar = ({ openDrawer }: StickyToolbarProps) => {
   const theme = useTheme();
   const notLargeScreen = useMediaQuery(theme.breakpoints.down("xxl"));
 
   return (
     <StyledToolbar className="main-toolbar">
-      <Grid container spacing={2} columns={{ xs: 4, sm: 8, md: 12 }}>
-        {notLargeScreen ? (
-          <Grid size={{ xs: 1, sm: 1, md: 2 }} sx={{ alignContent: "center" }}>
+      <Grid
+        container
+        spacing={2}
+        sx={{ flexGrow: 1 }}
+        justifyContent="space-between"
+      >
+        <Grid sx={{ xs: "auto" }}>
+          {notLargeScreen ? (
+            <Tooltip title="Åpne sidemeny">
+              <Button
+                variant="contained"
+                aria-label="Åpne sidemeny"
+                color="primary"
+                sx={{
+                  borderRadius: 4,
+                }}
+                onClick={() => {
+                  openDrawer();
+                }}
+              >
+                <TuneRounded fontSize="medium" />
+              </Button>
+            </Tooltip>
+          ) : (
+            <></>
+          )}
+        </Grid>
+        <Grid sx={{ xs: "auto" }}>
+          <Tooltip title="Til toppen">
             <Button
-              variant="contained"
-              aria-label="Åpne sidemeny"
+              variant="outlined"
+              aria-label="Til toppen"
               color="primary"
               sx={{
                 borderRadius: 4,
               }}
               onClick={() => {
-                openDrawer();
+                scrollToTop();
               }}
             >
-              <TuneRounded fontSize="medium" />
+              <KeyboardArrowUpRounded fontSize="medium" />
             </Button>
-          </Grid>
-        ) : null}
+          </Tooltip>
+        </Grid>
       </Grid>
     </StyledToolbar>
   );


### PR DESCRIPTION
Tabellen på siden for behandlingskvalitet er ofte lang og brukeren kan scrolle langt ned. For å gjøre det mer brukervennlig å komme tilbake til toppen, er det lagt inn en "til toppen"-knapp i toolbaren.

Før:

![image](https://github.com/user-attachments/assets/0e5e018b-90c7-4585-889d-b1d1467a921c)

Etter:

![image](https://github.com/user-attachments/assets/fa47610a-f3b9-45fd-8567-b85617c6377d)

