### PR TITLE
Bruk codecov-token

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,3 +40,5 @@ jobs:
       - name: Code coverage
         if: matrix.node-version == '20.x'
         uses: codecov/codecov-action@v4.6.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Code coverage dyttes ikke lenger opp til codecov uten token.