### PR TITLE
Dropp github-sjekk av codecoverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -22,5 +22,7 @@ coverage:
 
 comment: false
 
+github_checks: false
+
 ignore:
   - "apps/skde/public/"


### PR DESCRIPTION
Tester feilet veldig ofte, selv uten kodeendringer