### PR TITLE
Ikke krasj helseatlas-bygging hvis labels mangler i stolpediagram

### DIFF
--- a/apps/skde/src/charts/Barchart/AnnualVarLegend.tsx
+++ b/apps/skde/src/charts/Barchart/AnnualVarLegend.tsx
@@ -15,6 +15,7 @@ export const AnnualVarLegend = ({
   labels,
   values,
 }: AnnualVarLegendPops) => {
+  if (values.length != labels?.length) return null;
   return (
     <div className={classNames.legendContainer}>
       <ul className={classNames.legendUL}>

--- a/apps/skde/src/charts/Barchart/AnnualVariation.tsx
+++ b/apps/skde/src/charts/Barchart/AnnualVariation.tsx
@@ -30,6 +30,8 @@ export const AnnualVariation = function <
 }: AnnualVariaionProps<D, AnnualVar>) {
   const annualRates = annualVar.map((v) => Number(data[v]));
 
+  if (annualVar.length != labels?.length) return null;
+
   return (
     <>
       <Group top={yScale.bandwidth() / 2}>

--- a/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
+++ b/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
@@ -31363,6 +31363,5698 @@ exports[`Render with very little info 2 1`] = `
 </div>
 `;
 
+exports[`Render with wrong language 1`] = `
+<div>
+  <div
+    class="MuiBox-root css-sy0v5b"
+  >
+    <div
+      class="MuiBox-root css-9vv1l8"
+    >
+      <svg
+        height="100%"
+        style="display: block; margin: auto;"
+        viewBox="0 0 600 500"
+        width="100%"
+      >
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-left"
+            transform="translate(-10, 5)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="410.4545454545454"
+                y2="410.4545454545454"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="410.4545454545454"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Finnmark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="391.3636363636364"
+                y2="391.3636363636364"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="391.3636363636364"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    UNN
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="257.7272727272727"
+                y2="257.7272727272727"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="257.7272727272727"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nordland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="295.9090909090909"
+                y2="295.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="295.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Helgeland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="334.090909090909"
+                y2="334.090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="334.090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nord-Trøndelag
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="372.27272727272725"
+                y2="372.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="372.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    St. Olav
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="85.9090909090909"
+                y2="85.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="85.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Møre og Romsdal
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="315"
+                y2="315"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="315"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Førde
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="66.81818181818181"
+                y2="66.81818181818181"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="66.81818181818181"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Bergen
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="353.18181818181813"
+                y2="353.18181818181813"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="353.18181818181813"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Fonna
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="143.18181818181816"
+                y2="143.18181818181816"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="143.18181818181816"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Stavanger
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="200.45454545454544"
+                y2="200.45454545454544"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="200.45454545454544"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Østfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="105"
+                y2="105"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="105"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Akershus
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="47.72727272727272"
+                y2="47.72727272727272"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="47.72727272727272"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    OUS
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="9.545454545454543"
+                y2="9.545454545454543"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="9.545454545454543"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Lovisenberg
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="28.636363636363633"
+                y2="28.636363636363633"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="28.636363636363633"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Diakonhjemmet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="162.27272727272725"
+                y2="162.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="162.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Innlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="238.6363636363636"
+                y2="238.6363636363636"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="238.6363636363636"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestre Viken
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="276.81818181818176"
+                y2="276.81818181818176"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="276.81818181818176"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="181.36363636363635"
+                y2="181.36363636363635"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="181.36363636363635"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Telemark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="219.54545454545453"
+                y2="219.54545454545453"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="219.54545454545453"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Sørlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="124.09090909090908"
+                y2="124.09090909090908"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="124.09090909090908"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Norge
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="0"
+              x1="0"
+              x2="0"
+              y1="0.5"
+              y2="420.5"
+            />
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 450)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-bottom"
+            transform="translate(0, 0)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="0"
+                x2="0"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="0"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="0"
+                  >
+                    0
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="144.68909577335776"
+                x2="144.68909577335776"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="144.68909577335776"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="144.68909577335776"
+                  >
+                    2
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="289.3781915467155"
+                x2="289.3781915467155"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="289.3781915467155"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="289.3781915467155"
+                  >
+                    4
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="434.06728732007326"
+                x2="434.06728732007326"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="434.06728732007326"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="434.06728732007326"
+                  >
+                    6
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="2"
+              x1="0.5"
+              x2="440.5"
+              y1="0"
+              y2="0"
+            />
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group"
+            fill="rgba(171, 108, 166, 1)"
+            transform="translate(0, 0)"
+          >
+            <rect
+              data-testid="rect_Lovisenberg_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="53.88637861341164"
+              x="0"
+              y="1.9090909090909065"
+            />
+            <rect
+              data-testid="rect_Diakonhjemmet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="45.55075959056318"
+              x="0"
+              y="20.999999999999996"
+            />
+            <rect
+              data-testid="rect_OUS_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="42.39167818738664"
+              x="0"
+              y="40.090909090909086"
+            />
+            <rect
+              data-testid="rect_Bergen_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.66498408066309"
+              x="0"
+              y="59.18181818181817"
+            />
+            <rect
+              data-testid="rect_Møre og Romsdal_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.25252368386705"
+              x="0"
+              y="78.27272727272727"
+            />
+            <rect
+              data-testid="rect_Akershus_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="26.249899443712028"
+              x="0"
+              y="97.36363636363636"
+            />
+            <rect
+              data-testid="rect_Norge_unselected"
+              fill="rgba(120, 45, 135, 1)"
+              height="15.272727272727273"
+              style="cursor: auto;"
+              width="25.33977105055705"
+              x="0"
+              y="116.45454545454544"
+            />
+            <rect
+              data-testid="rect_Stavanger_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="25.147905290313133"
+              x="0"
+              y="135.54545454545453"
+            />
+            <rect
+              data-testid="rect_Innlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.919141485710277"
+              x="0"
+              y="154.63636363636363"
+            />
+            <rect
+              data-testid="rect_Telemark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.683957451183197"
+              x="0"
+              y="173.72727272727272"
+            />
+            <rect
+              data-testid="rect_Østfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.51129886368796"
+              x="0"
+              y="192.8181818181818"
+            />
+            <rect
+              data-testid="rect_Sørlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.171977686720357"
+              x="0"
+              y="211.9090909090909"
+            />
+            <rect
+              data-testid="rect_Vestre Viken_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.542395807756908"
+              x="0"
+              y="230.99999999999997"
+            />
+            <rect
+              data-testid="rect_Nordland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.52609640546548"
+              x="0"
+              y="250.09090909090907"
+            />
+            <rect
+              data-testid="rect_Vestfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="20.275598967832092"
+              x="0"
+              y="269.18181818181813"
+            />
+            <rect
+              data-testid="rect_Helgeland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="19.48576335726399"
+              x="0"
+              y="288.27272727272725"
+            />
+            <rect
+              data-testid="rect_Førde_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="18.538131251846266"
+              x="0"
+              y="307.3636363636364"
+            />
+            <rect
+              data-testid="rect_Nord-Trøndelag_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="17.164035278325816"
+              x="0"
+              y="326.4545454545454"
+            />
+            <rect
+              data-testid="rect_Fonna_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="16.138478812811613"
+              x="0"
+              y="345.5454545454545"
+            />
+            <rect
+              data-testid="rect_St. Olav_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="14.896882687991727"
+              x="0"
+              y="364.6363636363636"
+            />
+            <rect
+              data-testid="rect_UNN_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="10.38292330512385"
+              x="0"
+              y="383.72727272727275"
+            />
+            <rect
+              data-testid="rect_Finnmark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="9.707994226387914"
+              x="0"
+              y="402.81818181818176"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="351.2957685530132"
+              x2="356.0713773769473"
+              y1="402.81818181818176"
+              y2="402.81818181818176"
+            />
+            <circle
+              cx="356.0713773769473"
+              cy="402.81818181818176"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="352.10269830538425"
+              cy="402.81818181818176"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="351.2957685530132"
+              cy="402.81818181818176"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="390.7951156881125"
+              x2="411.1390173276863"
+              y1="383.72727272727275"
+              y2="383.72727272727275"
+            />
+            <circle
+              cx="405.3564919667915"
+              cy="383.72727272727275"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="411.1390173276863"
+              cy="383.72727272727275"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="390.7951156881125"
+              cy="383.72727272727275"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="403.73023544968225"
+              x2="414.3583777320276"
+              y1="250.09090909090907"
+              y2="250.09090909090907"
+            />
+            <circle
+              cx="403.73023544968225"
+              cy="250.09090909090907"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="413.00665736830683"
+              cy="250.09090909090907"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="414.3583777320276"
+              cy="250.09090909090907"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="364.04001231514627"
+              x2="382.3849439835189"
+              y1="288.27272727272725"
+              y2="288.27272727272725"
+            />
+            <circle
+              cx="364.04001231514627"
+              cy="288.27272727272725"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="382.3849439835189"
+              cy="288.27272727272725"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="366.2664712639036"
+              cy="288.27272727272725"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="409.25749904467784"
+              x2="440"
+              y1="326.4545454545454"
+              y2="326.4545454545454"
+            />
+            <circle
+              cx="409.25749904467784"
+              cy="326.4545454545454"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="439.7882430613164"
+              cy="326.4545454545454"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="440"
+              cy="326.4545454545454"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="364.91670572004097"
+              x2="390.4598806019625"
+              y1="364.6363636363636"
+              y2="364.6363636363636"
+            />
+            <circle
+              cx="364.91670572004097"
+              cy="364.6363636363636"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="390.4598806019625"
+              cy="364.6363636363636"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="373.7574240088265"
+              cy="364.6363636363636"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="387.036975130528"
+              x2="408.9317612060853"
+              y1="78.27272727272727"
+              y2="78.27272727272727"
+            />
+            <circle
+              cx="398.87471259185435"
+              cy="78.27272727272727"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="408.9317612060853"
+              cy="78.27272727272727"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.036975130528"
+              cy="78.27272727272727"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="375.1757913235593"
+              x2="388.3162228393601"
+              y1="307.3636363636364"
+              y2="307.3636363636364"
+            />
+            <circle
+              cx="375.1757913235593"
+              cy="307.3636363636364"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="388.3162228393601"
+              cy="307.3636363636364"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="386.5189200285001"
+              cy="307.3636363636364"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="350.7251962423942"
+              x2="374.0130130455444"
+              y1="59.18181818181817"
+              y2="59.18181818181817"
+            />
+            <circle
+              cx="350.7251962423942"
+              cy="59.18181818181817"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="374.0130130455444"
+              cy="59.18181818181817"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="358.654150081773"
+              cy="59.18181818181817"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="380.4412907552409"
+              x2="395.4684408682481"
+              y1="345.5454545454545"
+              y2="345.5454545454545"
+            />
+            <circle
+              cx="385.1081266619862"
+              cy="345.5454545454545"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="395.4684408682481"
+              cy="345.5454545454545"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="380.4412907552409"
+              cy="345.5454545454545"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="357.1243146226117"
+              x2="369.3457082875299"
+              y1="135.54545454545453"
+              y2="135.54545454545453"
+            />
+            <circle
+              cx="357.1243146226117"
+              cy="135.54545454545453"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="369.3457082875299"
+              cy="135.54545454545453"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="357.62994195643495"
+              cy="135.54545454545453"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="382.58970457864154"
+              x2="395.8339597974012"
+              y1="192.8181818181818"
+              y2="192.8181818181818"
+            />
+            <circle
+              cx="382.58970457864154"
+              cy="192.8181818181818"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="395.8339597974012"
+              cy="192.8181818181818"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="384.07891224691036"
+              cy="192.8181818181818"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="384.0174318997073"
+              x2="399.2846043627055"
+              y1="97.36363636363636"
+              y2="97.36363636363636"
+            />
+            <circle
+              cx="384.0174318997073"
+              cy="97.36363636363636"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.2846043627055"
+              cy="97.36363636363636"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.2100527636887"
+              cy="97.36363636363636"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="399.43756029962714"
+              x2="411.5021255382797"
+              y1="40.090909090909086"
+              y2="40.090909090909086"
+            />
+            <circle
+              cx="400.40008396991885"
+              cy="40.090909090909086"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="411.5021255382797"
+              cy="40.090909090909086"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.43756029962714"
+              cy="40.090909090909086"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="354.0138316574152"
+              x2="400.5833422997091"
+              y1="1.9090909090909065"
+              y2="1.9090909090909065"
+            />
+            <circle
+              cx="354.0138316574152"
+              cy="1.9090909090909065"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="379.9901496207168"
+              cy="1.9090909090909065"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="400.5833422997091"
+              cy="1.9090909090909065"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="334.20064090506696"
+              x2="341.28058224019003"
+              y1="20.999999999999996"
+              y2="20.999999999999996"
+            />
+            <circle
+              cx="338.0890933455619"
+              cy="20.999999999999996"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="334.20064090506696"
+              cy="20.999999999999996"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="341.28058224019003"
+              cy="20.999999999999996"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="422.4037807088546"
+              x2="430.3008756016476"
+              y1="154.63636363636363"
+              y2="154.63636363636363"
+            />
+            <circle
+              cx="425.245736770615"
+              cy="154.63636363636363"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="430.3008756016476"
+              cy="154.63636363636363"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="422.4037807088546"
+              cy="154.63636363636363"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="358.0143831750566"
+              x2="364.96319605554766"
+              y1="230.99999999999997"
+              y2="230.99999999999997"
+            />
+            <circle
+              cx="358.0143831750566"
+              cy="230.99999999999997"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="364.96319605554766"
+              cy="230.99999999999997"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="358.49821553967695"
+              cy="230.99999999999997"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="347.65648257679555"
+              x2="362.8292570349112"
+              y1="269.18181818181813"
+              y2="269.18181818181813"
+            />
+            <circle
+              cx="347.65648257679555"
+              cy="269.18181818181813"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="362.8292570349112"
+              cy="269.18181818181813"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="357.89199296226406"
+              cy="269.18181818181813"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="385.21180479686285"
+              x2="418.72093069864343"
+              y1="173.72727272727272"
+              y2="173.72727272727272"
+            />
+            <circle
+              cx="385.21180479686285"
+              cy="173.72727272727272"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="418.72093069864343"
+              cy="173.72727272727272"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.6506381137475"
+              cy="173.72727272727272"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="372.5191389513723"
+              x2="387.9117152608442"
+              y1="211.9090909090909"
+              y2="211.9090909090909"
+            />
+            <circle
+              cx="378.3651161930892"
+              cy="211.9090909090909"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.9117152608442"
+              cy="211.9090909090909"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="372.5191389513723"
+              cy="211.9090909090909"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="374.3620795758412"
+              x2="388.26238099341595"
+              y1="116.45454545454544"
+              y2="116.45454545454544"
+            />
+            <circle
+              cx="374.3620795758412"
+              cy="116.45454545454544"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="388.26238099341595"
+              cy="116.45454545454544"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="377.59851877213634"
+              cy="116.45454545454544"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div
+      class="_legendContainer_affb27"
+    >
+      <ul
+        class="_legendUL_affb27"
+      >
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(0, 0, 0)"
+                r="2"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2019
+        </li>
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(128, 128, 128)"
+                r="4.5"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2020
+        </li>
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(255, 255, 255)"
+                r="7"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2021
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render with wrong language 2`] = `
+<div>
+  <div
+    class="MuiBox-root css-sy0v5b"
+  >
+    <div
+      class="MuiBox-root css-9vv1l8"
+    >
+      <svg
+        height="100%"
+        style="display: block; margin: auto;"
+        viewBox="0 0 600 500"
+        width="100%"
+      >
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-left"
+            transform="translate(-10, 5)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="410.4545454545454"
+                y2="410.4545454545454"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="410.4545454545454"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Finnmark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="391.3636363636364"
+                y2="391.3636363636364"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="391.3636363636364"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    UNN
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="257.7272727272727"
+                y2="257.7272727272727"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="257.7272727272727"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nordland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="295.9090909090909"
+                y2="295.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="295.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Helgeland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="334.090909090909"
+                y2="334.090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="334.090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nord-Trøndelag
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="372.27272727272725"
+                y2="372.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="372.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    St. Olav
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="85.9090909090909"
+                y2="85.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="85.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Møre og Romsdal
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="315"
+                y2="315"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="315"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Førde
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="66.81818181818181"
+                y2="66.81818181818181"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="66.81818181818181"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Bergen
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="353.18181818181813"
+                y2="353.18181818181813"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="353.18181818181813"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Fonna
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="143.18181818181816"
+                y2="143.18181818181816"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="143.18181818181816"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Stavanger
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="200.45454545454544"
+                y2="200.45454545454544"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="200.45454545454544"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Østfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="105"
+                y2="105"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="105"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Akershus
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="47.72727272727272"
+                y2="47.72727272727272"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="47.72727272727272"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    OUS
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="9.545454545454543"
+                y2="9.545454545454543"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="9.545454545454543"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Lovisenberg
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="28.636363636363633"
+                y2="28.636363636363633"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="28.636363636363633"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Diakonhjemmet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="162.27272727272725"
+                y2="162.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="162.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Innlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="238.6363636363636"
+                y2="238.6363636363636"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="238.6363636363636"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestre Viken
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="276.81818181818176"
+                y2="276.81818181818176"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="276.81818181818176"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="181.36363636363635"
+                y2="181.36363636363635"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="181.36363636363635"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Telemark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="219.54545454545453"
+                y2="219.54545454545453"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="219.54545454545453"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Sørlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="124.09090909090908"
+                y2="124.09090909090908"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="124.09090909090908"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Norway
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="0"
+              x1="0"
+              x2="0"
+              y1="0.5"
+              y2="420.5"
+            />
+            <svg
+              font-size="14"
+              style="overflow: visible;"
+              x="0"
+              y="0"
+            >
+              <text
+                class="visx-axis-label"
+                fill=""
+                font-family=""
+                font-size="14"
+                font-weight="bold"
+                text-anchor="start"
+                transform=""
+                x="-127"
+                y="-15"
+              >
+                <tspan
+                  dy="0em"
+                  x="-127"
+                >
+                  qwerty
+                </tspan>
+              </text>
+            </svg>
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 450)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-bottom"
+            transform="translate(0, 0)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="0"
+                x2="0"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="0"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="0"
+                  >
+                    0
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="144.68909577335776"
+                x2="144.68909577335776"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="144.68909577335776"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="144.68909577335776"
+                  >
+                    2
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="289.3781915467155"
+                x2="289.3781915467155"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="289.3781915467155"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="289.3781915467155"
+                  >
+                    4
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="434.06728732007326"
+                x2="434.06728732007326"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="434.06728732007326"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="434.06728732007326"
+                  >
+                    6
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="2"
+              x1="0.5"
+              x2="440.5"
+              y1="0"
+              y2="0"
+            />
+            <svg
+              font-size="14"
+              style="overflow: visible;"
+              x="0"
+              y="0"
+            >
+              <text
+                class="visx-axis-label"
+                fill=""
+                font-family=""
+                font-size="14"
+                font-weight="bold"
+                text-anchor="middle"
+                x="220"
+                y="35"
+              >
+                <tspan
+                  dy="0em"
+                  x="220"
+                >
+                  qwerty
+                </tspan>
+              </text>
+            </svg>
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group"
+            fill="rgba(171, 108, 166, 1)"
+            transform="translate(0, 0)"
+          >
+            <rect
+              data-testid="rect_Lovisenberg_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="53.88637861341164"
+              x="0"
+              y="1.9090909090909065"
+            />
+            <rect
+              data-testid="rect_Diakonhjemmet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="45.55075959056318"
+              x="0"
+              y="20.999999999999996"
+            />
+            <rect
+              data-testid="rect_OUS_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="42.39167818738664"
+              x="0"
+              y="40.090909090909086"
+            />
+            <rect
+              data-testid="rect_Bergen_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.66498408066309"
+              x="0"
+              y="59.18181818181817"
+            />
+            <rect
+              data-testid="rect_Møre og Romsdal_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.25252368386705"
+              x="0"
+              y="78.27272727272727"
+            />
+            <rect
+              data-testid="rect_Akershus_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="26.249899443712028"
+              x="0"
+              y="97.36363636363636"
+            />
+            <rect
+              data-testid="rect_Norge_unselected"
+              fill="rgba(120, 45, 135, 1)"
+              height="15.272727272727273"
+              style="cursor: auto;"
+              width="25.33977105055705"
+              x="0"
+              y="116.45454545454544"
+            />
+            <rect
+              data-testid="rect_Stavanger_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="25.147905290313133"
+              x="0"
+              y="135.54545454545453"
+            />
+            <rect
+              data-testid="rect_Innlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.919141485710277"
+              x="0"
+              y="154.63636363636363"
+            />
+            <rect
+              data-testid="rect_Telemark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.683957451183197"
+              x="0"
+              y="173.72727272727272"
+            />
+            <rect
+              data-testid="rect_Østfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.51129886368796"
+              x="0"
+              y="192.8181818181818"
+            />
+            <rect
+              data-testid="rect_Sørlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.171977686720357"
+              x="0"
+              y="211.9090909090909"
+            />
+            <rect
+              data-testid="rect_Vestre Viken_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.542395807756908"
+              x="0"
+              y="230.99999999999997"
+            />
+            <rect
+              data-testid="rect_Nordland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.52609640546548"
+              x="0"
+              y="250.09090909090907"
+            />
+            <rect
+              data-testid="rect_Vestfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="20.275598967832092"
+              x="0"
+              y="269.18181818181813"
+            />
+            <rect
+              data-testid="rect_Helgeland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="19.48576335726399"
+              x="0"
+              y="288.27272727272725"
+            />
+            <rect
+              data-testid="rect_Førde_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="18.538131251846266"
+              x="0"
+              y="307.3636363636364"
+            />
+            <rect
+              data-testid="rect_Nord-Trøndelag_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="17.164035278325816"
+              x="0"
+              y="326.4545454545454"
+            />
+            <rect
+              data-testid="rect_Fonna_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="16.138478812811613"
+              x="0"
+              y="345.5454545454545"
+            />
+            <rect
+              data-testid="rect_St. Olav_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="14.896882687991727"
+              x="0"
+              y="364.6363636363636"
+            />
+            <rect
+              data-testid="rect_UNN_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="10.38292330512385"
+              x="0"
+              y="383.72727272727275"
+            />
+            <rect
+              data-testid="rect_Finnmark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="9.707994226387914"
+              x="0"
+              y="402.81818181818176"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="351.2957685530132"
+              x2="356.0713773769473"
+              y1="402.81818181818176"
+              y2="402.81818181818176"
+            />
+            <circle
+              cx="356.0713773769473"
+              cy="402.81818181818176"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="352.10269830538425"
+              cy="402.81818181818176"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="351.2957685530132"
+              cy="402.81818181818176"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="390.7951156881125"
+              x2="411.1390173276863"
+              y1="383.72727272727275"
+              y2="383.72727272727275"
+            />
+            <circle
+              cx="405.3564919667915"
+              cy="383.72727272727275"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="411.1390173276863"
+              cy="383.72727272727275"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="390.7951156881125"
+              cy="383.72727272727275"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="403.73023544968225"
+              x2="414.3583777320276"
+              y1="250.09090909090907"
+              y2="250.09090909090907"
+            />
+            <circle
+              cx="403.73023544968225"
+              cy="250.09090909090907"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="413.00665736830683"
+              cy="250.09090909090907"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="414.3583777320276"
+              cy="250.09090909090907"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="364.04001231514627"
+              x2="382.3849439835189"
+              y1="288.27272727272725"
+              y2="288.27272727272725"
+            />
+            <circle
+              cx="364.04001231514627"
+              cy="288.27272727272725"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="382.3849439835189"
+              cy="288.27272727272725"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="366.2664712639036"
+              cy="288.27272727272725"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="409.25749904467784"
+              x2="440"
+              y1="326.4545454545454"
+              y2="326.4545454545454"
+            />
+            <circle
+              cx="409.25749904467784"
+              cy="326.4545454545454"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="439.7882430613164"
+              cy="326.4545454545454"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="440"
+              cy="326.4545454545454"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="364.91670572004097"
+              x2="390.4598806019625"
+              y1="364.6363636363636"
+              y2="364.6363636363636"
+            />
+            <circle
+              cx="364.91670572004097"
+              cy="364.6363636363636"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="390.4598806019625"
+              cy="364.6363636363636"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="373.7574240088265"
+              cy="364.6363636363636"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="387.036975130528"
+              x2="408.9317612060853"
+              y1="78.27272727272727"
+              y2="78.27272727272727"
+            />
+            <circle
+              cx="398.87471259185435"
+              cy="78.27272727272727"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="408.9317612060853"
+              cy="78.27272727272727"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.036975130528"
+              cy="78.27272727272727"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="375.1757913235593"
+              x2="388.3162228393601"
+              y1="307.3636363636364"
+              y2="307.3636363636364"
+            />
+            <circle
+              cx="375.1757913235593"
+              cy="307.3636363636364"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="388.3162228393601"
+              cy="307.3636363636364"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="386.5189200285001"
+              cy="307.3636363636364"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="350.7251962423942"
+              x2="374.0130130455444"
+              y1="59.18181818181817"
+              y2="59.18181818181817"
+            />
+            <circle
+              cx="350.7251962423942"
+              cy="59.18181818181817"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="374.0130130455444"
+              cy="59.18181818181817"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="358.654150081773"
+              cy="59.18181818181817"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="380.4412907552409"
+              x2="395.4684408682481"
+              y1="345.5454545454545"
+              y2="345.5454545454545"
+            />
+            <circle
+              cx="385.1081266619862"
+              cy="345.5454545454545"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="395.4684408682481"
+              cy="345.5454545454545"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="380.4412907552409"
+              cy="345.5454545454545"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="357.1243146226117"
+              x2="369.3457082875299"
+              y1="135.54545454545453"
+              y2="135.54545454545453"
+            />
+            <circle
+              cx="357.1243146226117"
+              cy="135.54545454545453"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="369.3457082875299"
+              cy="135.54545454545453"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="357.62994195643495"
+              cy="135.54545454545453"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="382.58970457864154"
+              x2="395.8339597974012"
+              y1="192.8181818181818"
+              y2="192.8181818181818"
+            />
+            <circle
+              cx="382.58970457864154"
+              cy="192.8181818181818"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="395.8339597974012"
+              cy="192.8181818181818"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="384.07891224691036"
+              cy="192.8181818181818"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="384.0174318997073"
+              x2="399.2846043627055"
+              y1="97.36363636363636"
+              y2="97.36363636363636"
+            />
+            <circle
+              cx="384.0174318997073"
+              cy="97.36363636363636"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.2846043627055"
+              cy="97.36363636363636"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.2100527636887"
+              cy="97.36363636363636"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="399.43756029962714"
+              x2="411.5021255382797"
+              y1="40.090909090909086"
+              y2="40.090909090909086"
+            />
+            <circle
+              cx="400.40008396991885"
+              cy="40.090909090909086"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="411.5021255382797"
+              cy="40.090909090909086"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.43756029962714"
+              cy="40.090909090909086"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="354.0138316574152"
+              x2="400.5833422997091"
+              y1="1.9090909090909065"
+              y2="1.9090909090909065"
+            />
+            <circle
+              cx="354.0138316574152"
+              cy="1.9090909090909065"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="379.9901496207168"
+              cy="1.9090909090909065"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="400.5833422997091"
+              cy="1.9090909090909065"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="334.20064090506696"
+              x2="341.28058224019003"
+              y1="20.999999999999996"
+              y2="20.999999999999996"
+            />
+            <circle
+              cx="338.0890933455619"
+              cy="20.999999999999996"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="334.20064090506696"
+              cy="20.999999999999996"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="341.28058224019003"
+              cy="20.999999999999996"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="422.4037807088546"
+              x2="430.3008756016476"
+              y1="154.63636363636363"
+              y2="154.63636363636363"
+            />
+            <circle
+              cx="425.245736770615"
+              cy="154.63636363636363"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="430.3008756016476"
+              cy="154.63636363636363"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="422.4037807088546"
+              cy="154.63636363636363"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="358.0143831750566"
+              x2="364.96319605554766"
+              y1="230.99999999999997"
+              y2="230.99999999999997"
+            />
+            <circle
+              cx="358.0143831750566"
+              cy="230.99999999999997"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="364.96319605554766"
+              cy="230.99999999999997"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="358.49821553967695"
+              cy="230.99999999999997"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="347.65648257679555"
+              x2="362.8292570349112"
+              y1="269.18181818181813"
+              y2="269.18181818181813"
+            />
+            <circle
+              cx="347.65648257679555"
+              cy="269.18181818181813"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="362.8292570349112"
+              cy="269.18181818181813"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="357.89199296226406"
+              cy="269.18181818181813"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="385.21180479686285"
+              x2="418.72093069864343"
+              y1="173.72727272727272"
+              y2="173.72727272727272"
+            />
+            <circle
+              cx="385.21180479686285"
+              cy="173.72727272727272"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="418.72093069864343"
+              cy="173.72727272727272"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="399.6506381137475"
+              cy="173.72727272727272"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="372.5191389513723"
+              x2="387.9117152608442"
+              y1="211.9090909090909"
+              y2="211.9090909090909"
+            />
+            <circle
+              cx="378.3651161930892"
+              cy="211.9090909090909"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="387.9117152608442"
+              cy="211.9090909090909"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="372.5191389513723"
+              cy="211.9090909090909"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+          <g
+            class="visx-group"
+            transform="translate(0, 7.636363636363637)"
+          >
+            <line
+              stroke="black"
+              stroke-width="2"
+              x1="374.3620795758412"
+              x2="388.26238099341595"
+              y1="116.45454545454544"
+              y2="116.45454545454544"
+            />
+            <circle
+              cx="374.3620795758412"
+              cy="116.45454545454544"
+              fill="none"
+              r="7"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="388.26238099341595"
+              cy="116.45454545454544"
+              fill="rgb(128, 128, 128)"
+              r="4.5"
+              stroke="black"
+              stroke-width="1"
+            />
+            <circle
+              cx="377.59851877213634"
+              cy="116.45454545454544"
+              fill="rgb(0, 0, 0)"
+              r="2"
+              stroke="black"
+              stroke-width="1"
+            />
+          </g>
+        </g>
+      </svg>
+    </div>
+    <div
+      class="_legendContainer_affb27"
+    >
+      <ul
+        class="_legendUL_affb27"
+      >
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(0, 0, 0)"
+                r="2"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2019
+        </li>
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(128, 128, 128)"
+                r="4.5"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2020
+        </li>
+        <li
+          class="_legendLI_affb27"
+        >
+          <div
+            class="_legendAnnualVar_affb27"
+          >
+            <svg
+              height="20px"
+              width="20px"
+            >
+              <circle
+                cx="10"
+                cy="10"
+                fill="rgb(255, 255, 255)"
+                r="7"
+                stroke="black"
+                stroke-width="1"
+              />
+            </svg>
+          </div>
+          2021
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Render with wrong language 3`] = `
+<div>
+  <div
+    class="MuiBox-root css-sy0v5b"
+  >
+    <div
+      class="MuiBox-root css-9vv1l8"
+    >
+      <svg
+        height="100%"
+        style="display: block; margin: auto;"
+        viewBox="0 0 600 500"
+        width="100%"
+      >
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-left"
+            transform="translate(-10, 5)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="410.4545454545454"
+                y2="410.4545454545454"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="410.4545454545454"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Finnmark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="391.3636363636364"
+                y2="391.3636363636364"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="391.3636363636364"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    UNN
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="257.7272727272727"
+                y2="257.7272727272727"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="257.7272727272727"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nordland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="295.9090909090909"
+                y2="295.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="295.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Helgeland
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="334.090909090909"
+                y2="334.090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="334.090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Nord-Trøndelag
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="372.27272727272725"
+                y2="372.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="372.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    St. Olav
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="85.9090909090909"
+                y2="85.9090909090909"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="85.9090909090909"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Møre og Romsdal
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="315"
+                y2="315"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="315"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Førde
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="66.81818181818181"
+                y2="66.81818181818181"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="66.81818181818181"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Bergen
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="353.18181818181813"
+                y2="353.18181818181813"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="353.18181818181813"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Fonna
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="143.18181818181816"
+                y2="143.18181818181816"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="143.18181818181816"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Stavanger
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="200.45454545454544"
+                y2="200.45454545454544"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="200.45454545454544"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Østfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="105"
+                y2="105"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="105"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Akershus
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="47.72727272727272"
+                y2="47.72727272727272"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="47.72727272727272"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    OUS
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="9.545454545454543"
+                y2="9.545454545454543"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="9.545454545454543"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Lovisenberg
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="28.636363636363633"
+                y2="28.636363636363633"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="28.636363636363633"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Diakonhjemmet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="162.27272727272725"
+                y2="162.27272727272725"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="162.27272727272725"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Innlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="238.6363636363636"
+                y2="238.6363636363636"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="238.6363636363636"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestre Viken
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="276.81818181818176"
+                y2="276.81818181818176"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="276.81818181818176"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Vestfold
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="181.36363636363635"
+                y2="181.36363636363635"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="181.36363636363635"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Telemark
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="219.54545454545453"
+                y2="219.54545454545453"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="219.54545454545453"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Sørlandet
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0, 0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="white"
+                stroke-linecap="square"
+                stroke-width="0"
+                x1="0"
+                x2="-8"
+                y1="124.09090909090908"
+                y2="124.09090909090908"
+              />
+              <svg
+                font-size="14"
+                style="overflow: visible;"
+                x="0"
+                y="0"
+              >
+                <text
+                  fill="black"
+                  font-size="14"
+                  text-anchor="end"
+                  transform=""
+                  x="-8"
+                  y="124.09090909090908"
+                >
+                  <tspan
+                    dy="0em"
+                    x="-8"
+                  >
+                    Norge
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="0"
+              x1="0"
+              x2="0"
+              y1="0.5"
+              y2="420.5"
+            />
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 450)"
+        >
+          <g
+            class="visx-group visx-axis visx-axis-bottom"
+            transform="translate(0, 0)"
+          >
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="0"
+                x2="0"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="0"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="0"
+                  >
+                    0
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="144.68909577335776"
+                x2="144.68909577335776"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="144.68909577335776"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="144.68909577335776"
+                  >
+                    2
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="289.3781915467155"
+                x2="289.3781915467155"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="289.3781915467155"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="289.3781915467155"
+                  >
+                    4
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <g
+              class="visx-group visx-axis-tick"
+              transform="translate(0,0)"
+            >
+              <line
+                class="visx-line"
+                fill="transparent"
+                shape-rendering="crispEdges"
+                stroke="black"
+                stroke-linecap="square"
+                stroke-width="2"
+                x1="434.06728732007326"
+                x2="434.06728732007326"
+                y1="0"
+                y2="3"
+              />
+              <svg
+                font-size="10"
+                style="overflow: visible;"
+                x="0"
+                y="0.25em"
+              >
+                <text
+                  fill="#222"
+                  font-family="Arial"
+                  font-size="10"
+                  text-anchor="middle"
+                  transform=""
+                  x="434.06728732007326"
+                  y="13"
+                >
+                  <tspan
+                    dy="0em"
+                    x="434.06728732007326"
+                  >
+                    6
+                  </tspan>
+                </text>
+              </svg>
+            </g>
+            <line
+              class="visx-line visx-axis-line"
+              fill="transparent"
+              shape-rendering="crispEdges"
+              stroke="black"
+              stroke-width="2"
+              x1="0.5"
+              x2="440.5"
+              y1="0"
+              y2="0"
+            />
+          </g>
+        </g>
+        <g
+          class="visx-group"
+          transform="translate(140, 30)"
+        >
+          <g
+            class="visx-group"
+            fill="rgba(171, 108, 166, 1)"
+            transform="translate(0, 0)"
+          >
+            <rect
+              data-testid="rect_Lovisenberg_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="53.88637861341164"
+              x="0"
+              y="1.9090909090909065"
+            />
+            <rect
+              data-testid="rect_Diakonhjemmet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="45.55075959056318"
+              x="0"
+              y="20.999999999999996"
+            />
+            <rect
+              data-testid="rect_OUS_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="42.39167818738664"
+              x="0"
+              y="40.090909090909086"
+            />
+            <rect
+              data-testid="rect_Bergen_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.66498408066309"
+              x="0"
+              y="59.18181818181817"
+            />
+            <rect
+              data-testid="rect_Møre og Romsdal_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="32.25252368386705"
+              x="0"
+              y="78.27272727272727"
+            />
+            <rect
+              data-testid="rect_Akershus_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="26.249899443712028"
+              x="0"
+              y="97.36363636363636"
+            />
+            <rect
+              data-testid="rect_Norge_unselected"
+              fill="rgba(120, 45, 135, 1)"
+              height="15.272727272727273"
+              style="cursor: auto;"
+              width="25.33977105055705"
+              x="0"
+              y="116.45454545454544"
+            />
+            <rect
+              data-testid="rect_Stavanger_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="25.147905290313133"
+              x="0"
+              y="135.54545454545453"
+            />
+            <rect
+              data-testid="rect_Innlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.919141485710277"
+              x="0"
+              y="154.63636363636363"
+            />
+            <rect
+              data-testid="rect_Telemark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.683957451183197"
+              x="0"
+              y="173.72727272727272"
+            />
+            <rect
+              data-testid="rect_Østfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.51129886368796"
+              x="0"
+              y="192.8181818181818"
+            />
+            <rect
+              data-testid="rect_Sørlandet_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="24.171977686720357"
+              x="0"
+              y="211.9090909090909"
+            />
+            <rect
+              data-testid="rect_Vestre Viken_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.542395807756908"
+              x="0"
+              y="230.99999999999997"
+            />
+            <rect
+              data-testid="rect_Nordland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="23.52609640546548"
+              x="0"
+              y="250.09090909090907"
+            />
+            <rect
+              data-testid="rect_Vestfold_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="20.275598967832092"
+              x="0"
+              y="269.18181818181813"
+            />
+            <rect
+              data-testid="rect_Helgeland_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="19.48576335726399"
+              x="0"
+              y="288.27272727272725"
+            />
+            <rect
+              data-testid="rect_Førde_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="18.538131251846266"
+              x="0"
+              y="307.3636363636364"
+            />
+            <rect
+              data-testid="rect_Nord-Trøndelag_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="17.164035278325816"
+              x="0"
+              y="326.4545454545454"
+            />
+            <rect
+              data-testid="rect_Fonna_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="16.138478812811613"
+              x="0"
+              y="345.5454545454545"
+            />
+            <rect
+              data-testid="rect_St. Olav_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="14.896882687991727"
+              x="0"
+              y="364.6363636363636"
+            />
+            <rect
+              data-testid="rect_UNN_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="10.38292330512385"
+              x="0"
+              y="383.72727272727275"
+            />
+            <rect
+              data-testid="rect_Finnmark_unselected"
+              fill="rgba(171, 108, 166, 1)"
+              height="15.272727272727273"
+              style="cursor: pointer;"
+              width="9.707994226387914"
+              x="0"
+              y="402.81818181818176"
+            />
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Standard render 1`] = `
 <div>
   <div

--- a/apps/skde/src/charts/Barchart/__tests__/barchart.test.tsx
+++ b/apps/skde/src/charts/Barchart/__tests__/barchart.test.tsx
@@ -8,6 +8,7 @@
 
 import { render, fireEvent } from "@testing-library/react";
 import mockRouter from "next-router-mock";
+import { vi, test, expect } from "vitest";
 
 import { Barchart } from "..";
 import { atlasData } from "../../../../test/test_data/data";
@@ -319,4 +320,62 @@ test("Render with error bars outside bars", async () => {
     />,
   );
   expect(container).toMatchSnapshot();
+});
+
+test("Render with wrong language", async () => {
+  const barchartinfo = {
+    type: "barchart",
+    data: "qwerty",
+    x: ["spes_rate"],
+    y: "bohf",
+    yLabel: { en: "qwerty", nn: "Referral areas" },
+    xLabel: { en: "qwerty", nn: "Referral areas" },
+    annualVar: ["rate2019", "rate2020", "rate2021"],
+    annualVarLabels: {
+      en: ["2019", "2020", "2021"],
+    },
+  };
+  mockRouter.push("");
+  const { container: cont1 } = render(
+    <Barchart
+      {...barchartinfo}
+      data={atlasData}
+      lang="nb"
+      national="Norge"
+      format=",.0f"
+    />,
+  );
+  expect(cont1).toMatchSnapshot();
+
+  const { container: cont2 } = render(
+    <Barchart
+      {...barchartinfo}
+      data={atlasData}
+      lang="en"
+      national="Norge"
+      format=",.0f"
+    />,
+  );
+  expect(cont2).toMatchSnapshot();
+
+  /** Missing labels */
+  const barchartinfo2 = {
+    type: "barchart",
+    data: "qwerty",
+    x: ["spes_rate"],
+    y: "bohf",
+    yLabel: { en: "qwerty", nn: "Referral areas" },
+    xLabel: { en: "qwerty", nn: "Referral areas" },
+    annualVar: ["rate2019", "rate2020", "rate2021"],
+  };
+  const { container: cont3 } = render(
+    <Barchart
+      {...barchartinfo2}
+      data={atlasData}
+      lang="nb"
+      national="Norge"
+      format=",.0f"
+    />,
+  );
+  expect(cont3).toMatchSnapshot();
 });

--- a/apps/skde/src/charts/Barchart/index.tsx
+++ b/apps/skde/src/charts/Barchart/index.tsx
@@ -112,13 +112,14 @@ export const Barchart = <
   format,
   national,
 }: BarchartProps<Data, X, Y, AnnualVar, ErrorBar>) => {
-  //missing
-  //tooltip
-  //animation
   const innerHeight = height - margin.top - margin.bottom;
   const innerWidth = width - margin.left - margin.right;
 
-  const varLabels = annualVarLabels ? annualVarLabels[lang] : undefined;
+  const varLabels = annualVarLabels
+    ? annualVarLabels[lang]
+      ? annualVarLabels[lang]
+      : annualVarLabels["en"]
+    : undefined;
 
   const sorted = [...data].sort((first, second) => {
     const firstVal = sum(x.map((xVal) => parseFloat(first[xVal])));


### PR DESCRIPTION
Feil skjedde egentlig fordi atlas var satt til `nb` og labels var satt til `nn`. Nå velger den engelsk labels hvis språk-spesifikk labels ikke finnes. Den bygger også hvis labels mangler, og da vises ikke prikkene heller.