### PR TITLE
Fikset bug i behandlingkvalitet angående bredde

### DIFF
--- a/apps/skde/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
+++ b/apps/skde/src/components/Footer/__tests__/__snapshots__/footer.test.tsx.snap
@@ -153,53 +153,52 @@ exports[`Footer component > renders with className prop set to a custom class na
           style="background: rgb(26, 26, 26);"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
             >
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-md-4 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-7 MuiGrid2-grid-xxl-8 css-x2vnc7-MuiGrid2-root"
+              <a
+                href="https://www.skde.no/"
               >
-                <a
-                  href="https://www.skde.no/"
-                >
-                  <img
-                    alt="SKDE-logo"
-                    class="footer-logo"
-                    data-nimg="1"
-                    decoding="async"
-                    height="52"
-                    id="skde-footer-logo"
-                    loading="lazy"
-                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                    style="color: transparent;"
-                    width="129"
-                  />
-                </a>
-              </div>
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-8 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-5 MuiGrid2-grid-xxl-4 css-q7weaj-MuiGrid2-root"
+                <img
+                  alt="SKDE-logo"
+                  class="footer-logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  id="skde-footer-logo"
+                  loading="lazy"
+                  src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                  srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                  style="color: transparent;"
+                  width="129"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+            >
+              <a
+                href="https://www.kvalitetsregistre.no/"
               >
-                <a
-                  href="https://www.kvalitetsregistre.no/"
+                <div
+                  class="MuiBox-root css-1ih0f61"
                 >
                   <img
                     alt="NSM-logo"
                     class="footer-logo"
-                    data-nimg="1"
+                    data-nimg="fill"
                     decoding="async"
-                    height="52"
                     id="nsm-footer-logo"
                     loading="lazy"
-                    src="/img/logos/nsm-hvit.svg?w=1080&q=75"
-                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 1x, /img/logos/nsm-hvit.svg?w=1080&q=75 2x"
-                    style="color: transparent;"
-                    width="467"
+                    sizes="100vw"
+                    src="/img/logos/nsm-hvit.svg?w=3840&q=75"
+                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 640w, /img/logos/nsm-hvit.svg?w=750&q=75 750w, /img/logos/nsm-hvit.svg?w=828&q=75 828w, /img/logos/nsm-hvit.svg?w=1080&q=75 1080w, /img/logos/nsm-hvit.svg?w=1200&q=75 1200w, /img/logos/nsm-hvit.svg?w=1920&q=75 1920w, /img/logos/nsm-hvit.svg?w=2048&q=75 2048w, /img/logos/nsm-hvit.svg?w=3840&q=75 3840w"
+                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
-                </a>
-              </div>
+                </div>
+              </a>
             </div>
           </div>
           <div
@@ -451,32 +450,28 @@ exports[`Footer component > renders with default props 1`] = `
           style="background: rgb(26, 26, 26);"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
             >
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              <a
+                href="https://www.skde.no/"
               >
-                <a
-                  href="https://www.skde.no/"
-                >
-                  <img
-                    alt="SKDE-logo"
-                    class="footer-logo"
-                    data-nimg="1"
-                    decoding="async"
-                    height="52"
-                    id="skde-footer-logo"
-                    loading="lazy"
-                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                    style="color: transparent;"
-                    width="129"
-                  />
-                </a>
-              </div>
+                <img
+                  alt="SKDE-logo"
+                  class="footer-logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  id="skde-footer-logo"
+                  loading="lazy"
+                  src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                  srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                  style="color: transparent;"
+                  width="129"
+                />
+              </a>
             </div>
           </div>
           <div
@@ -728,53 +723,52 @@ exports[`Footer component > renders with maxWidth prop set to false 1`] = `
           style="background: rgb(26, 26, 26);"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
             >
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-md-4 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-7 MuiGrid2-grid-xxl-8 css-x2vnc7-MuiGrid2-root"
+              <a
+                href="https://www.skde.no/"
               >
-                <a
-                  href="https://www.skde.no/"
-                >
-                  <img
-                    alt="SKDE-logo"
-                    class="footer-logo"
-                    data-nimg="1"
-                    decoding="async"
-                    height="52"
-                    id="skde-footer-logo"
-                    loading="lazy"
-                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                    style="color: transparent;"
-                    width="129"
-                  />
-                </a>
-              </div>
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-8 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-5 MuiGrid2-grid-xxl-4 css-q7weaj-MuiGrid2-root"
+                <img
+                  alt="SKDE-logo"
+                  class="footer-logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  id="skde-footer-logo"
+                  loading="lazy"
+                  src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                  srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                  style="color: transparent;"
+                  width="129"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+            >
+              <a
+                href="https://www.kvalitetsregistre.no/"
               >
-                <a
-                  href="https://www.kvalitetsregistre.no/"
+                <div
+                  class="MuiBox-root css-1ih0f61"
                 >
                   <img
                     alt="NSM-logo"
                     class="footer-logo"
-                    data-nimg="1"
+                    data-nimg="fill"
                     decoding="async"
-                    height="52"
                     id="nsm-footer-logo"
                     loading="lazy"
-                    src="/img/logos/nsm-hvit.svg?w=1080&q=75"
-                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 1x, /img/logos/nsm-hvit.svg?w=1080&q=75 2x"
-                    style="color: transparent;"
-                    width="467"
+                    sizes="100vw"
+                    src="/img/logos/nsm-hvit.svg?w=3840&q=75"
+                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 640w, /img/logos/nsm-hvit.svg?w=750&q=75 750w, /img/logos/nsm-hvit.svg?w=828&q=75 828w, /img/logos/nsm-hvit.svg?w=1080&q=75 1080w, /img/logos/nsm-hvit.svg?w=1200&q=75 1200w, /img/logos/nsm-hvit.svg?w=1920&q=75 1920w, /img/logos/nsm-hvit.svg?w=2048&q=75 2048w, /img/logos/nsm-hvit.svg?w=3840&q=75 3840w"
+                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
-                </a>
-              </div>
+                </div>
+              </a>
             </div>
           </div>
           <div
@@ -1026,53 +1020,52 @@ exports[`Footer component > renders with page prop set to "behandlingskvalitet" 
           style="background: rgb(26, 26, 26);"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
             >
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-md-4 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-7 MuiGrid2-grid-xxl-8 css-x2vnc7-MuiGrid2-root"
+              <a
+                href="https://www.skde.no/"
               >
-                <a
-                  href="https://www.skde.no/"
-                >
-                  <img
-                    alt="SKDE-logo"
-                    class="footer-logo"
-                    data-nimg="1"
-                    decoding="async"
-                    height="52"
-                    id="skde-footer-logo"
-                    loading="lazy"
-                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                    style="color: transparent;"
-                    width="129"
-                  />
-                </a>
-              </div>
-              <div
-                class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-8 MuiGrid2-grid-lg-6 MuiGrid2-grid-xl-5 MuiGrid2-grid-xxl-4 css-q7weaj-MuiGrid2-root"
+                <img
+                  alt="SKDE-logo"
+                  class="footer-logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  id="skde-footer-logo"
+                  loading="lazy"
+                  src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                  srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                  style="color: transparent;"
+                  width="129"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+            >
+              <a
+                href="https://www.kvalitetsregistre.no/"
               >
-                <a
-                  href="https://www.kvalitetsregistre.no/"
+                <div
+                  class="MuiBox-root css-1ih0f61"
                 >
                   <img
                     alt="NSM-logo"
                     class="footer-logo"
-                    data-nimg="1"
+                    data-nimg="fill"
                     decoding="async"
-                    height="52"
                     id="nsm-footer-logo"
                     loading="lazy"
-                    src="/img/logos/nsm-hvit.svg?w=1080&q=75"
-                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 1x, /img/logos/nsm-hvit.svg?w=1080&q=75 2x"
-                    style="color: transparent;"
-                    width="467"
+                    sizes="100vw"
+                    src="/img/logos/nsm-hvit.svg?w=3840&q=75"
+                    srcset="/img/logos/nsm-hvit.svg?w=640&q=75 640w, /img/logos/nsm-hvit.svg?w=750&q=75 750w, /img/logos/nsm-hvit.svg?w=828&q=75 828w, /img/logos/nsm-hvit.svg?w=1080&q=75 1080w, /img/logos/nsm-hvit.svg?w=1200&q=75 1200w, /img/logos/nsm-hvit.svg?w=1920&q=75 1920w, /img/logos/nsm-hvit.svg?w=2048&q=75 2048w, /img/logos/nsm-hvit.svg?w=3840&q=75 3840w"
+                    style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
                   />
-                </a>
-              </div>
+                </div>
+              </a>
             </div>
           </div>
           <div
@@ -1324,76 +1317,68 @@ exports[`Footer component > renders with page prop set to "helseatlas" 1`] = `
           style="background: rgb(26, 26, 26);"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
             >
-              <div
-                class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-i8ms3i-MuiGrid2-root"
+              <a
+                href="https://www.skde.no/"
               >
-                <div
-                  class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                >
-                  <a
-                    href="https://www.skde.no/"
-                  >
-                    <img
-                      alt="SKDE-logo"
-                      class="footer-logo"
-                      data-nimg="1"
-                      decoding="async"
-                      height="52"
-                      id="skde-footer-logo"
-                      loading="lazy"
-                      src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                      srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                      style="color: transparent;"
-                      width="129"
-                    />
-                  </a>
-                </div>
-                <div
-                  class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                >
-                  <a
-                    href="https://helse-forde.no/"
-                    title="Link til Helse Førde"
-                  >
-                    <img
-                      alt="Helse Førde logo"
-                      data-nimg="1"
-                      decoding="async"
-                      height="52"
-                      loading="lazy"
-                      src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
-                      srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
-                      style="color: transparent;"
-                      width="234"
-                    />
-                  </a>
-                </div>
-                <div
-                  class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                >
-                  <a
-                    href="https://helse-vest.no/"
-                    title="Link til Helse Vest"
-                  >
-                    <img
-                      alt="Helse Vest logo"
-                      data-nimg="1"
-                      decoding="async"
-                      height="52"
-                      loading="lazy"
-                      src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
-                      srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
-                      style="color: transparent;"
-                      width="234"
-                    />
-                  </a>
-                </div>
-              </div>
+                <img
+                  alt="SKDE-logo"
+                  class="footer-logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  id="skde-footer-logo"
+                  loading="lazy"
+                  src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                  srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                  style="color: transparent;"
+                  width="129"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+            >
+              <a
+                href="https://helse-forde.no/"
+                title="Link til Helse Førde"
+              >
+                <img
+                  alt="Helse Førde logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  loading="lazy"
+                  src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
+                  srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
+                  style="color: transparent;"
+                  width="234"
+                />
+              </a>
+            </div>
+            <div
+              class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+            >
+              <a
+                href="https://helse-vest.no/"
+                title="Link til Helse Vest"
+              >
+                <img
+                  alt="Helse Vest logo"
+                  data-nimg="1"
+                  decoding="async"
+                  height="52"
+                  loading="lazy"
+                  src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
+                  srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
+                  style="color: transparent;"
+                  width="234"
+                />
+              </a>
             </div>
           </div>
           <div

--- a/apps/skde/src/components/Footer/index.tsx
+++ b/apps/skde/src/components/Footer/index.tsx
@@ -65,15 +65,16 @@ export const Footer = ({
 
   const nsmLogo = (
     <Link href={"https://www.kvalitetsregistre.no/"}>
-      <Image
-        className="footer-logo"
-        id="nsm-footer-logo"
-        loader={imgLoader}
-        src={"/img/logos/nsm-hvit.svg"}
-        alt="NSM-logo"
-        width={467}
-        height={52}
-      />
+      <Box sx={{ width: "min(467px, 85vw)", height: 52, position: "relative" }}>
+        <Image
+          className="footer-logo"
+          id="nsm-footer-logo"
+          loader={imgLoader}
+          src={"/img/logos/nsm-hvit.svg"}
+          alt="NSM-logo"
+          layout="fill"
+        />
+      </Box>
     </Link>
   );
 
@@ -91,24 +92,17 @@ export const Footer = ({
 
   // Logo grids
   const atlasLogoGrid = (
-    <Grid
-      size={12}
-      gap={1}
-      container
-      display="flex"
-      justifyContent="space-between"
-      alignItems="center"
-    >
+    <>
       <Grid>{skdeLogo}</Grid>
       <Grid>{helseFordeLogo}</Grid>
       <Grid>{helseVestLogo}</Grid>
-    </Grid>
+    </>
   );
 
   const kvalitetLogoGrid = (
     <>
-      <Grid size={{ xs: 12, md: 4, lg: 6, xl: 7, xxl: 8 }}>{skdeLogo}</Grid>
-      <Grid size={{ xs: 12, sm: 8, lg: 6, xl: 5, xxl: 4 }}>{nsmLogo}</Grid>
+      <Grid>{skdeLogo}</Grid>
+      <Grid>{nsmLogo}</Grid>
     </>
   );
 
@@ -170,22 +164,22 @@ export const Footer = ({
             paddingBottom={10}
             rowGap={4}
           >
-            <Grid container size={{ xs: 12 }} alignItems="center">
-              <Grid
-                container
-                display="flex"
-                size={{ xs: 12 }}
-                alignItems="center"
-                paddingTop="3rem"
-              >
-                {helseatlas ? (
-                  atlasLogoGrid
-                ) : kvalitet ? (
-                  kvalitetLogoGrid
-                ) : (
-                  <Grid>{skdeLogo}</Grid>
-                )}
-              </Grid>
+            <Grid
+              container
+              display="flex"
+              size={{ xs: 12 }}
+              alignItems="center"
+              paddingTop="3rem"
+              gap={1}
+              justifyContent="space-between"
+            >
+              {helseatlas ? (
+                atlasLogoGrid
+              ) : kvalitet ? (
+                kvalitetLogoGrid
+              ) : (
+                <Grid>{skdeLogo}</Grid>
+              )}
             </Grid>
 
             <Grid size={{ xs: 12 }}>

--- a/apps/skde/src/components/Static/__tests__/__snapshots__/static.test.tsx.snap
+++ b/apps/skde/src/components/Static/__tests__/__snapshots__/static.test.tsx.snap
@@ -237,76 +237,68 @@ exports[`Bokmål render 1`] = `
             style="background: rgb(26, 26, 26);"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
             >
               <div
-                class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
               >
-                <div
-                  class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-i8ms3i-MuiGrid2-root"
+                <a
+                  href="https://www.skde.no/"
                 >
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://www.skde.no/"
-                    >
-                      <img
-                        alt="SKDE-logo"
-                        class="footer-logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        id="skde-footer-logo"
-                        loading="lazy"
-                        src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                        srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                        style="color: transparent;"
-                        width="129"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-forde.no/"
-                      title="Link til Helse Førde"
-                    >
-                      <img
-                        alt="Helse Førde logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-vest.no/"
-                      title="Link til Helse Vest"
-                    >
-                      <img
-                        alt="Helse Vest logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                </div>
+                  <img
+                    alt="SKDE-logo"
+                    class="footer-logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    id="skde-footer-logo"
+                    loading="lazy"
+                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                    style="color: transparent;"
+                    width="129"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-forde.no/"
+                  title="Link til Helse Førde"
+                >
+                  <img
+                    alt="Helse Førde logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-vest.no/"
+                  title="Link til Helse Vest"
+                >
+                  <img
+                    alt="Helse Vest logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
               </div>
             </div>
             <div
@@ -687,76 +679,68 @@ run;
             style="background: rgb(26, 26, 26);"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
             >
               <div
-                class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
               >
-                <div
-                  class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-i8ms3i-MuiGrid2-root"
+                <a
+                  href="https://www.skde.no/"
                 >
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://www.skde.no/"
-                    >
-                      <img
-                        alt="SKDE-logo"
-                        class="footer-logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        id="skde-footer-logo"
-                        loading="lazy"
-                        src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                        srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                        style="color: transparent;"
-                        width="129"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-forde.no/"
-                      title="Link til Helse Førde"
-                    >
-                      <img
-                        alt="Helse Førde logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-vest.no/"
-                      title="Link til Helse Vest"
-                    >
-                      <img
-                        alt="Helse Vest logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                </div>
+                  <img
+                    alt="SKDE-logo"
+                    class="footer-logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    id="skde-footer-logo"
+                    loading="lazy"
+                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                    style="color: transparent;"
+                    width="129"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-forde.no/"
+                  title="Link til Helse Førde"
+                >
+                  <img
+                    alt="Helse Førde logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-vest.no/"
+                  title="Link til Helse Vest"
+                >
+                  <img
+                    alt="Helse Vest logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
               </div>
             </div>
             <div
@@ -1093,76 +1077,68 @@ exports[`Nynorsk render 1`] = `
             style="background: rgb(26, 26, 26);"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-2m1vtf-MuiGrid2-root"
+              class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-hxd1by-MuiGrid2-root"
             >
               <div
-                class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-yoknlv-MuiGrid2-root"
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
               >
-                <div
-                  class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-i8ms3i-MuiGrid2-root"
+                <a
+                  href="https://www.skde.no/"
                 >
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://www.skde.no/"
-                    >
-                      <img
-                        alt="SKDE-logo"
-                        class="footer-logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        id="skde-footer-logo"
-                        loading="lazy"
-                        src="/img/logos/logo-skde-neg.svg?w=384&q=75"
-                        srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
-                        style="color: transparent;"
-                        width="129"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-forde.no/"
-                      title="Link til Helse Førde"
-                    >
-                      <img
-                        alt="Helse Førde logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                  <div
-                    class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
-                  >
-                    <a
-                      href="https://helse-vest.no/"
-                      title="Link til Helse Vest"
-                    >
-                      <img
-                        alt="Helse Vest logo"
-                        data-nimg="1"
-                        decoding="async"
-                        height="52"
-                        loading="lazy"
-                        src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
-                        srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
-                        style="color: transparent;"
-                        width="234"
-                      />
-                    </a>
-                  </div>
-                </div>
+                  <img
+                    alt="SKDE-logo"
+                    class="footer-logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    id="skde-footer-logo"
+                    loading="lazy"
+                    src="/img/logos/logo-skde-neg.svg?w=384&q=75"
+                    srcset="/img/logos/logo-skde-neg.svg?w=256&q=75 1x, /img/logos/logo-skde-neg.svg?w=384&q=75 2x"
+                    style="color: transparent;"
+                    width="129"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-forde.no/"
+                  title="Link til Helse Førde"
+                >
+                  <img
+                    alt="Helse Førde logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-forde-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-forde-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
+              </div>
+              <div
+                class="MuiGrid2-root MuiGrid2-direction-xs-row css-1fzlhpv-MuiGrid2-root"
+              >
+                <a
+                  href="https://helse-vest.no/"
+                  title="Link til Helse Vest"
+                >
+                  <img
+                    alt="Helse Vest logo"
+                    data-nimg="1"
+                    decoding="async"
+                    height="52"
+                    loading="lazy"
+                    src="/helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75"
+                    srcset="/helseatlas/img/logos/helse-vest-hvit.svg?w=256&q=75 1x, /helseatlas/img/logos/helse-vest-hvit.svg?w=640&q=75 2x"
+                    style="color: transparent;"
+                    width="234"
+                  />
+                </a>
               </div>
             </div>
             <div


### PR DESCRIPTION
Fixer #3489.

Problemet er at logoen for NSM er gigantisk. Jeg gjorde sånn at logoen krymper hvis skjermen ikke er bred nok:

![image](https://github.com/user-attachments/assets/a1f11488-0846-44ba-93fa-2c53e0affb84)
