### PR TITLE
Fikset advarsel i ny tabell

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/IndicatortablebodyV2/index.tsx
@@ -292,40 +292,40 @@ const IndicatorRow = (props: {
         >
           <Collapse in={open} timeout="auto" unmountOnExit>
             <Typography variant="body2" sx={{ margin: "2rem" }}>
-              <p>{indData.shortDescription}</p>
-              <p>
-                {"Ønsket målnivå: "}
-                {indData.levelGreen === null ? (
-                  <b>{"Ikke oppgitt"}</b>
-                ) : (
-                  <b>
-                    {levelSignHigh + customFormat(",.0%")(indData.levelGreen)}
-                  </b>
-                )}
-                <br />
-                {"Lavt målnivå: "}
-                {indData.levelYellow === null ? (
-                  <b>{"Ikke oppgitt"}</b>
-                ) : (
-                  <b>
-                    {levelSignLow + customFormat(",.0%")(indData.levelYellow)}
-                  </b>
-                )}
-              </p>
-              <p>
-                {"Siste levering av data: " +
-                  (indData.data[0].deliveryTime === null
-                    ? "Ikke oppgitt"
-                    : new Date(indData.data[0].deliveryTime).toLocaleString(
-                        "no-NO",
-                        {
-                          day: "numeric",
-                          month: "long",
-                          year: "numeric",
-                          timeZone: "CET",
-                        },
-                      ))}
-              </p>
+              {indData.shortDescription}
+              <br />
+              <br />
+              {"Ønsket målnivå: "}
+              {indData.levelGreen === null ? (
+                <b>{"Ikke oppgitt"}</b>
+              ) : (
+                <b>
+                  {levelSignHigh + customFormat(",.0%")(indData.levelGreen)}
+                </b>
+              )}
+              <br />
+              {"Lavt målnivå: "}
+              {indData.levelYellow === null ? (
+                <b>{"Ikke oppgitt"}</b>
+              ) : (
+                <b>
+                  {levelSignLow + customFormat(",.0%")(indData.levelYellow)}
+                </b>
+              )}
+              <br />
+              <br />
+              {"Siste levering av data: " +
+                (indData.data[0].deliveryTime === null
+                  ? "Ikke oppgitt"
+                  : new Date(indData.data[0].deliveryTime).toLocaleString(
+                      "no-NO",
+                      {
+                        day: "numeric",
+                        month: "long",
+                        year: "numeric",
+                        timeZone: "CET",
+                      },
+                    ))}
             </Typography>
 
             <div style={{ display: "flex", justifyContent: "center" }}>
@@ -356,29 +356,33 @@ const IndicatorRow = (props: {
 
             <Typography variant="body2" sx={{ margin: "2rem" }}>
               <b>Om kvalitetsindikatoren</b>
-              <ReactMarkdown
-                remarkPlugins={remarkPlugins}
-                components={{
-                  p({ children }) {
-                    return <p style={{ margin: 0 }}>{children}</p>;
-                  },
-                  a({ href, children }) {
-                    return (
-                      <a
-                        href={href}
-                        target={href?.startsWith("#") ? "_self" : "_blank"}
-                        rel="noreferrer"
-                        style={{ color: "#006492" }}
-                      >
-                        {children}
-                      </a>
-                    );
-                  },
-                }}
-              >
-                {indData.longDescription}
-              </ReactMarkdown>
             </Typography>
+            <ReactMarkdown
+              remarkPlugins={remarkPlugins}
+              components={{
+                p({ children }) {
+                  return (
+                    <Typography variant="body2" sx={{ margin: "2rem" }}>
+                      {children}
+                    </Typography>
+                  );
+                },
+                a({ href, children }) {
+                  return (
+                    <a
+                      href={href}
+                      target={href?.startsWith("#") ? "_self" : "_blank"}
+                      rel="noreferrer"
+                      style={{ color: "#006492" }}
+                    >
+                      {children}
+                    </a>
+                  );
+                },
+              }}
+            >
+              {indData.longDescription}
+            </ReactMarkdown>
           </Collapse>
         </StyledTableCell>
       </TableRow>


### PR DESCRIPTION
Man kan tydeligvis ikke ha en `<p>`-tag inne i en `Typography`-tag. 

![image](https://github.com/user-attachments/assets/19c03f9d-57a4-4641-a28e-d1c3194ba90b)
