### PR TITLE
Fjernet 'Tall om helsetjenesten' fra brødsmulesti

### DIFF
--- a/apps/skde/pages/kvalitetsregistre/[register]/[tab].tsx
+++ b/apps/skde/pages/kvalitetsregistre/[register]/[tab].tsx
@@ -21,10 +21,6 @@ const SelectedRegisterPage = ({ register }: { register: string }) => {
       text: "Forside",
     },
     {
-      link: "https://www.skde.no/resultater/",
-      text: "Tall om helsetjenesten",
-    },
-    {
       link: `/kvalitetsregistre/${register}`,
       text: `Kvalitetsregistre/${register}`,
     },

--- a/apps/skde/pages/kvalitetsregistre/alle/[tab].tsx
+++ b/apps/skde/pages/kvalitetsregistre/alle/[tab].tsx
@@ -12,10 +12,6 @@ const MainRegisterPage = () => {
       text: "Forside",
     },
     {
-      link: "https://www.skde.no/resultater/",
-      text: "Tall om helsetjenesten",
-    },
-    {
       link: `/kvalitetsregistre/`,
       text: `Kvalitetsregistre/`,
     },

--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -73,10 +73,6 @@ export const Skde = (): JSX.Element => {
       text: "Forside",
     },
     {
-      link: "https://www.skde.no/resultater/",
-      text: "Tall om helsetjenesten",
-    },
-    {
       link: "/sykehusprofil/",
       text: "Sykehusprofil",
     },

--- a/apps/skde/pages/varmekart/index.tsx
+++ b/apps/skde/pages/varmekart/index.tsx
@@ -47,10 +47,6 @@ export const Skde = (): JSX.Element => {
       text: "Forside",
     },
     {
-      link: "https://www.skde.no/resultater",
-      text: "Tall om helsetjenesten",
-    },
-    {
       link: "/varmekart/",
       text: "Varmekart",
     },

--- a/apps/skde/src/components/TreatmentQuality/TreatmentQualityAppBar.tsx
+++ b/apps/skde/src/components/TreatmentQuality/TreatmentQualityAppBar.tsx
@@ -21,10 +21,6 @@ const TreatmentQualityAppBar = ({
 }: AppBarProps) => {
   let breadcrumbs: BreadCrumbPath = [
     { link: "https://www.skde.no", text: "Forside" },
-    {
-      link: "https://www.skde.no/resultater/",
-      text: "Tall om helsetjenesten",
-    },
     { link: "/behandlingskvalitet/", text: "Behandlingskvalitet" },
   ];
 


### PR DESCRIPTION
Denne siden brukes ikke lenger. Alt ligger rett på forsiden av skde.no. Closes #3607