### PR TITLE
Fikset logo-størrelse for engelske HF-atlas

### DIFF
--- a/apps/skde/src/charts/Barchart/index.tsx
+++ b/apps/skde/src/charts/Barchart/index.tsx
@@ -177,7 +177,8 @@ export const Barchart = ({
             }[forfatter]
           })`,
           backgroundRepeat: "no-repeat",
-          backgroundSize: lang === "nn" ? "max(5rem, 20%)" : "max(3rem, 10%)",
+          backgroundSize:
+            forfatter === "Helse Førde" ? "max(5rem, 20%)" : "max(3rem, 10%)",
           backgroundPosition: "bottom min(13%, 5rem) right 5%",
         }}
       >


### PR DESCRIPTION
Det var en liten ting som hang igjen fra før vi fikk et "forfatter"-felt i json-filene for helseatlas, som gjorde at de engelske atlasene til Helse Førde fikk for små logoer