### PR TITLE
La til litt mer margin i linjediagrammet for helseatlas

### DIFF
--- a/apps/skde/src/charts/Linechart/index.tsx
+++ b/apps/skde/src/charts/Linechart/index.tsx
@@ -91,7 +91,7 @@ export const Linechart = ({
           xScale={{ type: "band", paddingOuter: 0 }}
           yScale={{ type: "linear" }}
           margin={{
-            top: 50,
+            top: 70,
             right: 50,
             bottom: 50,
             left: 55 + yvaluesMaxTextLength,


### PR DESCRIPTION
La til en liten quick fix som gjør det mindre sannsynlig at linjediagrammene i helseatlas krasjer med SKDE-logoen. Når Tank kommer med sine anbefalinger vil nok SKDE-logoen havne utenfor grafen, så dette er en midlertidig greie.