### PR TITLE
Vis noe annet enn tabell når det mangler data i Behandlingskvalitet

### DIFF
--- a/packages/qmongjs/src/components/IndicatorTable/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/index.tsx
@@ -1,8 +1,11 @@
 import { IndicatorTableHeader } from "./indicatortableheader";
 import { IndicatorTableBody } from "./indicatortablebody";
 import { RegisterName } from "types";
-import { useState, useCallback } from "react";
 import { NestedTreatmentUnitName } from "types";
+import { useIndicatorQuery } from "../../helpers/hooks";
+import { UseQueryResult } from "@tanstack/react-query";
+import { Indicator } from "types";
+import { NoDataAvailible } from "./ContenForEmptyTable";
 
 interface IndicatorTableProps {
   context: string;
@@ -45,29 +48,48 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
     chartColours,
     registriesWithResidentData,
   } = props;
-  const [emptyBlocks, setEmptyBlocks] = useState<Set<string>>(new Set());
 
-  const handleEmptyStatusChanged = useCallback(
-    (registerName: string, isEmpty: boolean) => {
-      setEmptyBlocks((prevEmptyBlocks) => {
-        const newEmptyBlocks = new Set(prevEmptyBlocks);
-        if (isEmpty) {
-          newEmptyBlocks.add(registerName);
-        } else {
-          newEmptyBlocks.delete(registerName);
-        }
-        return newEmptyBlocks;
-      });
-    },
-    [],
-  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const indicatorDataQuery: UseQueryResult<any, unknown> = useIndicatorQuery({
+    unitNames: unitNames,
+    treatmentYear: treatmentYear,
+    type: dataQuality ? "dg" : "ind",
+  });
 
-  const isTableEmpty = emptyBlocks.size === registerNames.length;
+  if (indicatorDataQuery.isFetching) {
+    return null;
+  }
 
-  return (
-    <>
-      <table>
-        {!isTableEmpty && (
+  // Count the number of rows of data to be shown in the whole table.
+  // Filter on selected registries first.
+  let rowCountData = indicatorDataQuery.data.filter((row: Indicator) => {
+    return medicalFieldFilter.includes(row.registry_name);
+  });
+
+  // If one or more treatment units that is not "Nasjonalt" is selected, then the data shown is governed by the data for those units.
+  // Indicators from "Nasjonalt" will be excluded if the other treatment units do not have data for these indicators.
+  if (unitNames.length > 1 || unitNames[0] !== "Nasjonalt") {
+    rowCountData = indicatorDataQuery.data
+      .filter((row: Indicator) =>
+        medicalFieldFilter.includes(row.registry_name),
+      )
+      .filter((row: Indicator) => row.unit_name !== "Nasjonalt");
+  }
+
+  // If the selected context is "caregiver", the table is not empty if there is data for "resident".
+  // Instead a message should be displayed per registry.
+  if (context === "resident") {
+    rowCountData = rowCountData.filter(
+      (row: Indicator) => row.context === context,
+    );
+  }
+
+  const isTableEmpty = rowCountData.length === 0;
+
+  if (!isTableEmpty) {
+    return (
+      <>
+        <table>
           <IndicatorTableHeader
             colspan={colspan}
             unitNames={unitNames}
@@ -77,23 +99,28 @@ export const IndicatorTable = (props: IndicatorTableProps) => {
             treatmentYear={showTreatmentYear ? treatmentYear : undefined}
             nestedUnitNames={nestedUnitNames}
           />
-        )}
-        <IndicatorTableBody
-          context={context}
-          dataQuality={dataQuality}
-          tableType={tableType}
-          colspan={colspan}
-          registerNames={registerNames}
-          unitNames={unitNames}
-          treatmentYear={treatmentYear}
-          medicalFieldFilter={medicalFieldFilter}
-          showLevelFilter={showLevelFilter ?? ""}
-          blockTitle={blockTitle}
-          onEmptyStatusChanged={handleEmptyStatusChanged}
-          chartColours={chartColours}
-          registriesWithResidentData={registriesWithResidentData}
-        />
+          <IndicatorTableBody
+            context={context}
+            dataQuality={dataQuality}
+            tableType={tableType}
+            colspan={colspan}
+            registerNames={registerNames}
+            unitNames={unitNames}
+            treatmentYear={treatmentYear}
+            medicalFieldFilter={medicalFieldFilter}
+            showLevelFilter={showLevelFilter ?? ""}
+            blockTitle={blockTitle}
+            chartColours={chartColours}
+            registriesWithResidentData={registriesWithResidentData}
+          />
+        </table>
+      </>
+    );
+  } else {
+    return (
+      <table>
+        <tbody>{<NoDataAvailible colspan={colspan} />}</tbody>
       </table>
-    </>
-  );
+    );
+  }
 };

--- a/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
@@ -33,36 +33,29 @@ export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
     registriesWithResidentData,
   } = props;
 
-  const done: string[] = [];
   const register_block = registerNames.map((register, i) => {
-    if (!done.includes(register.rname)) {
-      done.push(register.rname);
+    const hasResidentData =
+      registriesWithResidentData != undefined &&
+      registriesWithResidentData.length > 0 &&
+      registriesWithResidentData.includes(register.rname);
 
-      const hasResidentData =
-        registriesWithResidentData != undefined &&
-        registriesWithResidentData.length > 0 &&
-        registriesWithResidentData.includes(register.rname);
-
-      return (
-        <TableBlock
-          context={context}
-          dataQuality={dataQuality}
-          tableType={tableType}
-          key={`${register.rname}`}
-          registerName={register}
-          colspan={colspan}
-          unitNames={unitNames}
-          treatmentYear={treatmentYear}
-          medicalFieldFilter={medicalFieldFilter}
-          showLevelFilter={showLevelFilter}
-          blockTitle={blockTitle ? blockTitle[i] : undefined}
-          chartColours={chartColours}
-          hasResidentData={hasResidentData}
-        />
-      );
-    } else {
-      return null;
-    }
+    return (
+      <TableBlock
+        context={context}
+        dataQuality={dataQuality}
+        tableType={tableType}
+        key={`${register.rname}`}
+        registerName={register}
+        colspan={colspan}
+        unitNames={unitNames}
+        treatmentYear={treatmentYear}
+        medicalFieldFilter={medicalFieldFilter}
+        showLevelFilter={showLevelFilter}
+        blockTitle={blockTitle ? blockTitle[i] : undefined}
+        chartColours={chartColours}
+        hasResidentData={hasResidentData}
+      />
+    );
   });
 
   return <tbody>{register_block}</tbody>;

--- a/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/indicatortablebody/index.tsx
@@ -1,6 +1,5 @@
 import { RegisterName } from "types";
 import TableBlock from "../tableblock";
-import { NoDataAvailible } from "../ContenForEmptyTable";
 
 interface IndicatorTableBodyProps {
   context: string;
@@ -30,7 +29,6 @@ export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
     medicalFieldFilter,
     showLevelFilter,
     blockTitle,
-    onEmptyStatusChanged,
     chartColours,
     registriesWithResidentData,
   } = props;
@@ -58,7 +56,6 @@ export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
           medicalFieldFilter={medicalFieldFilter}
           showLevelFilter={showLevelFilter}
           blockTitle={blockTitle ? blockTitle[i] : undefined}
-          onEmptyStatusChanged={onEmptyStatusChanged}
           chartColours={chartColours}
           hasResidentData={hasResidentData}
         />
@@ -67,12 +64,6 @@ export const IndicatorTableBody = (props: IndicatorTableBodyProps) => {
       return null;
     }
   });
-  const isEmpty = !done.length;
 
-  return (
-    <tbody>
-      {isEmpty && <NoDataAvailible colspan={colspan} />}
-      {register_block}
-    </tbody>
-  );
+  return <tbody>{register_block}</tbody>;
 };

--- a/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
+++ b/packages/qmongjs/src/components/IndicatorTable/tableblock/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect, useRef } from "react";
+import { useMemo } from "react";
 import { UseQueryResult } from "@tanstack/react-query";
 import style from "./tableblock.module.css";
 import { useDescriptionQuery, useIndicatorQuery } from "../../../helpers/hooks";
@@ -50,7 +50,6 @@ const TableBlock = (props: TableBlockProps) => {
     showLevelFilter,
     blockTitle,
     unitNames,
-    onEmptyStatusChanged,
     chartColours,
     hasResidentData,
   } = props;
@@ -92,35 +91,6 @@ const TableBlock = (props: TableBlockProps) => {
       showLevelFilter,
     ],
   );
-
-  const isEmptyRef = useRef(false);
-
-  useEffect(() => {
-    if (
-      !descriptionQuery.isLoading &&
-      !indicatorDataQuery.isLoading &&
-      !descriptionQuery.isError &&
-      !indicatorDataQuery.isError
-    ) {
-      const isEmpty =
-        descriptionQuery.data.length === 0 ||
-        indicatorDataQuery.data.length === 0;
-
-      if (isEmpty !== isEmptyRef.current) {
-        isEmptyRef.current = isEmpty;
-        onEmptyStatusChanged?.(registerName.rname, isEmpty);
-      }
-    }
-  }, [
-    descriptionQuery.isLoading,
-    indicatorDataQuery.isLoading,
-    descriptionQuery.isError,
-    indicatorDataQuery.isError,
-    descriptionQuery.data,
-    indicatorDataQuery.data,
-    onEmptyStatusChanged,
-    registerName.rname,
-  ]);
 
   if (descriptionQuery.isLoading || indicatorDataQuery.isLoading) {
     return SkeletonRow(colspan);


### PR DESCRIPTION
Det finnes en komponent `NoDataAvailible` (sic) som er ment å vises når tabellen er tom. `TableBlock`-komponenten skal gi beskjed til `IndicatorTable`-komponenten to nivå over hvis et register ikke har data via en callback-funksjon. `IndicatorTable` skal telle antall tomme registre, og hvis antallet er lik totalt antall registre vises en `NoDataAvailible`. Dette fungerer ikke slik det er satt opp. 

Et alternativ er å spørre etter data i toppkomponenten og telle rader der. Da kan man også ta hensyn til om data finnes på sykehus eller opptaksområder. Denne løsningen fungerer sammen med #3836. 

![image](https://github.com/user-attachments/assets/5509a11e-a5b8-4183-9ee6-dde05032078a)
