### PR TITLE
Endret kolonnetekst i Sykehusprofil

### DIFF
--- a/packages/qmongjs/src/components/MedfieldTable/__tests__/__snapshots__/medfieldtable.test.tsx.snap
+++ b/packages/qmongjs/src/components/MedfieldTable/__tests__/__snapshots__/medfieldtable.test.tsx.snap
@@ -120,7 +120,7 @@ exports[`Table renders correctly 1`] = `
               class="MuiTypography-root MuiTypography-subtitle1 css-1i3tsf3-MuiTypography-root"
             >
               <b>
-                Resultat
+                Kvalitetsindikatorer
               </b>
             </h6>
           </th>

--- a/packages/qmongjs/src/components/MedfieldTable/index.tsx
+++ b/packages/qmongjs/src/components/MedfieldTable/index.tsx
@@ -303,7 +303,7 @@ export const MedfieldTable = (medfieldTableParams: MedfieldTableProps) => {
 
             <TableCell>
               <Typography variant="subtitle1">
-                <b>Resultat</b>
+                <b>Kvalitetsindikatorer</b>
               </Typography>
             </TableCell>
           </TableRow>


### PR DESCRIPTION
Før: 

![image](https://github.com/user-attachments/assets/61467c08-5cd8-4dcc-a096-0b44e2408052)


Etter: 

![image](https://github.com/user-attachments/assets/86ddfb86-0416-49df-858c-b744095de8c3)

