### PR TITLE
Fjernet <script> for identify.netlify.com

### DIFF
--- a/apps/skde/pages/helseatlas/admin.jsx
+++ b/apps/skde/pages/helseatlas/admin.jsx
@@ -12,7 +12,6 @@ export function CMS() {
 
   return (
     <>
-      <Script src="https://identity.netlify.com/v1/netlify-identity-widget.js" />
       <Script
         src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"
         onLoad={() => {


### PR DESCRIPTION
Det funket ikke å logge på i develop, og det virker som det henger sammen med et av scriptene som ble inkludert. I og med at detaljene for github-autentisering ligger i configurasjonen tror jeg ikke dette scriptet er nødvendig.