### PR TITLE
Flyttet base_url til riktig plass

### DIFF
--- a/apps/skde/src/helpers/config/CMS-config.ts
+++ b/apps/skde/src/helpers/config/CMS-config.ts
@@ -239,12 +239,12 @@ export const config = {
     name: "github",
     repo: "mong/mongts",
     branch: "main",
+    base_url: process.env.NEXT_PUBLIC_API_HOST ?? "https://prod-api.skde.org",
   },
   logo_url: "https://apps.skde.no/helseatlas/img/logos/helseatlas.svg",
   media_folder: "/apps/skde/public/helseatlas/img",
   public_folder: "/helseatlas/img",
   site_url: "https://apps.skde.no/helseatlas/",
-  base_url: process.env.NEXT_PUBLIC_API_HOST ?? "https://prod-api.skde.org",
   locale: "nb_no",
   collections: [atlas("no"), staticPages("no"), atlas("en"), staticPages("en")],
 };


### PR DESCRIPTION
Configurasjons-feltet `base_url` var havnet på feil plass. Det kan virke som at /auth er nødvendig i api-et når man hoster CMS-en på nettet, mens at det ikke er nødvendig når man kjører CMS-en lokalt. Hvis man kjører det lokalt går det faktisk an å logge inn med github, og publisere på github-repoet, uten å kjøre en "[oauth proxy](https://decapcms.org/docs/backends-overview/)".