### PR TITLE
Ga Helse Midt-Norge nok plass i barchart

### DIFF
--- a/apps/skde/src/charts/Barchart/index.tsx
+++ b/apps/skde/src/charts/Barchart/index.tsx
@@ -191,7 +191,7 @@ export const Barchart = ({
           <Group left={margin.left} top={margin.top}>
             <AxisLeft
               top={5}
-              left={-10}
+              left={-5}
               scale={yScale}
               strokeWidth={yAxisLineStrokeWidth}
               stroke={yAxisLineStroke}


### PR DESCRIPTION
Etter oppgraderinger av MUI ble Helse Midt-Norge kuttet litt av i barcharts i lab-atlaset, så jeg justerte et tall for å gi Helse Midt-Norge plass.

Før: