### PR TITLE
Endret variant på tittel i header på liten skjerm

### DIFF
--- a/apps/skde/src/components/Header/HeaderMiddle.tsx
+++ b/apps/skde/src/components/Header/HeaderMiddle.tsx
@@ -3,6 +3,8 @@ import { Toolbar, Typography, styled, Container } from "@mui/material";
 import Grid from "@mui/material/Grid";
 import { Breakpoint } from "@mui/material";
 import { useRouter } from "next/router";
+import { useScreenSize } from "@visx/responsive";
+import { breakpoints } from "qmongjs";
 
 const StyledToolbar = styled(Toolbar)(({ theme }) => ({
   paddingTop: theme.spacing(12),
@@ -34,6 +36,7 @@ type HeaderMiddleProps = PropsWithChildren<{
 export const HeaderMiddle = (props: HeaderMiddleProps) => {
   const router = useRouter();
   const mainUrl = "https://apps.skde.no" + router.asPath;
+  const { width } = useScreenSize({ debounceTime: 150 });
 
   return (
     <StyledToolbar
@@ -59,7 +62,9 @@ export const HeaderMiddle = (props: HeaderMiddleProps) => {
                 <br />
               </>
             )}
-            <Typography variant="h1">{props.title}</Typography>
+            <Typography variant={width > breakpoints.sm ? "h1" : "h2"}>
+              {props.title}
+            </Typography>
           </Grid>
           <Grid size={{ xs: 12 }}>
             <Typography variant="h6">{props.children}</Typography>

--- a/packages/qmongjs/src/themes/SkdeTheme.tsx
+++ b/packages/qmongjs/src/themes/SkdeTheme.tsx
@@ -47,6 +47,7 @@ const fonts = {
     fontWeight: "300",
     fontSize: "3rem",
     letterSpacing: `-${0.5 / 16}rem`,
+    color: "#001b52",
   },
   h3: {
     fontFamily: `${jakartaStyle.fontFamily}`,


### PR DESCRIPTION
Gå ned fra h1 til h2 når skjermen er mindre enn breakpunktet small. 

Før: 
![image](https://github.com/user-attachments/assets/889690e8-a63f-4ecb-8a43-4ddc99c03aea)

Etter: 
![image](https://github.com/user-attachments/assets/46fd737a-3bec-4cac-ade8-c80d20583c93)
