### PR TITLE
Lollipop for helseatlas

### DIFF
--- a/apps/skde/src/charts/Barchart/Lollipop.tsx
+++ b/apps/skde/src/charts/Barchart/Lollipop.tsx
@@ -1,0 +1,66 @@
+import { Group } from "@visx/group";
+import { ScaleBand, ScaleLinear } from "d3-scale";
+import { DataItemPoint } from "../../types";
+import classNames from "./ChartLegend.module.css";
+
+type LollipopProps = {
+  data: DataItemPoint;
+  y: string;
+  lollipopVar: string;
+  xScale: ScaleLinear<number, number, never>;
+  yScale: ScaleBand<string>;
+  label?: string;
+};
+
+export const Lollipop = function ({
+  data,
+  xScale,
+  yScale,
+  lollipopVar,
+  y,
+}: LollipopProps) {
+  return (
+    <Group top={yScale.bandwidth() / 2}>
+      <line
+        x1={xScale(0)}
+        x2={xScale(data[lollipopVar] as number)}
+        y1={yScale(data[y].toString())}
+        y2={yScale(data[y].toString())}
+        stroke={"black"}
+        strokeWidth="2"
+      />
+      <circle
+        r={5}
+        cx={xScale(data[lollipopVar] as number)}
+        cy={yScale(data[y].toString())}
+        fill={"#AAA"}
+        stroke={"black"}
+        strokeWidth="1"
+      />
+    </Group>
+  );
+};
+
+export const LollipopLegend = ({ label }: { label: string }) => {
+  return (
+    <div className={classNames.legendContainer}>
+      <ul className={classNames.legendUL}>
+        <li className={classNames.legendLI}>
+          <div className={classNames.legendAnnualVar}>
+            <svg width="20px" height="20px">
+              <circle
+                r={5}
+                cx={10}
+                cy={10}
+                fill={"#AAA"}
+                stroke={"black"}
+                strokeWidth="1"
+              />
+            </svg>
+          </div>
+          {label}
+        </li>
+      </ul>
+    </div>
+  );
+};

--- a/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
+++ b/apps/skde/src/charts/Barchart/__tests__/__snapshots__/barchart.test.tsx.snap
@@ -1098,7 +1098,7 @@ exports[`Click in table 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -1107,11 +1107,11 @@ exports[`Click in table 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -3324,7 +3324,7 @@ exports[`Click in table 2`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -3333,11 +3333,11 @@ exports[`Click in table 2`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -5550,7 +5550,7 @@ exports[`Click in table 3`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -5559,11 +5559,11 @@ exports[`Click in table 3`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -7776,7 +7776,7 @@ exports[`Click in table 4`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -7785,11 +7785,11 @@ exports[`Click in table 4`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -10002,7 +10002,7 @@ exports[`English render 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -10011,11 +10011,11 @@ exports[`English render 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -18923,7 +18923,7 @@ exports[`Render with figure split in two 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -18932,11 +18932,11 @@ exports[`Render with figure split in two 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -20461,7 +20461,7 @@ exports[`Render with figure split in two 2`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -20470,11 +20470,11 @@ exports[`Render with figure split in two 2`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -25013,7 +25013,7 @@ exports[`Render with picked HF 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -25022,11 +25022,11 @@ exports[`Render with picked HF 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -27199,7 +27199,7 @@ exports[`Render with split figure 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -27208,11 +27208,11 @@ exports[`Render with split figure 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -34638,7 +34638,7 @@ exports[`Render with wrong language 2`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -34647,11 +34647,11 @@ exports[`Render with wrong language 2`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"
@@ -38153,7 +38153,7 @@ exports[`Standard render 1`] = `
               y2="0"
             />
             <svg
-              font-size="14"
+              font-size="12"
               style="overflow: visible;"
               x="0"
               y="0"
@@ -38162,11 +38162,11 @@ exports[`Standard render 1`] = `
                 class="visx-axis-label"
                 fill=""
                 font-family=""
-                font-size="14"
-                font-weight="bold"
+                font-size="12"
+                font-weight="none"
                 text-anchor="middle"
                 x="220"
-                y="35"
+                y="33"
               >
                 <tspan
                   dy="0em"

--- a/apps/skde/src/charts/Barchart/index.tsx
+++ b/apps/skde/src/charts/Barchart/index.tsx
@@ -11,6 +11,7 @@ import { toBarchart } from "../../helpers/functions/dataTransformation";
 import { customFormat } from "qmongjs";
 
 import { AnnualVariation } from "./AnnualVariation";
+import { Lollipop, LollipopLegend } from "./Lollipop";
 import { ErrorBars } from "./errorBars";
 import {
   mainBarColors,
@@ -36,6 +37,8 @@ type BarchartProps = {
   xLegend?: { en: string[]; nb: string[]; nn: string[] };
   annualVar?: string[];
   annualVarLabels?: { en: number[]; nn: number[]; nb: number[] };
+  lollipopVar?: string;
+  lollipopLabel?: { en: string; nb: string; nn: string };
   errorBars?: string[];
   format: string;
   national: string;
@@ -62,6 +65,8 @@ export const Barchart = ({
   xLegend,
   annualVar,
   annualVarLabels,
+  lollipopVar,
+  lollipopLabel,
   errorBars,
   format,
   national,
@@ -213,9 +218,9 @@ export const Barchart = ({
               tickTransform={`translate(0,0)`}
               label={xLabel[lang]}
               labelProps={{
-                fontSize: 14,
+                fontSize: 12,
                 textAnchor: "middle",
-                fontWeight: "bold",
+                fontWeight: "none",
                 fill: "",
                 fontFamily: "",
               }}
@@ -279,6 +284,20 @@ export const Barchart = ({
                   />
                 );
               })}
+            {lollipopVar &&
+              data.map((d, i) => {
+                return (
+                  <Lollipop
+                    data={d}
+                    xScale={xScale}
+                    yScale={yScale}
+                    lollipopVar={lollipopVar}
+                    y={y}
+                    label={lollipopLabel[lang]}
+                    key={`${d[y]}${i}`}
+                  />
+                );
+              })}
             {errorBars &&
               data.map((d) => {
                 return (
@@ -303,6 +322,7 @@ export const Barchart = ({
           labels={varLabels}
         />
       )}
+      {lollipopVar && <LollipopLegend label={lollipopLabel[lang]} />}
       {x.length > 1 && (
         <ColorLegend
           colorScale={colorScale}


### PR DESCRIPTION
Helseatlas barn2025 hadde behov for å vise data på toppen av et søylediagram som ikke er årsvariasjons-prikker, så vi la til en mulighet for å legge til en "lollipop":

![Screenshot from 2025-05-09 13-45-11](https://github.com/user-attachments/assets/fa317f78-1470-40ed-878a-cbb8403ed516)

Vi endret også stilen til teksten under grafen, fordi vi syntes den var for in-your-face med font-weight bold og størrelse 14.