### PR TITLE
Markdown i stadievurdering

### DIFF
--- a/apps/skde/pages/stadievurdering/[registry].tsx
+++ b/apps/skde/pages/stadievurdering/[registry].tsx
@@ -16,6 +16,7 @@ import {
 import { RegistryEvaluation, RegistryRank, RegisterName } from "types";
 import { FaCircle } from "react-icons/fa";
 import { styled, Box, Tabs, Tab, Stack, Typography } from "@mui/material";
+import { Markdown } from "../../src/components/Markdown";
 
 const levelAColour = "#58A55C";
 const levelBColour = "#FD9C00";
@@ -190,11 +191,13 @@ const Stadiumfigur = ({ registry }) => {
         <h2>
           {"Ekspertgruppens vurdering av årsrapporten for " + defaultYear}
         </h2>
-        <div style={{ whiteSpace: "pre-wrap" }}>
-          {evaluationData
-            ? evaluationData.evaluation_text
-            : "Ingen evaluering tilgjengelig"}
-        </div>
+        <Typography style={{ width: "50%" }} variant="body1">
+          <Markdown>
+            {evaluationData
+              ? evaluationData.evaluation_text
+              : "Ingen evaluering tilgjengelig"}
+          </Markdown>
+        </Typography>
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
         {checkList}

--- a/apps/skde/pages/stadievurdering/[registry].tsx
+++ b/apps/skde/pages/stadievurdering/[registry].tsx
@@ -23,6 +23,8 @@ const levelBColour = "#FD9C00";
 const levelCColour = "#D85140";
 const noLevelColour = "#777777";
 
+const reportYear = defaultYear - 1;
+
 const Stadiumfigur = ({ registry }) => {
   // Copy-paste code from https://mui.com/material-ui/react-tabs/
   const [value, setValue] = React.useState(0);
@@ -62,11 +64,11 @@ const Stadiumfigur = ({ registry }) => {
   // End copy-paste code
 
   const rankQuery = useRegistryRankQuery();
-  const evaluationQuery = useRegistryEvaluationQuery(defaultYear);
+  const evaluationQuery = useRegistryEvaluationQuery(reportYear);
 
   const checkList = RequirementList({
     registry: registry,
-    year: defaultYear,
+    year: reportYear,
   });
 
   if (rankQuery.isFetching || evaluationQuery.isFetching) {
@@ -188,9 +190,7 @@ const Stadiumfigur = ({ registry }) => {
         <PlotComponent />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
-        <h2>
-          {"Ekspertgruppens vurdering av årsrapporten for " + defaultYear}
-        </h2>
+        <h2>{"Ekspertgruppens vurdering av årsrapporten for " + reportYear}</h2>
         <Typography style={{ width: "50%" }} variant="body1">
           <Markdown>
             {evaluationData


### PR DESCRIPTION
Hent resultater fra år `defaultYear - 1` og vis dem som Markdown-tekst. 

<img width="1053" height="687" alt="image" src="https://github.com/user-attachments/assets/b041ba1b-0f89-4643-bfad-eae8c694d6fa" />
