### PR TITLE
Fikset aksemerker på MuiLineChart i Edge

### DIFF
--- a/apps/skde/src/components/Charts/MuiLineChart/index.tsx
+++ b/apps/skde/src/components/Charts/MuiLineChart/index.tsx
@@ -75,6 +75,10 @@ export const MuiLineChart = (props: MuiLineChartProps) => {
         xAxis={[
           {
             scaleType: "point",
+            // The height must be set so that the axis ticks are not truncated.
+            // If this occurs they will not be visible.
+            // TODO: set automatically according to the axis tick font.
+            height: 60,
             data: uniqueYears,
             valueFormatter: (value: number) => value.toString(),
             tickLabelStyle: {


### PR DESCRIPTION
Får ikke samme feil i Edge på Ubuntu. 