### PR TITLE
chore: logo flyttet under figurer

### DIFF
--- a/apps/skde/src/components/Charts/MuiBarChart/index.tsx
+++ b/apps/skde/src/components/Charts/MuiBarChart/index.tsx
@@ -276,10 +276,9 @@ export const MuiBarChart = (props: MuiBarChartProps) => {
             >
               {year}
             </Typography>
-            <ChartLogo width={100} marginRight={6} />
           </Box>
           <ChartsTooltip />
-          <ChartsSurface>
+          <ChartsSurface sx={{ mb: 2 }}>
             <BarBackground
               data={data}
               percentage={percentage}
@@ -293,6 +292,7 @@ export const MuiBarChart = (props: MuiBarChartProps) => {
             <ChartsYAxis />
             <BarPlot />
           </ChartsSurface>
+          <ChartLogo width={100} marginRight={6} />
         </CustomChartWrapper>
       </ChartsDataProviderPro>
     </Box>

--- a/apps/skde/src/components/Charts/MuiBarChart/index.tsx
+++ b/apps/skde/src/components/Charts/MuiBarChart/index.tsx
@@ -278,7 +278,7 @@ export const MuiBarChart = (props: MuiBarChartProps) => {
             </Typography>
           </Box>
           <ChartsTooltip />
-          <ChartsSurface sx={{ mb: 2 }}>
+          <ChartsSurface>
             <BarBackground
               data={data}
               percentage={percentage}

--- a/apps/skde/src/components/Charts/MuiLineChart/index.tsx
+++ b/apps/skde/src/components/Charts/MuiLineChart/index.tsx
@@ -125,11 +125,10 @@ export const MuiLineChart = (props: MuiLineChartProps) => {
                   },
                 }}
               />
-              <ChartLogo width={100} marginRight={0} />
             </Box>
             <ChartsTooltip />
             <ChartsSurface
-              sx={{ "& .line-after path": { strokeDasharray: "10 5" } }}
+              sx={{ "& .line-after path": { strokeDasharray: "10 5" }, mb: -6 }}
             >
               <LineBackground
                 data={data}
@@ -156,6 +155,7 @@ export const MuiLineChart = (props: MuiLineChartProps) => {
               <ChartsAxisHighlight x="line" />
             </ChartsSurface>
           </CustomChartWrapper>
+          <ChartLogo width={100} marginRight={0} />
         </Box>
       </ChartsDataProviderPro>
     </Box>

--- a/apps/skde/src/components/Charts/MuiLineChart/index.tsx
+++ b/apps/skde/src/components/Charts/MuiLineChart/index.tsx
@@ -128,7 +128,7 @@ export const MuiLineChart = (props: MuiLineChartProps) => {
             </Box>
             <ChartsTooltip />
             <ChartsSurface
-              sx={{ "& .line-after path": { strokeDasharray: "10 5" }, mb: -6 }}
+              sx={{ "& .line-after path": { strokeDasharray: "10 5" }, mb: -4 }}
             >
               <LineBackground
                 data={data}
@@ -154,8 +154,8 @@ export const MuiLineChart = (props: MuiLineChartProps) => {
               <MarkPlot />
               <ChartsAxisHighlight x="line" />
             </ChartsSurface>
+            <ChartLogo width={100} marginRight={0} />
           </CustomChartWrapper>
-          <ChartLogo width={100} marginRight={0} />
         </Box>
       </ChartsDataProviderPro>
     </Box>


### PR DESCRIPTION
closes #4607

Fjernet og la til noe bottom margin for at logoene skulle ligge likt på begge figurer. Kan enkelt endres