### PR TITLE
chore: update to @mong/material-ui v11 and fix minor responsivity bugs

### DIFF
--- a/apps/skde/app/global.css
+++ b/apps/skde/app/global.css
@@ -1,1 +1,8 @@
 @import "tailwindcss";
+
+/* Add design tokens + SKDE theme (base styles, components, utilities, @theme) */
+@import "@mong/material-ui/variables.css";
+@import "@mong/material-ui/theme.css";
+
+/* Make Tailwind scan the shipped components so their classes are generated */
+@source "../node_modules/@mong/material-ui/dist";

--- a/apps/skde/package.json
+++ b/apps/skde/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "11.14.1",
-    "@mong/material-ui": "^8.0.0",
+    "@mong/material-ui": "^11.0.0",
     "@mui/icons-material": "7.3.10",
     "@mui/material": "^7.3.10",
     "@mui/system": "^7.0.0",

--- a/apps/skde/pages/_app.tsx
+++ b/apps/skde/pages/_app.tsx
@@ -1,13 +1,3 @@
-import { LicenseInfo } from "@mui/x-license";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { useRouter } from "next/router";
-import { NextAdapter } from "next-query-params";
-import { useEffect, useState } from "react";
-import { QueryParamProvider } from "use-query-params";
-import "../app/global.css";
-import "@mong/material-ui/index.css"; //Denne må nederst
 import {
   Breadcrumbs,
   Footer,
@@ -16,7 +6,16 @@ import {
   PageLayout,
   SkdeThemeProvider,
 } from "@mong/material-ui";
+import { LicenseInfo } from "@mui/x-license";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import { NextAdapter } from "next-query-params";
+import { useEffect, useState } from "react";
+import { QueryParamProvider } from "use-query-params";
+
+import "../app/global.css";
 
 type Languages = "en" | "no";
 

--- a/apps/skde/pages/behandlingskvalitetV2/index.tsx
+++ b/apps/skde/pages/behandlingskvalitetV2/index.tsx
@@ -117,18 +117,21 @@ export default function TreatmentQualityPage() {
         title="Behandlingskvalitet"
         image="/hero-bg-4.jpg"
       />
-      <div className="flex bg-neutral-0 w-full align-middle items-center justify-center">
-        <div className="flex flex-col w-full h-full md:px-6 md:min-w-360 max-w-260 ">
+      <div className="flex bg-neutral-0 w-full align-middle items-center justify-center px-12">
+        <div className="flex flex-col w-full h-full max-w-360">
           <TreatmentQualityAppBarV2>
             <Stack
               direction="row"
               justifyContent="space-between"
-              alignItems="end"
-              sx={{ paddingTop: 2, paddingBottom: 2 }}
+              alignItems="center"
+              sx={{
+                paddingTop: 2,
+                paddingBottom: 2,
+              }}
               width="100%"
             >
               <Stack direction="row" spacing={3}>
-                <div className="flex flex-col text-small font-semibold  text-brand-primary-900">
+                <div className="flex flex-col text-small font-semibold text-brand-primary-900">
                   Fagområde
                   <Button onClick={handleMedicalFieldButtonClick}>
                     Velg fagområde
@@ -213,9 +216,7 @@ export default function TreatmentQualityPage() {
               borderRadius: "16px",
             }}
           >
-            <Typography variant="h3" color="#0D244E">
-              Velg et fagområde du vil se resultater fra
-            </Typography>
+            <h3>Velg et fagområde du vil se resultater fra</h3>
             <Button onClick={handleMedicalFieldButtonClick}>
               Velg fagområde
             </Button>

--- a/apps/skde/src/components/IndicatorTable/Indicatortable/StickyHeader.tsx
+++ b/apps/skde/src/components/IndicatorTable/Indicatortable/StickyHeader.tsx
@@ -7,7 +7,7 @@ type AppBarProps = {
 export const TreatmentQualityAppBarV2 = ({ children }: AppBarProps) => {
   return (
     <AppBar position="sticky" color="transparent" elevation={0}>
-      <Toolbar>{children}</Toolbar>
+      <Toolbar disableGutters={true}>{children}</Toolbar>
     </AppBar>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,8 +106,8 @@ importers:
         specifier: 11.14.1
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
       '@mong/material-ui':
-        specifier: ^8.0.0
-        version: 8.1.0(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^11.0.0
+        version: 11.0.0(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@mui/icons-material':
         specifier: 7.3.10
         version: 7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
@@ -1341,8 +1341,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@mong/material-ui@8.1.0':
-    resolution: {integrity: sha512-VDanalIBZ+lWp06DZRHx7Rse+iAw7nHL5A7Fgbjpc4AcfnnK1waOA8x3GYb80w0lPSIUJ+PtHjyh1uZqydZTlQ==, tarball: https://npm.pkg.github.com/download/@mong/material-ui/8.1.0/12c640f3bb31b8e8196b72f44cdec44fcc2e26f1}
+  '@mong/material-ui@11.0.0':
+    resolution: {integrity: sha512-P/gbcYMW/vcaU6BFhSWRMkhqClTQ3Uisv+E/C/T/jXYsemPBgWT3WE8SQ30hE/9Kfhsy1aJzBa847dHWhZ08tA==, tarball: https://npm.pkg.github.com/download/@mong/material-ui/11.0.0/3c3e4ce0bb4742bac68eb4a1ca7edb7d912fdf46}
     engines: {node: '>=22.0.0', pnpm: ^11.0.0}
     peerDependencies:
       '@emotion/react': ^11.14.0
@@ -2618,8 +2618,8 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
   boxen@7.0.0:
@@ -6763,7 +6763,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@mong/material-ui@8.1.0(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@mong/material-ui@11.0.0(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@emotion/react': 11.14.0(@types/react@19.2.15)(react@19.2.6)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
@@ -7943,10 +7943,10 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.2:
+  body-parser@2.3.0:
     dependencies:
       bytes: 3.1.2
-      content-type: 1.0.5
+      content-type: 2.0.0
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
@@ -8592,7 +8592,7 @@ snapshots:
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.3.0
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   "@mong/material-ui": true
   "@mui/x-telemetry": true
   cypress: true
+  inotify: true
   sharp: true
 minimumReleaseAgeExclude:
   - "@mong/material-ui"


### PR DESCRIPTION
Har oppgradert pakken til v11 som har en litt annen implementasjon, fiksa samtidig det at verktøylinja ikke fulgte med når man resiza nettleser