### PR TITLE
fix: bruk useQueryParams i popup for enheter og fiks typeadvarsler

### DIFF
--- a/apps/skde/src/components/DialogBox/MedicalFieldPopup.tsx
+++ b/apps/skde/src/components/DialogBox/MedicalFieldPopup.tsx
@@ -40,7 +40,8 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
   const [highlightedMedField, setHighlightedMedField] = useState<string>("");
 
   const [registrySelection = [], setRegistrySelection] = useQueryParam<
-    string[] | undefined
+    string[] | undefined,
+    string[]
     // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
   >("registries", mainQueryParamsConfig.registries);
 
@@ -64,7 +65,6 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
           // May contain duplicates
 
           const newRegistrySelection = [
-            // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
             ...registrySelection,
             ...medfield.registers,
           ];
@@ -86,7 +86,6 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
       // The corresponding medfield checkbox should then be indeterminate
       // if some if its registries are selected and checked if all are selected.
       const registryChecked = (registry: string) => {
-        // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
         return registrySelection.includes(registry);
       };
 
@@ -135,7 +134,6 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
             setRegistrySelection([...newSelection]);
           } else {
             const newSelection = [
-              // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
               ...registrySelection.filter((row) => {
                 return row !== registry;
               }),
@@ -155,7 +153,6 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
             sx={{ width: "100%", background: columnColour2 }}
             control={
               <Checkbox
-                // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
                 checked={registrySelection.includes(registry)}
                 onChange={handleChange}
                 key={`${registry}_checkbox`}
@@ -177,7 +174,6 @@ export const MedicalFieldPopup = (props: MedicalFieldPopupProps) => {
 
   const handleSubmit = () => {
     updateRegistries(registrySelection);
-    // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
     onSubmit(registrySelection);
     setOpen(false);
   };

--- a/apps/skde/src/components/DialogBox/TreatmentunitPopup.tsx
+++ b/apps/skde/src/components/DialogBox/TreatmentunitPopup.tsx
@@ -11,9 +11,10 @@ import {
   Grid,
 } from "@mui/material";
 import type { UseQueryResult } from "@tanstack/react-query";
-import { useUnitNamesQuery } from "qmongjs";
+import { mainQueryParamsConfig, useUnitNamesQuery } from "qmongjs";
 import { type Dispatch, type JSX, type SetStateAction, useState } from "react";
 import type { NestedTreatmentUnitName } from "types";
+import { useQueryParam } from "use-query-params";
 import { getTreatmentUnitsTree } from "../FilterMenu/TreatmentQualityFilterMenu/filterMenuOptions";
 import { getFilterSettingsValuesMap } from "../FilterMenu/TreeViewFilterSection";
 import TreeViewSearchBox from "../FilterMenu/TreeViewSearchBox";
@@ -37,9 +38,14 @@ type TreatmentUnitPopupProps = {
 export const TreatmentUnitPopup = (props: TreatmentUnitPopupProps) => {
   const { open, setOpen, onSubmit, context, type } = props;
 
-  const [unitSelection, setUnitSelection] = useState<string[]>([]);
   const [highlightedRHF, setHighlightedRHF] = useState<string>("");
   const [highlightedHF, setHighlightedHF] = useState<string>("");
+
+  const [unitSelection = [], setUnitSelection] = useQueryParam<
+    string[] | undefined,
+    string[]
+    // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
+  >("units", mainQueryParamsConfig.units);
 
   // biome-ignore lint: ignored to pass ci checks, but should be fixed properly in the future
   const unitNamesQuery: UseQueryResult<any, unknown> = useUnitNamesQuery(


### PR DESCRIPTION
Popup for behandlingsenheter brukte useState istedenfor useQueryParams, så valgene vises ikke når man kommer inn på sident med url-parametere. 