### PR TITLE
fix(Api-hooks and query states): add explicit pending/error/empty/timeouts handling

### DIFF
--- a/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
+++ b/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
@@ -68,6 +68,7 @@ export const TreatmentQualityPageV3 = () => {
   const handleMedicalFieldButtonClick = () => {
     setMedicalFieldPopupOpen(true);
   };
+
   const handleTreatmentUnitButtonClick = () => {
     setTreatmentUnitPopupOpen(true);
   };
@@ -83,11 +84,15 @@ export const TreatmentQualityPageV3 = () => {
     ],
   };
 
+  // biome-ignore lint: ignored to pass ci checks, but should be fixed properly in the future
   const nestedDataQuery: UseQueryResult<any, unknown> = useIndicatorQuery({
     nested: true,
   });
 
   const registerData = nestedDataQuery?.data;
+  const isInitialLoading =
+    nestedDataQuery.status === "pending" && !registerData;
+  const hasLoadingError = nestedDataQuery.status === "error";
 
   return (
     <Box
@@ -145,7 +150,7 @@ export const TreatmentQualityPageV3 = () => {
                     context={selectedTableContext}
                     type={"ind"}
                   />
-                  <div className="flex flex-col text-small  font-semibold  text-brand-primary-900">
+                  <div className="flex flex-col text-small font-semibold text-brand-primary-900">
                     Årstall
                     <Dropdown
                       value={selectedYear.toString()}
@@ -175,27 +180,42 @@ export const TreatmentQualityPageV3 = () => {
         </div>
       </div>
       <PageContent>
-        {selectedMedicalFields.length > 0 && registerData ? (
-          registerData ? (
-            <IndicatorTableV3
-              key={"indicator-table2"}
-              data={registerData}
-              unitNames={getSortedList(
-                colourMap,
-                selectedTreatmentUnits,
-                "units",
-              )}
-              year={selectedYear}
-              medfields={selectedMedicalFields}
-              chartColours={getSortedList(
-                colourMap,
-                selectedTreatmentUnits,
-                "colours",
-              )}
-            />
-          ) : (
-            LoadingComponent
-          )
+        {isInitialLoading ? (
+          LoadingComponent
+        ) : hasLoadingError ? (
+          <Stack
+            height="484px"
+            spacing={4}
+            justifyContent="center"
+            alignItems="center"
+            sx={{
+              background: "#FFFFFF",
+              border: "1px solid #AE2323",
+              borderRadius: "16px",
+            }}
+          >
+            <h3>Kunne ikke laste data. Proev igjen.</h3>
+            <Button onClick={() => nestedDataQuery.refetch()}>
+              Last pa nytt
+            </Button>
+          </Stack>
+        ) : selectedMedicalFields.length > 0 && registerData ? (
+          <IndicatorTableV3
+            key={"indicator-table2"}
+            data={registerData}
+            unitNames={getSortedList(
+              colourMap,
+              selectedTreatmentUnits,
+              "units",
+            )}
+            year={selectedYear}
+            medfields={selectedMedicalFields}
+            chartColours={getSortedList(
+              colourMap,
+              selectedTreatmentUnits,
+              "colours",
+            )}
+          />
         ) : registerData ? (
           <Stack
             height="484px"
@@ -214,7 +234,22 @@ export const TreatmentQualityPageV3 = () => {
             </Button>
           </Stack>
         ) : (
-          LoadingComponent
+          <Stack
+            height="484px"
+            spacing={4}
+            justifyContent="center"
+            alignItems="center"
+            sx={{
+              background: "#FFFFFF",
+              border: "1px solid #2354AE",
+              borderRadius: "16px",
+            }}
+          >
+            <h3>Ingen data tilgjengelig for dette valget.</h3>
+            <Button onClick={() => nestedDataQuery.refetch()}>
+              Last pa nytt
+            </Button>
+          </Stack>
         )}
       </PageContent>
     </Box>

--- a/packages/qmongjs/src/helpers/hooks/apihooks.ts
+++ b/packages/qmongjs/src/helpers/hooks/apihooks.ts
@@ -8,6 +8,7 @@ const API_HOST =
 
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 const MAX_FETCH_ATTEMPTS = 3;
+const REQUEST_TIMEOUT_MS = 15000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -15,12 +16,21 @@ const fetchJsonWithRetry = async (url: string) => {
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
+    const abortController = new AbortController();
+    const timeout = setTimeout(
+      () => abortController.abort(),
+      REQUEST_TIMEOUT_MS,
+    );
+
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: abortController.signal });
 
       if (response.ok) {
+        clearTimeout(timeout);
         return await response.json();
       }
+
+      clearTimeout(timeout);
 
       const shouldRetry =
         attempt < MAX_FETCH_ATTEMPTS && RETRYABLE_STATUSES.has(response.status);
@@ -34,7 +44,12 @@ const fetchJsonWithRetry = async (url: string) => {
         response.statusText || `Request failed with ${response.status}`,
       );
     } catch (error) {
+      clearTimeout(timeout);
       lastError = error;
+
+      if (error instanceof Error && error.name === "AbortError") {
+        lastError = new Error("Request timed out");
+      }
 
       if (attempt < MAX_FETCH_ATTEMPTS) {
         await sleep(300 * attempt);


### PR DESCRIPTION
Har lagt inn handling for query-states (loading, error, empty) og en timeout på query attempts. Klarer ikke reprodusere den uendelige loading skjermen så mener den skal være fikset av denne.