### PR TITLE
chore: hides linkcopy button on mobile screen

### DIFF
--- a/apps/skde/src/components/IndicatorTable/IndicatortableV3/index.tsx
+++ b/apps/skde/src/components/IndicatorTable/IndicatortableV3/index.tsx
@@ -180,7 +180,7 @@ const fillMissingUnitnames = (
 };
 
 export const IndicatorTableV3 = (props: IndicatorTableV3Props) => {
-  const { data, medfields, unitNames, year, chartColours } = props;
+  const { data, medfields, unitNames, year } = props;
 
   const medfieldFilteredData = data.filter((row: RegisterData) =>
     medfields.includes(row.registerName),

--- a/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
+++ b/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
@@ -13,7 +13,6 @@ import { useQueryParam } from "use-query-params";
 import { defaultYear, mainQueryParamsConfig } from "../../../../src/app_config";
 import { MedicalFieldPopup } from "../../../../src/components/DialogBox/MedicalFieldPopup";
 import { TreatmentUnitPopup } from "../../../../src/components/DialogBox/TreatmentunitPopup";
-import { TreatmentQualityAppBarV2 } from "../../../../src/components/IndicatorTable/Indicatortable/StickyHeader";
 import { IndicatorTableV3 } from "../../../../src/components/IndicatorTable/IndicatortableV3";
 import { LayoutHead } from "../../../../src/components/LayoutHead";
 import {
@@ -157,7 +156,7 @@ export const TreatmentQualityPageV3 = () => {
                   </div>
                 </Stack>
                 <div
-                   className="pb-4 pl-6 hidden md:block"
+                  className="pb-4 pl-6 hidden md:block"
                   data-testid="copy-url-button"
                 >
                   <Button

--- a/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
+++ b/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
@@ -157,9 +157,8 @@ export const TreatmentQualityPageV3 = () => {
                   </div>
                 </Stack>
                 <div
-                  className="pb-4 pl-6"
+                   className="pb-4 pl-6 hidden md:block"
                   data-testid="copy-url-button"
-                  class="hidden lg:block"
                 >
                   <Button
                     startIcon={<Icon size="small" symbol="content_copy" />}

--- a/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
+++ b/apps/skde/src/components/IndicatorTable/TreatmentQualityPageV3/index.tsx
@@ -156,7 +156,11 @@ export const TreatmentQualityPageV3 = () => {
                     />
                   </div>
                 </Stack>
-                <div className="pb-4 pl-6" data-testid="copy-url-button">
+                <div
+                  className="pb-4 pl-6"
+                  data-testid="copy-url-button"
+                  class="hidden lg:block"
+                >
                   <Button
                     startIcon={<Icon size="small" symbol="content_copy" />}
                     variant="secondary"


### PR DESCRIPTION
La til class hidden på copy link button slik at knappen blir borte på mobilvisning, ikke nødvendig når man er på mobil.