### PR TITLE
fix(Sykehusprofil): vis alle private enheter med data og fiks datahenting

### DIFF
--- a/apps/skde/pages/sykehusprofil/index.tsx
+++ b/apps/skde/pages/sykehusprofil/index.tsx
@@ -5,7 +5,6 @@ import { useScreenSize } from "@visx/responsive";
 import {
   breakpoints,
   getUnitFullName,
-  mainHospitals,
   skdeTheme,
   useUnitNamesQuery,
   useUnitUrlsQuery,
@@ -83,18 +82,6 @@ export const Skde = (): JSX.Element => {
   let unitFullName: string;
 
   if (unitNamesQuery.data) {
-    // Only keep the "real" hospitals
-    // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future
-    // biome-ignore lint: ignored to pass ci checks, but should be fixed properly in the future
-    unitNamesQuery.data.nestedUnitNames.map((rhf) => {
-      // biome-ignore lint: ignored to pass ci checks, but should be fixed properly in the future
-      rhf.hf.map((hf) => {
-        hf.hospital = hf.hospital.filter((unit) =>
-          mainHospitals.includes(unit),
-        );
-      });
-    });
-
     unitFullName =
       (unitNamesQuery.data &&
         // @ts-expect-error - Ignored to pass ci checks, but should be fixed properly in the future

--- a/apps/skde/pages/sykehusprofilV2/index.tsx
+++ b/apps/skde/pages/sykehusprofilV2/index.tsx
@@ -93,7 +93,7 @@ export const Skde = (): JSX.Element => {
       ...rhf,
       hf: rhf.hf.map((hf) => ({
         ...hf,
-        hospital: hf.hospital.filter((unit) => mainHospitals.includes(unit)),
+        hospital: hf.hospital,
       })),
     }),
   );

--- a/apps/skde/pages/sykehusprofilV2/index.tsx
+++ b/apps/skde/pages/sykehusprofilV2/index.tsx
@@ -13,12 +13,7 @@ import { Toolbar } from "@mui/material";
 import type { UseQueryResult } from "@tanstack/react-query";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
-import {
-  getUnitFullName,
-  mainHospitals,
-  useUnitNamesQuery,
-  useUnitUrlsQuery,
-} from "qmongjs";
+import { getUnitFullName, useUnitNamesQuery, useUnitUrlsQuery } from "qmongjs";
 import { type JSX, Suspense, useEffect, useState } from "react";
 import type { NestedTreatmentUnitName, OptsTu } from "types";
 import { useQueryParam } from "use-query-params";

--- a/apps/skde/src/components/Charts/AchievementResultsBars/index.tsx
+++ b/apps/skde/src/components/Charts/AchievementResultsBars/index.tsx
@@ -37,7 +37,8 @@ export const AchievementResultsBars = (
   // Set indicator colour from value and colour limits
   const levels: AchievementLevel[] = indicatorRows.map((row: Indicator) => {
     const hasValidDg =
-      row.dg !== null && row.dg !== undefined && row.dg >= minDG;
+      // TODO: do no show data if row.dg is not defined
+      row.dg ? row.dg >= minDG : true;
     const indicatorLevel: AchievementLevel["level"] = hasValidDg
       ? mapIndicatorLevel(level(row) ?? "")
       : -1;

--- a/apps/skde/src/components/Charts/AchievementResultsBars/types.ts
+++ b/apps/skde/src/components/Charts/AchievementResultsBars/types.ts
@@ -2,6 +2,8 @@ export type AchievementResultsBarsProps = {
   registerShortName?: string;
   unitNames?: string[];
   unitLevel?: "nation" | "rhf" | "hf" | "hospital";
+  type?: "ind" | "dg";
+  context?: "caregiver" | "resident";
   startYear: number;
   endYear: number;
 };

--- a/apps/skde/src/components/Charts/IndicatorLinechartV2/index.tsx
+++ b/apps/skde/src/components/Charts/IndicatorLinechartV2/index.tsx
@@ -46,7 +46,7 @@ type GroupedLevels = {
 // Define high achievement as 0, medium as 1 and low as 2
 // If the limits are not set the level is undefined
 // Let -1 be undefined
-const mapLevel = (indicatorLevel: string) => {
+const mapLevel = (indicatorLevel: string | undefined) => {
   let mappedLevel: number;
   switch (indicatorLevel) {
     case "H":
@@ -167,9 +167,7 @@ export const IndicatorLinechartV2 = (
       ?.map((row: Indicator) => {
         const rowLevel = level(row);
         const indicatorLevel =
-          row.dg !== null && row.dg >= minDG && rowLevel != null
-            ? mapLevel(rowLevel)
-            : -1;
+          row.dg === null || row.dg >= minDG ? mapLevel(rowLevel) : -1;
         return indicatorLevel !== -1
           ? {
               ind_id: row.ind_id,

--- a/apps/skde/src/components/HospitalProfile/TopSummarySection/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/TopSummarySection/index.tsx
@@ -50,6 +50,8 @@ const AchievementSummaryCard = ({
       <h4 className="-mt-0.5 mb-6">{title}</h4>
       <AchievementResultsBars
         unitNames={[unitName]}
+        type={"ind"}
+        context={"caregiver"}
         startYear={startYear}
         endYear={endYear}
       />

--- a/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
+++ b/apps/skde/src/components/HospitalProfile/UnitFilterMenu/index.tsx
@@ -66,15 +66,6 @@ export const UnitFilterMenu = (props: UnitFilterMenuProps) => {
   // Get thre treatment unit structure and trim it
   const treatmentUnits = getTreatmentUnitsTree(unitNamesQuery);
 
-  if (treatmentUnits.treedata.length > 1) {
-    // Find the index of "Private" and remove the children. The sub units should not be shown.
-    // TreetmentUnits.treedata starts with one element "Nasjonalt". Need to wait for it to build up the rest.
-    const indPrivate = treatmentUnits.treedata.findIndex(
-      (x) => x.nodeValue.value === "Private",
-    );
-    treatmentUnits.treedata[indPrivate].children = [];
-  }
-
   // ###################################### //
   // Callback functions for the filter menu //
   // ###################################### //


### PR DESCRIPTION
Sykehusprofil og SykehusprofilV2 skal nå vise samme resultater som Behandlingskvalitet for alle enheter. 

- Vis alle private enheter i Sykehusprofil
- Vis alle private enheter i SykehusprofilV2
- Ikke filtrer bort indikatorer uten dekningsgradsindikator i SykehusprofilV2
- Hent kun data med `context="caregiver"` og `type="ind"` i søylediagram i SykehusprofilV2